### PR TITLE
Moves bytecode to Java 1.6 for agent instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin) [![Build Status](https://travis-ci.org/openzipkin/zipkin-reporter-java.svg?branch=master)](https://travis-ci.org/openzipkin/zipkin-reporter-java) [![Download](https://api.bintray.com/packages/openzipkin/maven/zipkin-reporter-java/images/download.svg) ](https://bintray.com/openzipkin/maven/zipkin-reporter-java/_latestVersion)
 
 # zipkin-reporter-java
-Shared library for reporting zipkin spans on transports including http and kafka.
+Shared library for reporting zipkin spans on transports including http and kafka. Requires JRE 6 or later.
 
 # Usage
 These components can be called when spans have been recorded and ready to send to zipkin.

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
+    <!-- default bytecode version for src/main -->
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+
     <main.basedir>${project.basedir}</main.basedir>
 
-    <zipkin.version>1.6.0</zipkin.version>
+    <zipkin.version>1.7.0</zipkin.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 
@@ -154,7 +158,7 @@
         <inherited>true</inherited>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <!-- Retrolamda will rewrite lambdas as Java 7 bytecode -->
+          <!-- Retrolambda will rewrite lambdas as Java 6 bytecode -->
           <source>1.8</source>
           <target>1.8</target>
           <compilerId>javac-with-errorprone</compilerId>
@@ -185,7 +189,7 @@
               <goal>process-main</goal>
             </goals>
             <configuration>
-              <target>1.7</target>
+              <target>${main.java.version}</target>
               <fork>false</fork>
             </configuration>
           </execution>
@@ -199,7 +203,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
+            <artifactId>${main.signature.artifact}</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
Java 1.6 is widely used and the agent needs to compile against 1.6 to be
able to instrument 1.6 runtime code.

While its possible to use higher source level to compile against lower
bytecode level, this is not really working correctly. This will be
improved in Java 9. until then it is kind of best practice to keep your
source and target level down. Also using animalsniffer on that level to
find usage of newer jdk classes (will also be fixed in 9)

This issue has been repeatedly raised in Brave, most recently from
@CodingFabian and @ivansenic