### PR TITLE
Adds Reporter for instrumentation to use after they record a span

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ These components can be called when spans have been recorded and ready to send t
 ## SpanEncoder
 The span encoder is a specialized form of Zipkin's Codec, which only deals with encoding one span.
 
+## Reporter
+After recording an operation into a span, it needs to be reported out of process. There are two
+builtin reporter implementations in this library, although you are free to create your own.
+
+The simplest mechanism is printing out spans as they are reported.
+
+```java
+Reporter.CONSOLE.report(span);
+```
+
+## AsyncReporter
+AsyncReporter is how you actually get spans to zipkin. By default, it waits up to a second
+before flushes any pending spans out of process via a Sender.
+
+```java
+reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
+                        .build(Encoder.THRIFT_BYTES);
+
+// Schedules the span to be sent, and won't block the calling thread on I/O
+reporter.report(span);
+```
+
 ### Sender
 The sender component handles the last step of sending a list of encoded spans onto a transport.
 This involves I/O, so you can call `Sender.check()` to check its health on a given frequency. 
@@ -41,6 +63,28 @@ class CustomReporter implements Flushable {
   }
 ```
 
+### Tuning
+
+By default AsyncReporter starts a thread to flush the queue of reported
+spans. Spans are encoded before enqueuing so it is easiest to relate the
+backlog as a function of bytes.
+
+Here are the most important properties to understand when tuning.
+
+Property | Description
+--- | ---
+`queuedMaxBytes` |  Maximum backlog of span bytes reported vs sent. Default 1% of heap
+`messageMaxBytes` | Maximum bytes sendable per message including overhead. Default `Sender.messageMaxBytes`
+`messageTimeout` |  Maximum time to wait for messageMaxBytes to accumulate before sending. Default 1 second
+
+#### Don't block the flusher thread
+When `messageTimeout` is non-zero, a single thread is responsible for
+bundling spans into a message for the sender. If you are using a blocking
+sender, a surge of reporting activity could lead to a queue backup. This
+will show in metrics as spans dropped. If you get into this position,
+switch to an asynchronous sender (like kafka), or increase the concurrency
+of your sender.
+
 ## Json Encoding
 By default, components use thrift encoding, as it is the most compatible
 and efficient. However, json is readable and helpful during debugging.
@@ -52,4 +96,8 @@ sender = URLConnectionSender.builder()
                             .messageEncoder(MessageEncoder.JSON_BYTES)
                             .endpoint("http://localhost:9411/api/v1/spans")
                             .build();
+
+// and if you are using the async reporter..
+reporter = AsyncReporter.builder(sender)
+                        .build(Encoder.JSON_BYTES);
 ```

--- a/benchmarks/src/main/java/zipkin/reporter/AsyncReporterBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/reporter/AsyncReporterBenchmarks.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.reporter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import zipkin.Span;
+import zipkin.TestObjects;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Group)
+public class AsyncReporterBenchmarks {
+  static final Span clientSpan = TestObjects.TRACE.get(2);
+  static final InMemoryReporterMetrics metrics = new InMemoryReporterMetrics();
+  static final AtomicLong spanBacklog = new AtomicLong();
+
+  @AuxCounters
+  @State(Scope.Thread)
+  public static class InMemoryReporterMetricsAsCounters {
+
+    public long spans() {
+      return metrics.spans();
+    }
+
+    public long spansDropped() {
+      return metrics.spansDropped();
+    }
+
+    public long messages() {
+      return metrics.messages();
+    }
+
+    public long messagesDropped() {
+      return metrics.messagesDropped();
+    }
+
+    public long spanBacklog() {
+      return spanBacklog.get();
+    }
+
+    @Setup(Level.Iteration)
+    public void clean() {
+      metrics.clear();
+      spanBacklog.set(0);
+    }
+  }
+
+  AsyncReporter<Span> reporter;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    reporter = AsyncReporter.builder(new NoopSender())
+        .messageMaxBytes(1000000) // example default from Kafka message.max.bytes
+        .metrics(metrics)
+        .build(Encoder.THRIFT_BYTES);
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public void no_contention_report(InMemoryReporterMetricsAsCounters counters) {
+    reporter.report(clientSpan);
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public void mild_contention_report(InMemoryReporterMetricsAsCounters counters) {
+    reporter.report(clientSpan);
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public void high_contention_report(InMemoryReporterMetricsAsCounters counters) {
+    reporter.report(clientSpan);
+  }
+
+  @TearDown(Level.Iteration)
+  public void clear() throws IOException {
+    spanBacklog.addAndGet(((AsyncReporter.BoundedAsyncReporter) reporter).pending.clear());
+  }
+}

--- a/benchmarks/src/main/java/zipkin/reporter/ByteBoundedQueueBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/reporter/ByteBoundedQueueBenchmarks.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.reporter;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Group)
+public class ByteBoundedQueueBenchmarks {
+
+  @AuxCounters
+  @State(Scope.Thread)
+  public static class OfferCounters {
+    public int offersFailed;
+    public int offersMade;
+
+    @Setup(Level.Iteration)
+    public void clean() {
+      offersFailed = offersMade = 0;
+    }
+  }
+
+  @AuxCounters
+  @State(Scope.Thread)
+  public static class DrainCounters {
+    public int drained;
+
+    @Setup(Level.Iteration)
+    public void clean() {
+      drained = 0;
+    }
+  }
+
+  private static ThreadLocal<Object> marker = new ThreadLocal<>();
+
+  @State(Scope.Thread)
+  public static class ConsumerMarker {
+    public ConsumerMarker() {
+      marker.set(this);
+    }
+  }
+
+  ByteBoundedQueue<Boolean> q;
+
+  @Setup
+  public void setup() {
+    q = new ByteBoundedQueue<>(10000, 10000);
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public void no_contention_offer(OfferCounters counters) {
+    if (q.offer(Boolean.TRUE, 1)) {
+      counters.offersMade++;
+    } else {
+      counters.offersFailed++;
+    }
+  }
+
+  @Benchmark @Group("no_contention") @GroupThreads(1)
+  public void no_contention_drain(DrainCounters counters, ConsumerMarker cm) {
+    q.drainTo((buffer, sizeInBytes) -> {
+      counters.drained++;
+      return true;
+    }, 1000);
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(2)
+  public void mild_contention_offer(OfferCounters counters) {
+    if (q.offer(Boolean.TRUE, 1)) {
+      counters.offersMade++;
+    } else {
+      counters.offersFailed++;
+    }
+  }
+
+  @Benchmark @Group("mild_contention") @GroupThreads(1)
+  public void mild_contention_drain(DrainCounters counters, ConsumerMarker cm) {
+    q.drainTo((buffer, sizeInBytes) -> {
+      counters.drained++;
+      return true;
+    }, 1000);
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(8)
+  public void high_contention_offer(OfferCounters counters) {
+    if (q.offer(Boolean.TRUE, 1)) {
+      counters.offersMade++;
+    } else {
+      counters.offersFailed++;
+    }
+  }
+
+  @Benchmark @Group("high_contention") @GroupThreads(1)
+  public void high_contention_drain(DrainCounters counters, ConsumerMarker cm) {
+    q.drainTo((buffer, sizeInBytes) -> {
+      counters.drained++;
+      return true;
+    }, 1000);
+  }
+
+  @TearDown(Level.Iteration)
+  public void emptyQ() {
+    // If this thread didn't drain, return
+    if (marker.get() == null) return;
+    q.clear();
+  }
+}

--- a/benchmarks/src/main/java/zipkin/reporter/NoopSender.java
+++ b/benchmarks/src/main/java/zipkin/reporter/NoopSender.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.io.IOException;
+import java.util.List;
+
+final class NoopSender implements Sender<byte[]> {
+
+  @Override public int messageMaxBytes() {
+    return Integer.MAX_VALUE;
+  }
+
+  @Override public MessageEncoding messageEncoding() {
+    return MessageEncoder.THRIFT_BYTES;
+  }
+
+  @Override public void sendSpans(List<byte[]> encodedSpans, Callback callback) {
+    callback.onComplete();
+  }
+
+  @Override public CheckResult check() {
+    return CheckResult.OK;
+  }
+
+  @Override public void close() throws IOException {
+  }
+
+  @Override public String toString() {
+    return "NoopSender";
+  }
+}

--- a/core/src/main/java/zipkin/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin/reporter/AsyncReporter.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.io.Flushable;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+import zipkin.Component;
+
+import static java.lang.String.format;
+import static java.util.logging.Level.WARNING;
+import static zipkin.internal.Util.checkArgument;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * As spans are reported, they are encoded and added to a pending queue. The task of sending spans
+ * happens on a separate thread which calls {@link #flush()}. By doing so, callers are protected
+ * from latency or exceptions possible when exporting spans out of process.
+ *
+ * <p>Spans are bundled into messages based on size in bytes or a timeout, whichever happens first.
+ *
+ * @param <S> type of the span, usually {@link zipkin.Span}
+ */
+public abstract class AsyncReporter<S> implements Reporter<S>, Flushable, Component {
+  /**
+   * After a certain threshold, spans are drained and {@link Sender#sendSpans(List, Callback) sent}
+   * to Zipkin collectors.
+   */
+  public static <B> Builder<B> builder(Sender<B> sender) {
+    return new Builder<>(sender);
+  }
+
+  /**
+   * Calling this will flush any pending spans to the transport on the current thread.
+   *
+   * <p>Note: If you set {@link Builder#messageTimeout(long, TimeUnit) message timeout} to zero, you
+   * must call this externally as otherwise spans will never be sent.
+   *
+   * @throws IllegalStateException if closed
+   */
+  @Override public abstract void flush();
+
+  /** Shuts down the sender thread, and increments drop metrics if there were any unsent spans. */
+  @Override public abstract void close();
+
+  public static final class Builder<B> {
+    final Sender<B> sender;
+    ReporterMetrics metrics = ReporterMetrics.NOOP_METRICS;
+    int messageMaxBytes;
+    long messageTimeoutNanos = TimeUnit.SECONDS.toNanos(1);
+    int queuedMaxSpans = 10000;
+    int queuedMaxBytes = onePercentOfMemory();
+
+    static int onePercentOfMemory() {
+      long result = (long) (Runtime.getRuntime().totalMemory() * 0.01);
+      // don't overflow in the rare case 1% of memory is larger than 2 GiB!
+      return (int) Math.max(Math.min(Integer.MAX_VALUE, result), Integer.MIN_VALUE);
+    }
+
+    Builder(Sender<B> sender) {
+      this.sender = checkNotNull(sender, "sender");
+      this.messageMaxBytes = sender.messageMaxBytes();
+    }
+
+    /**
+     * Aggregates and reports reporter metrics to a monitoring system. Should be {@link
+     * ReporterMetrics#forTransport(String) scoped to this transport}.  Defaults to no-op.
+     */
+    public Builder<B> metrics(ReporterMetrics metrics) {
+      this.metrics = checkNotNull(metrics, "metrics");
+      return this;
+    }
+
+    /**
+     * Maximum bytes sendable per message including {@link Sender.MessageEncoding#overheadInBytes(int)
+     * overhead}. Defaults to, and is limited by {@link Sender#messageMaxBytes()}.
+     */
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      checkArgument(messageMaxBytes >= 0, "messageMaxBytes < 0: %s", messageMaxBytes);
+      this.messageMaxBytes = Math.min(messageMaxBytes, sender.messageMaxBytes());
+      return this;
+    }
+
+    /**
+     * Default 1 second. 0 implies spans are {@link #flush() flushed} externally.
+     *
+     * <p>Instead of sending one message at a time, spans are bundled into messages, up to {@link
+     * Sender#messageMaxBytes()}. This timeout ensures that spans are not stuck in an incomplete
+     * message.
+     *
+     * <p>Note: this timeout starts when the first unsent span is reported.
+     */
+    public Builder messageTimeout(long timeout, TimeUnit unit) {
+      checkArgument(timeout >= 0, "timeout < 0: %s", timeout);
+      this.messageTimeoutNanos = unit.toNanos(checkNotNull(timeout, "timeout"));
+      return this;
+    }
+
+    /** Maximum backlog of spans reported vs sent. Default 10000 */
+    public Builder queuedMaxSpans(int queuedMaxSpans) {
+      this.queuedMaxSpans = queuedMaxSpans;
+      return this;
+    }
+
+    /** Maximum backlog of span bytes reported vs sent. Default 1% of heap */
+    public Builder queuedMaxBytes(int queuedMaxBytes) {
+      this.queuedMaxBytes = queuedMaxBytes;
+      return this;
+    }
+
+    /** Builds an async reporter that encodes spans as they are reported. */
+    public <S> AsyncReporter<S> build(Encoder<S, B> encoder) {
+      checkNotNull(encoder, "encoder");
+      checkArgument(encoder.encoding() == sender.messageEncoding().encoding(),
+          "Sender.encoding() %s != Encoder.encoding() %s", sender.messageEncoding().encoding(),
+          encoder.encoding());
+
+      final BoundedAsyncReporter<S, B> result = new BoundedAsyncReporter<>(this, encoder);
+
+      if (messageTimeoutNanos > 0) { // Start a thread that flushes the queue in a loop.
+        final BufferNextMessage<B> consumer =
+            new BufferNextMessage<>(sender.messageEncoding(), messageMaxBytes, messageTimeoutNanos);
+        new Thread(() -> {
+          try {
+            while (!result.closed.get()) {
+              result.flush(consumer);
+            }
+          } finally {
+            for (B next : consumer.drain()) {
+              result.pending.offer(next, result.encoder.sizeInBytes(next));
+            }
+            result.close.countDown();
+          }
+        }, "AsyncReporter(" + sender + ")").start();
+      }
+      return result;
+    }
+  }
+
+  static final class BoundedAsyncReporter<S, B> extends AsyncReporter<S> {
+    static final Logger logger = Logger.getLogger(BoundedAsyncReporter.class.getName());
+    final AtomicBoolean closed = new AtomicBoolean(false);
+    final Encoder<S, B> encoder;
+    final ByteBoundedQueue<B> pending;
+    final Sender<B> sender;
+    final int messageMaxBytes;
+    final int messageOverheadOfSingleton;
+    final long messageTimeoutNanos;
+    final CountDownLatch close;
+    final ReporterMetrics metrics;
+
+    BoundedAsyncReporter(Builder builder, Encoder<S, B> encoder) {
+      this.pending = new ByteBoundedQueue(builder.queuedMaxSpans, builder.queuedMaxBytes);
+      this.sender = builder.sender;
+      this.messageMaxBytes = builder.messageMaxBytes;
+      this.messageOverheadOfSingleton = sender.messageEncoding().overheadInBytes(1);
+      this.messageTimeoutNanos = builder.messageTimeoutNanos;
+      this.close = new CountDownLatch(builder.messageTimeoutNanos > 0 ? 1 : 0);
+      this.metrics = builder.metrics;
+      this.encoder = encoder;
+    }
+
+    /** Returns true if the was encoded and accepted onto the queue. */
+    @Override
+    public void report(S span) {
+      checkNotNull(span, "span");
+      metrics.incrementSpans(1);
+      B next = encoder.encode(span);
+      int nextSizeInBytes = encoder.sizeInBytes(next);
+      metrics.incrementSpanBytes(nextSizeInBytes);
+      if (closed.get() ||
+          // don't enqueue something larger than we can drain
+          messageOverheadOfSingleton + nextSizeInBytes > messageMaxBytes ||
+          !pending.offer(next, nextSizeInBytes)) {
+        metrics.incrementSpansDropped(1);
+      }
+    }
+
+    @Override
+    public final void flush() {
+      if (closed.get()) throw new IllegalStateException("closed");
+      flush(new BufferNextMessage<>(sender.messageEncoding(), messageMaxBytes, 0));
+    }
+
+    void flush(BufferNextMessage<B> bundler) {
+      pending.drainTo(bundler, bundler.remainingNanos());
+      if (closed.get() || !bundler.isReady()) return;
+
+      // Signal that we are about to send a message of a known size in bytes
+      metrics.incrementMessages();
+      metrics.incrementMessageBytes(bundler.sizeInBytes());
+      List<B> nextMessage = bundler.drain();
+
+      // In failure case, we increment messages and spans dropped.
+      Callback failureCallback = sendSpansCallback(nextMessage.size());
+      try {
+        sender.sendSpans(nextMessage, failureCallback);
+      } catch (RuntimeException e) {
+        failureCallback.onError(e);
+      }
+    }
+
+    @Override public CheckResult check() {
+      return sender.check();
+    }
+
+    @Override
+    public void close() {
+      closed.set(true);
+      try {
+        if (!close.await(messageTimeoutNanos, TimeUnit.NANOSECONDS)) {
+          logger.warning("Timed out waiting for close");
+        }
+      } catch (InterruptedException e) {
+        logger.warning("Interrupted waiting for close");
+      }
+      int count = pending.clear();
+      if (count > 0) {
+        metrics.incrementSpansDropped(count);
+        logger.warning("Dropped " + count + " spans due to close");
+      }
+    }
+
+    Callback sendSpansCallback(final int count) {
+      return new Callback() {
+        @Override public void onComplete() {
+        }
+
+        @Override public void onError(Throwable t) {
+          metrics.incrementMessagesDropped();
+          metrics.incrementSpansDropped(count);
+          warn("Dropped " + count + " spans", t);
+        }
+      };
+    }
+
+    void warn(String message, Throwable e) {
+      message = format("%s due to %s(%s)", message, e.getClass().getSimpleName(),
+          e.getMessage() == null ? "" : e.getMessage());
+      logger.log(WARNING, message, e);
+    }
+
+    @Override public String toString() {
+      return "AsyncReporter(" + sender + ")";
+    }
+  }
+}

--- a/core/src/main/java/zipkin/reporter/BufferNextMessage.java
+++ b/core/src/main/java/zipkin/reporter/BufferNextMessage.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import zipkin.reporter.Sender.MessageEncoding;
+
+final class BufferNextMessage<B> implements ByteBoundedQueue.Consumer<B> {
+  private final MessageEncoding encoding;
+  private final int maxBytes;
+  private final long timeoutNanos;
+  private final List<B> buffer = new LinkedList<>();
+
+  long deadlineNanoTime;
+  int bufferSizeInBytes;
+  boolean bufferFull;
+
+  BufferNextMessage(MessageEncoding encoding, int maxBytes, long timeoutNanos) {
+    this.encoding = encoding;
+    this.maxBytes = maxBytes;
+    this.timeoutNanos = timeoutNanos;
+  }
+
+  @Override
+  public boolean accept(B next, int nextSizeInBytes) {
+    int x = encoding.overheadInBytes(buffer.size() + 1) + bufferSizeInBytes + nextSizeInBytes;
+    int y = maxBytes;
+    int includingNextVsMaxBytes = (x < y) ? -1 : ((x == y) ? 0 : 1);
+
+    // If we can fit queued spans and the next into one message...
+    if (includingNextVsMaxBytes <= 0) {
+      buffer.add(next);
+      bufferSizeInBytes += nextSizeInBytes;
+
+      // If there's still room, accept more.
+      if (includingNextVsMaxBytes < 0) return true;
+    }
+    bufferFull = true;
+    return false; // Either we've reached exact message size or cannot consume next
+  }
+
+  long remainingNanos() {
+    if (buffer.isEmpty()) {
+      deadlineNanoTime = System.nanoTime() + timeoutNanos;
+    }
+    return Math.max(deadlineNanoTime - System.nanoTime(), 0);
+  }
+
+  boolean isReady() {
+    return bufferFull || remainingNanos() <= 0;
+  }
+
+  List<B> drain() {
+    if (buffer.isEmpty()) return Collections.emptyList();
+    ArrayList<B> result = new ArrayList<>(buffer);
+    buffer.clear();
+    bufferSizeInBytes = 0;
+    bufferFull = false;
+    deadlineNanoTime = 0;
+    return result;
+  }
+
+  int sizeInBytes() {
+    return encoding.overheadInBytes(buffer.size()) + bufferSizeInBytes;
+  }
+}

--- a/core/src/main/java/zipkin/reporter/ByteBoundedQueue.java
+++ b/core/src/main/java/zipkin/reporter/ByteBoundedQueue.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.util.Arrays;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Multi-producer, multi-consumer queue that can measure the count of entries as they are added.
+ *
+ * <p>This is similar to {@link java.util.concurrent.ArrayBlockingQueue} in implementation.
+ *
+ * @param <T> the type of the stream elements
+ */
+final class ByteBoundedQueue<T> {
+
+  interface Consumer<T> {
+    /** Returns true if it accepted the next element */
+    boolean accept(T next, int nextSizeInBytes);
+  }
+
+  final ReentrantLock lock = new ReentrantLock(false);
+  final Condition available = lock.newCondition();
+
+  final int maxSize;
+  final int maxBytes;
+
+  final T[] elements;
+  final int[] sizes;
+  int count;
+  int sizeInBytes;
+  int writePos;
+  int readPos;
+
+  ByteBoundedQueue(int maxSize, int maxBytes) {
+    this.elements = (T[]) new Object[maxSize];
+    this.sizes = new int[maxSize];
+    this.maxSize = maxSize;
+    this.maxBytes = maxBytes;
+  }
+
+  /**
+   * Returns true if the element could be added or false if it could not due to its size.
+   */
+  boolean offer(T next, int nextSizeInBytes) {
+    lock.lock();
+    try {
+      if (count == elements.length) return false;
+      if (sizeInBytes + nextSizeInBytes > maxBytes) return false;
+
+      elements[writePos] = next;
+      sizes[writePos++] = nextSizeInBytes;
+
+      if (writePos == elements.length) writePos = 0; // circle back to the front of the array
+
+      count++;
+      sizeInBytes += nextSizeInBytes;
+
+      available.signal(); // alert any drainers
+      return true;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Blocks for up to nanosTimeout for elements to appear. Then, consume as many as possible. */
+  int drainTo(Consumer<T> consumer, long nanosTimeout) {
+    try {
+      // This may be called by multiple threads. If one is holding a lock, another is waiting. We
+      // use lockInterruptibly to ensure the one waiting can be interrupted.
+      lock.lockInterruptibly();
+      try {
+        long nanosLeft = nanosTimeout;
+        while (count == 0) {
+          if (nanosLeft <= 0) return 0;
+          nanosLeft = available.awaitNanos(nanosLeft);
+        }
+        return doDrain(consumer);
+      } finally {
+        lock.unlock();
+      }
+    } catch (InterruptedException e) {
+      return 0;
+    }
+  }
+
+  /** Clears the queue unconditionally and returns count of elements cleared. */
+  int clear() {
+    lock.lock();
+    try {
+      int result = count;
+      count = sizeInBytes = readPos = writePos = 0;
+      Arrays.fill(elements, null);
+      return result;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private int doDrain(Consumer<T> consumer) {
+    int drainedCount = 0;
+    int drainedSizeInBytes = 0;
+    while (drainedCount < count) {
+      T element = elements[readPos];
+      int sizeInBytes = sizes[readPos];
+
+      if (element == null) break;
+      if (consumer.accept(element, sizeInBytes)) {
+        drainedCount++;
+        drainedSizeInBytes += sizeInBytes;
+
+        elements[readPos] = null;
+        if (++readPos == elements.length) readPos = 0; // circle back to the front of the array
+      } else {
+        break;
+      }
+    }
+    count -= drainedCount;
+    sizeInBytes -= drainedSizeInBytes;
+    return drainedCount;
+  }
+}

--- a/core/src/main/java/zipkin/reporter/InMemoryReporterMetrics.java
+++ b/core/src/main/java/zipkin/reporter/InMemoryReporterMetrics.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static zipkin.internal.Util.checkNotNull;
+
+public final class InMemoryReporterMetrics implements ReporterMetrics {
+
+  private final ConcurrentHashMap<String, AtomicLong> metrics;
+  private final String messages;
+  private final String messageBytes;
+  private final String messagesDropped;
+  private final String spans;
+  private final String spanBytes;
+  private final String spansDropped;
+
+  public InMemoryReporterMetrics() {
+    this(new ConcurrentHashMap<String, AtomicLong>(), null);
+  }
+
+  InMemoryReporterMetrics(ConcurrentHashMap<String, AtomicLong> metrics, String transport) {
+    this.metrics = metrics;
+    this.messages = scope("messages", transport);
+    this.messageBytes = scope("messageBytes", transport);
+    this.messagesDropped = scope("messagesDropped", transport);
+    this.spans = scope("spans", transport);
+    this.spanBytes = scope("spanBytes", transport);
+    this.spansDropped = scope("spansDropped", transport);
+  }
+
+  @Override public InMemoryReporterMetrics forTransport(String transportType) {
+    return new InMemoryReporterMetrics(metrics, checkNotNull(transportType, "transportType"));
+  }
+
+  @Override public void incrementMessages() {
+    increment(messages, 1);
+  }
+
+  public long messages() {
+    return get(messages);
+  }
+
+  @Override public void incrementMessagesDropped() {
+    increment(messagesDropped, 1);
+  }
+
+  public long messagesDropped() {
+    return get(messagesDropped);
+  }
+
+  @Override public void incrementMessageBytes(int quantity) {
+    increment(messageBytes, quantity);
+  }
+
+  public long messageBytes() {
+    return get(messageBytes);
+  }
+
+  @Override public void incrementSpans(int quantity) {
+    increment(spans, quantity);
+  }
+
+  public long spans() {
+    return get(spans);
+  }
+
+  @Override public void incrementSpanBytes(int quantity) {
+    increment(spanBytes, quantity);
+  }
+
+  public long spanBytes() {
+    return get(spanBytes);
+  }
+
+  @Override
+  public void incrementSpansDropped(int quantity) {
+    increment(spansDropped, quantity);
+  }
+
+  public long spansDropped() {
+    return get(spansDropped);
+  }
+
+  public void clear() {
+    metrics.clear();
+  }
+
+  private long get(String key) {
+    AtomicLong atomic = metrics.get(key);
+    return atomic == null ? 0 : atomic.get();
+  }
+
+  private void increment(String key, int quantity) {
+    if (quantity == 0) return;
+    while (true) {
+      AtomicLong metric = metrics.get(key);
+      if (metric == null) {
+        metric = metrics.putIfAbsent(key, new AtomicLong(quantity));
+        if (metric == null) return; // won race creating the entry 
+      }
+
+      while (true) {
+        long oldValue = metric.get();
+        long update = oldValue + quantity;
+        if (metric.compareAndSet(oldValue, update)) return; // won race updating
+      }
+    }
+  }
+
+  static String scope(String key, String transport) {
+    return key + (transport == null ? "" : "." + transport);
+  }
+}

--- a/core/src/main/java/zipkin/reporter/MessageEncoder.java
+++ b/core/src/main/java/zipkin/reporter/MessageEncoder.java
@@ -22,7 +22,7 @@ import zipkin.reporter.internal.ThriftBytesMessageEncoder;
  * @param <B> buffer holding the encoded span. For example "byte[]"
  * @param <M> encoded form of a message including one or more spans. Often, but not always the same
  * item type. For example, Kafka messages need to take the form of a "byte[]" although that has
- * no bearing on the span item type. For example, almost all buffers can output to a byte array.
+ * no bearing on the span item type. For example, almost all elements can output to a byte array.
  */
 public interface MessageEncoder<B, M> extends MessageEncoding {
   MessageEncoder<byte[], byte[]> JSON_BYTES = new JsonBytesMessageEncoder();

--- a/core/src/main/java/zipkin/reporter/Reporter.java
+++ b/core/src/main/java/zipkin/reporter/Reporter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import zipkin.Span;
+
+import static zipkin.internal.Util.UTF_8;
+
+/**
+ * Spans are created in instrumentation, transported out-of-band, and eventually persisted.
+ * Reporters sends spans (or encoded spans) recorded by instrumentation out of process.
+ *
+ * <S>Type of span to report, usually {@link zipkin.Span}, but extracted for reporting other java
+ * types like HTrace spans to zipkin, and to allow future Zipkin model types to be reported (ex.
+ * zipkin2.Span).
+ */
+public interface Reporter<S> {
+  Reporter<Span> CONSOLE = s -> System.out.println(new String(Encoder.JSON_BYTES.encode(s), UTF_8));
+
+  /**
+   * Schedules the span to be sent onto the transport.
+   *
+   * @param span Span, should not be <code>null</code>.
+   */
+  void report(S span);
+}

--- a/core/src/main/java/zipkin/reporter/ReporterMetrics.java
+++ b/core/src/main/java/zipkin/reporter/ReporterMetrics.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+/**
+ * Instrumented applications report spans over a transport such as Kafka to Zipkin Collectors.
+ *
+ * <p>Callbacks on this type are invoked by zipkin reporters to improve the visibility of the
+ * system. A typical implementation will report metrics to a telemetry system for analysis and
+ * reporting.
+ *
+ * <h3>Spans Reported vs Queryable Spans</h3>
+ *
+ * <p>A span in the context of reporting is <= span in the context of query. Instrumentation should
+ * report a span only once except, but certain types of spans cross the network. For example, RPC
+ * spans are reported at the client and the server separately.
+ *
+ * <h3>Key Relationships</h3>
+ *
+ * <p>The following relationships can be used to consider health of the tracing system.
+ * <pre>
+ * <ul>
+ * <li>Dropped spans = Alert when this increases as it could indicate a queue backup.
+ * <li>Successful Messages = {@link #incrementMessages() Accepted messages} -
+ * {@link #incrementMessagesDropped() Dropped messages}. Alert when this is more than amount of
+ * messages received from collectors.</li>
+ * </li>
+ * </ul>
+ * </pre>
+ */
+public interface ReporterMetrics {
+
+  /**
+   * Those who wish to partition metrics by transport can call this method to include the transport
+   * type in the backend metric key.
+   *
+   * <p>For example, an implementation may by default report {@link #incrementSpans(int) incremented
+   * spans} to the key "zipkin.reporter.span.accepted". When {@code metrics.forTransport("kafka"} is
+   * called, the counter would report to "zipkin.reporter.scribe.span.accepted"
+   *
+   * @param transportType ex "http", "scribe", "kafka"
+   */
+  ReporterMetrics forTransport(String transportType);
+
+  /**
+   * Increments count of message attempts, which contain 1 or more spans. Ex POST requests or Kafka
+   * messages sent.
+   */
+  void incrementMessages();
+
+  /**
+   * Increments count of messages that could not be sent. Ex host unavailable, or peer disconnect.
+   */
+  void incrementMessagesDropped();
+
+  /**
+   * Increments the count of spans reported. When {@link AsyncReporter} is used, reported spans will
+   * usually be a larger number than messages.
+   */
+  void incrementSpans(int quantity);
+
+  /**
+   * Increments the number of {@link Encoder#sizeInBytes(Object) encoded spans bytes} reported.
+   *
+   * @see MessageEncoder
+   */
+  void incrementSpanBytes(int quantity);
+
+  /**
+   * Increments the number of bytes containing encoded spans in a message.
+   *
+   * <p>This is a function of span bytes per message and {@link MessageEncoder#overheadInBytes(int)
+   * overhead}
+   */
+  void incrementMessageBytes(int quantity);
+
+  /**
+   * Increments the count of spans dropped for any reason. For example, failure queueing or
+   * sending.
+   */
+  void incrementSpansDropped(int quantity);
+
+  ReporterMetrics NOOP_METRICS = new ReporterMetrics() {
+
+    @Override public ReporterMetrics forTransport(String transportType) {
+      return this;
+    }
+
+    @Override public void incrementMessages() {
+    }
+
+    @Override public void incrementMessagesDropped() {
+    }
+
+    @Override public void incrementSpans(int quantity) {
+    }
+
+    @Override public void incrementSpanBytes(int quantity) {
+    }
+
+    @Override public void incrementMessageBytes(int quantity) {
+    }
+
+    @Override public void incrementSpansDropped(int quantity) {
+    }
+
+    @Override public String toString() {
+      return "NoOpReporterMetrics";
+    }
+  };
+}

--- a/core/src/main/java/zipkin/reporter/Sender.java
+++ b/core/src/main/java/zipkin/reporter/Sender.java
@@ -32,10 +32,10 @@ import zipkin.collector.Collector;
  * message}. For example, a large span might need to be sent as a separate message to avoid kafka
  * limits. Also, logging transports like scribe will likely write each span as a separate log line.
  *
- * <p>This accepts a list of @link Encoder#encode(Object) encoded buffers}, such as a byte arrays,
+ * <p>This accepts a list of @link Encoder#encode(Object) encoded elements}, such as a byte arrays,
  * as opposed a list of spans like {@link zipkin.Span}. This allows senders to be re-usable as model
  * shapes change. This also allows them to use their most natural item type. For example, okhttp
- * would more naturally send http bodies as okio buffers.
+ * would more naturally send http bodies as okio elements.
  *
  * <p>If performance is critical, {@link Encoding#THRIFT thrift encoding} is most efficient,
  * sometimes an order of magnitude faster than json.

--- a/core/src/test/java/zipkin/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin/reporter/AsyncReporterTest.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Test;
+import zipkin.Annotation;
+import zipkin.Codec;
+import zipkin.Span;
+import zipkin.TestObjects;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsyncReporterTest {
+
+  Span span = TestObjects.TRACE.get(2);
+  int sizeInBytesOfSingleSpanMessage =
+      MessageEncoder.THRIFT_BYTES.overheadInBytes(1) + Encoder.THRIFT_BYTES.encode(span).length;
+
+  AsyncReporter<Span> reporter;
+  InMemoryReporterMetrics metrics = new InMemoryReporterMetrics();
+
+  @After
+  public void close() {
+    if (reporter != null) reporter.close();
+  }
+
+  @Test
+  public void messageMaxBytes_defaultsToSender() {
+    AtomicInteger sentSpans = new AtomicInteger();
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> sentSpans.addAndGet(spans.size()))
+        .messageMaxBytes(sizeInBytesOfSingleSpanMessage))
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.report(span); // drops
+    reporter.flush();
+
+    assertThat(sentSpans.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void messageMaxBytes_dropsWhenOverqueuing() {
+    AtomicInteger sentSpans = new AtomicInteger();
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> sentSpans.addAndGet(spans.size())))
+        .messageMaxBytes(sizeInBytesOfSingleSpanMessage)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.report(span); // dropped the one that queued more than allowed bytes
+    reporter.flush();
+
+    assertThat(sentSpans.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void messageMaxBytes_dropsWhenTooLarge() {
+    AtomicInteger sentSpans = new AtomicInteger();
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> sentSpans.addAndGet(spans.size())))
+        .messageMaxBytes(sizeInBytesOfSingleSpanMessage)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span.toBuilder().addAnnotation(Annotation.create(1L, "fooooo", null)).build());
+    reporter.flush();
+
+    assertThat(sentSpans.get()).isEqualTo(0);
+  }
+
+  @Test
+  public void queuedMaxSpans_dropsWhenOverqueuing() {
+    AtomicInteger sentSpans = new AtomicInteger();
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> sentSpans.addAndGet(spans.size())))
+        .queuedMaxSpans(1)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.report(span); // dropped the one that queued more than allowed count
+    reporter.flush();
+
+    assertThat(sentSpans.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void report_incrementsMetrics() {
+    reporter = AsyncReporter.builder(FakeSender.create())
+        .metrics(metrics)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.report(span);
+    assertThat(metrics.spans()).isEqualTo(2);
+    assertThat(metrics.spanBytes()).isEqualTo(Encoder.THRIFT_BYTES.encode(span).length * 2);
+  }
+
+  @Test
+  public void report_incrementsSpansDropped() {
+    reporter = AsyncReporter.builder(FakeSender.create())
+        .queuedMaxSpans(1)
+        .metrics(metrics)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.report(span);
+
+    assertThat(metrics.spans()).isEqualTo(2);
+    assertThat(metrics.spansDropped()).isEqualTo(1);
+  }
+
+  @Test
+  public void flush_incrementsMetrics() {
+    reporter = AsyncReporter.builder(FakeSender.create())
+        .metrics(metrics)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.report(span);
+
+    reporter.flush();
+    assertThat(metrics.messages()).isEqualTo(1);
+    assertThat(metrics.messageBytes()).isEqualTo(
+        Codec.THRIFT.writeSpans(asList(span, span)).length);
+  }
+
+  @Test
+  public void flush_incrementsMessagesDropped() {
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> {
+          throw new RuntimeException();
+        }))
+        .metrics(metrics)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+
+    reporter.flush();
+    assertThat(metrics.messagesDropped()).isEqualTo(1);
+  }
+
+  /** It can take up to the messageTimeout past the first span to send */
+  @Test
+  public void messageTimeout_flushesWhenTimeoutExceeded() throws InterruptedException {
+    CountDownLatch sentSpans = new CountDownLatch(1);
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> sentSpans.countDown()))
+        .messageTimeout(10, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    assertThat(sentSpans.await(5, TimeUnit.MILLISECONDS))
+        .isFalse();
+    assertThat(sentSpans.await(10, TimeUnit.MILLISECONDS))
+        .isTrue();
+  }
+
+  @Test
+  public void messageTimeout_disabled() throws InterruptedException {
+    CountDownLatch sentSpans = new CountDownLatch(1);
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> sentSpans.countDown()))
+        .messageTimeout(0, TimeUnit.NANOSECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    assertThat(sentSpans.getCount()).isEqualTo(1);
+
+    // Since no threads started, the above lingers
+    assertThat(sentSpans.await(10, TimeUnit.MILLISECONDS))
+        .isFalse();
+  }
+
+  @Test
+  public void senderThread_threadHasAPrettyName() throws InterruptedException {
+    BlockingQueue<String> threadName = new LinkedBlockingQueue<>();
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> threadName.offer(Thread.currentThread().getName())))
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+
+    // check name is pretty
+    assertThat(threadName.take())
+        .isEqualTo("AsyncReporter(FakeSender)");
+  }
+
+  @Test
+  public void close_stopsSender() throws InterruptedException {
+    AtomicInteger sendCount = new AtomicInteger();
+    reporter = AsyncReporter.builder(FakeSender.create()
+        .onSpans(spans -> {
+          sendCount.incrementAndGet();
+          try {
+            Thread.sleep(10); // this blocks the loop
+          } catch (InterruptedException e) {
+          }
+        }))
+        .metrics(metrics)
+        .messageTimeout(2, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    Thread.sleep(5);
+    reporter.report(span); // report while sender is blocked
+    reporter.close(); // close before sender can send the next message
+    Thread.sleep(5);
+
+    assertThat(sendCount.get()).isEqualTo(1);
+    assertThat(metrics.spansDropped()).isEqualTo(1);
+  }
+
+  @Test
+  public void senderThread_pushesBackOnClose() throws InterruptedException {
+    AtomicInteger sendCount = new AtomicInteger();
+    reporter = AsyncReporter.builder(FakeSender.create())
+        .metrics(metrics)
+        .messageTimeout(10, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    Thread.sleep(5); // flush thread got the first span, but still waiting for more
+    reporter.close(); // close while there's a pending span
+    Thread.sleep(10); // wait for the poll to unblock
+
+    assertThat(sendCount.get()).isZero();
+    assertThat(metrics.spansDropped()).isEqualTo(1);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void flush_throwsOnClose() {
+    reporter = AsyncReporter.builder(FakeSender.create())
+        .metrics(metrics)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.report(span);
+    reporter.close(); // close while there's a pending span
+    reporter.flush();
+  }
+
+  @Test
+  public void report_doesntThrowWhenClosed() {
+    reporter = AsyncReporter.builder(FakeSender.create())
+        .metrics(metrics)
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build(Encoder.THRIFT_BYTES);
+
+    reporter.close();
+
+    // Don't throw, as that could crash apps. Just increment drop metrics
+    reporter.report(span);
+    assertThat(metrics.spansDropped()).isEqualTo(1);
+  }
+}

--- a/core/src/test/java/zipkin/reporter/ByteBoundedQueueTest.java
+++ b/core/src/test/java/zipkin/reporter/ByteBoundedQueueTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ByteBoundedQueueTest {
+  ByteBoundedQueue<Boolean> queue = new ByteBoundedQueue(10, 10);
+
+  @Test
+  public void offer_failsWhenFull_size() {
+    for (int i = 0; i < queue.maxSize; i++) {
+      assertThat(queue.offer(Boolean.TRUE, 1)).isTrue();
+    }
+    assertThat(queue.offer(Boolean.TRUE, 1)).isFalse();
+  }
+
+  @Test
+  public void offer_failsWhenFull_sizeInBytes() {
+    assertThat(queue.offer(Boolean.TRUE, 10)).isTrue();
+    assertThat(queue.offer(Boolean.TRUE, 1)).isFalse();
+  }
+
+  @Test
+  public void offer_updatesCount() {
+    for (int i = 0; i < queue.maxSize; i++) {
+      queue.offer(Boolean.TRUE, 1);
+    }
+    assertThat(queue.count).isEqualTo(10);
+  }
+
+  @Test
+  public void offer_sizeInBytes() {
+    for (int i = 0; i < queue.maxSize; i++) {
+      queue.offer(Boolean.TRUE, 1);
+    }
+    assertThat(queue.sizeInBytes).isEqualTo(queue.maxSize);
+  }
+
+  @Test
+  public void circular() {
+    ByteBoundedQueue<Integer> queue = new ByteBoundedQueue(10, 10);
+
+    List<Integer> polled = new ArrayList<>();
+    ByteBoundedQueue.Consumer<Integer> consumer = (buffer, size) -> polled.add(buffer);
+
+    // Offer more than the capacity, flushing via poll on interval
+    for (int i = 0; i < 15; i++) {
+      queue.offer(i, 1);
+      queue.drainTo(consumer, 1);
+    }
+
+    // ensure we have all of the elements
+    assertThat(polled)
+        .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+  }
+}

--- a/core/src/test/java/zipkin/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin/reporter/FakeSender.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import com.google.auto.value.AutoValue;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Consumer;
+import zipkin.Codec;
+import zipkin.Span;
+
+@AutoValue
+public abstract class FakeSender implements Sender<byte[]> {
+
+  static FakeSender create() {
+    return new AutoValue_FakeSender(
+        Integer.MAX_VALUE,
+        MessageEncoder.THRIFT_BYTES,
+        Codec.THRIFT,
+        spans -> {
+        }
+    );
+  }
+
+  FakeSender onSpans(Consumer<List<Span>> onSpans) {
+    return new AutoValue_FakeSender(
+        messageMaxBytes(),
+        encoder(),
+        codec(),
+        onSpans
+    );
+  }
+
+  FakeSender json() {
+    return new AutoValue_FakeSender(
+        messageMaxBytes(),
+        MessageEncoder.JSON_BYTES,
+        Codec.JSON,
+        onSpans()
+    );
+  }
+
+  FakeSender messageMaxBytes(int messageMaxBytes) {
+    return new AutoValue_FakeSender(
+        messageMaxBytes,
+        encoder(),
+        codec(),
+        onSpans()
+    );
+  }
+
+  abstract MessageEncoder<byte[], byte[]> encoder();
+
+  abstract Codec codec();
+
+  abstract Consumer<List<Span>> onSpans();
+
+  @Override public MessageEncoding messageEncoding() {
+    return encoder();
+  }
+
+  @Override public void sendSpans(List<byte[]> encodedSpans, Callback callback) {
+    try {
+      onSpans().accept(codec().readSpans(encoder().encode(encodedSpans)));
+      callback.onComplete();
+    } catch (Throwable t) {
+      callback.onError(t);
+    }
+  }
+
+  @Override public CheckResult check() {
+    return CheckResult.OK;
+  }
+
+  @Override public void close() throws IOException {
+  }
+
+  @Override public String toString() {
+    return "FakeSender";
+  }
+
+  FakeSender() {
+  }
+}

--- a/core/src/test/java/zipkin/reporter/NoopSender.java
+++ b/core/src/test/java/zipkin/reporter/NoopSender.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter;
+
+import java.io.IOException;
+import java.util.List;
+
+final class NoopSender implements Sender<byte[]> {
+
+  @Override public int messageMaxBytes() {
+    return Integer.MAX_VALUE;
+  }
+
+  @Override public MessageEncoding messageEncoding() {
+    return MessageEncoder.THRIFT_BYTES;
+  }
+
+  @Override public void sendSpans(List<byte[]> encodedSpans, Callback callback) {
+    callback.onComplete();
+  }
+
+  @Override public CheckResult check() {
+    return CheckResult.OK;
+  }
+
+  @Override public void close() throws IOException {
+  }
+
+  @Override public String toString() {
+    return "NoopSender";
+  }
+}


### PR DESCRIPTION
## Reporter
After recording an operation into a span, it needs to be reported out of process. There are two
builtin reporter implementations in this library, although you are free to create your own.

The simplest mechanism is printing out spans as they are reported.

```java
Reporter.CONSOLE.report(span);
```

Reporter is very similar to the following:
* Finagle's DeadlineSpanMap
* zipkin-finagle's SpanRecorder
* Brave's SpanCollector
* HTrace's ZipkinSpanReceiver
* Wingtips' ZipkinSpanSender
* Sleuth's ZipkinSpanReporter
* Jaeger's Reporter

and.. probably many others.

## AsyncReporter
AsyncReporter is how you actually get spans to zipkin. By default, it waits up to a second
before flushes any pending spans out of process via a Sender.

```java
reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
                        .build(Encoder.THRIFT_BYTES);

// Schedules the span to be sent, and won't block the calling thread on I/O
reporter.report(span);
```
