### PR TITLE
Adds OkHttp sender

### DIFF
--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.reporter</groupId>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-sender-okhttp3</artifactId>
+  <name>Zipkin Sender: OkHttp 3</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <!-- OkHttp is Java 1.7 bytecode -->
+    <main.java.version>1.7</main.java.version>
+    <main.signature.artifact>java17</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin-junit</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.okhttp3;
+
+import com.google.auto.value.AutoValue;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import okhttp3.Call;
+import okhttp3.Dispatcher;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.internal.Util;
+import okio.Buffer;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+import zipkin.reporter.Callback;
+import zipkin.reporter.Encoding;
+import zipkin.reporter.MessageEncoder;
+import zipkin.reporter.Sender;
+
+import static zipkin.internal.Util.checkArgument;
+import static zipkin.internal.Util.checkNotNull;
+
+/**
+ * Reports spans to Zipkin, using its <a href="http://zipkin.io/zipkin-api/#/">POST</a> endpoint.
+ */
+@AutoValue
+public abstract class OkHttpSender implements Sender<RequestBody> {
+  /** Creates a sender that posts {@link Encoding#THRIFT thrift} messages. */
+  public static OkHttpSender create(String endpoint) {
+    return builder().endpoint(endpoint).build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_OkHttpSender.Builder()
+        .compressionEnabled(true)
+        .maxRequests(64)
+        .messageMaxBytes(5 * 1024 * 1024)
+        .spanEncoding(Encoding.THRIFT);
+  }
+
+  @AutoValue.Builder
+  public static abstract class Builder {
+
+    /**
+     * No default. The POST URL for zipkin's <a href="http://zipkin.io/zipkin-api/#/">v1 api</a>,
+     * usually "http://zipkinhost:9411/api/v1/spans"
+     */
+    // customizable so that users can re-map /api/v1/spans ex for browser-originated traces
+    public final Builder endpoint(String endpoint) {
+      checkNotNull(endpoint, "endpoint ex: http://zipkinhost:9411/api/v1/spans");
+      HttpUrl parsed = HttpUrl.parse(endpoint);
+      checkArgument(parsed != null, "invalid post url: " + endpoint);
+      return endpoint(parsed);
+    }
+
+    public abstract Builder endpoint(HttpUrl endpoint);
+
+    /** Default true. true implies that spans will be gzipped before transport. */
+    public abstract Builder compressionEnabled(boolean compressSpans);
+
+    /** Maximum size of a message. Default 5MiB */
+    public abstract Builder messageMaxBytes(int messageMaxBytes);
+
+    /** Maximum in-flight requests. Default 64 */
+    public abstract Builder maxRequests(int maxRequests);
+
+    /**
+     * Controls the "Content-Type" header and {@link MessageEncoder#encode(List) message encoder}
+     * when sending spans.
+     */
+    public abstract Builder spanEncoding(Encoding spanEncoding);
+
+    abstract int maxRequests();
+
+    abstract Encoding spanEncoding();
+
+    public final OkHttpSender build() {
+      // bound the executor so that we get consistent performance
+      ThreadPoolExecutor dispatchExecutor =
+          new ThreadPoolExecutor(0, maxRequests(), 60, TimeUnit.SECONDS,
+              new ArrayBlockingQueue<>(maxRequests()),
+              Util.threadFactory("OkHttpSender Dispatcher", false));
+      dispatchExecutor(dispatchExecutor);
+      Dispatcher dispatcher = new Dispatcher(dispatchExecutor);
+      dispatcher.setMaxRequests(maxRequests());
+      dispatcher.setMaxRequestsPerHost(maxRequests());
+      client(new OkHttpClient.Builder()
+          .dispatcher(dispatcher).build());
+
+      if (spanEncoding() == Encoding.JSON) {
+        return encoder(RequestBodyMessageEncoder.JSON).autoBuild();
+      } else if (spanEncoding() == Encoding.THRIFT) {
+        return encoder(RequestBodyMessageEncoder.THRIFT).autoBuild();
+      }
+      throw new UnsupportedOperationException("Unsupported spanEncoding: " + spanEncoding().name());
+    }
+
+    abstract Builder dispatchExecutor(ExecutorService dispatchExecutor);
+
+    abstract Builder client(OkHttpClient client);
+
+    abstract Builder encoder(MessageEncoder<RequestBody> encoder);
+
+    abstract OkHttpSender autoBuild();
+
+    Builder() {
+    }
+  }
+
+  public Builder toBuilder() {
+    return new AutoValue_OkHttpSender.Builder(this);
+  }
+
+  abstract OkHttpClient client();
+
+  abstract ExecutorService dispatchExecutor();
+
+  abstract HttpUrl endpoint();
+
+  abstract int maxRequests();
+
+  abstract boolean compressionEnabled();
+
+  @Override public abstract MessageEncoder<RequestBody> encoder();
+
+  /** Asynchronously sends the spans as a POST to {@link #endpoint()}. */
+  @Override public void sendSpans(List<byte[]> encodedSpans, Callback callback) {
+    if (encodedSpans.isEmpty()) {
+      callback.onComplete();
+      return;
+    }
+    try {
+      Request request = newRequest(encoder().encode(encodedSpans));
+      client().newCall(request).enqueue(new CallbackAdapter(callback));
+    } catch (Throwable e) {
+      callback.onError(e);
+      if (e instanceof Error) throw (Error) e;
+    }
+  }
+
+  /** Sends an empty json message to the configured endpoint. */
+  @Override public CheckResult check() {
+    try {
+      Request request = new Request.Builder().url(endpoint())
+          .post(RequestBody.create(MediaType.parse("application/json"), "[]")).build();
+      Response response = client().newCall(request).execute();
+      if (!response.isSuccessful()) {
+        throw new IllegalStateException("check response failed: " + response);
+      }
+      return CheckResult.OK;
+    } catch (Exception e) {
+      return CheckResult.failed(e);
+    }
+  }
+
+  @Override public void close() {
+    client().dispatcher().cancelAll();
+    dispatchExecutor().shutdown();
+  }
+
+  Request newRequest(RequestBody body) throws IOException {
+    Request.Builder request = new Request.Builder().url(endpoint());
+    if (compressionEnabled()) {
+      request.addHeader("Content-Encoding", "gzip");
+      Buffer gzipped = new Buffer();
+      BufferedSink gzipSink = Okio.buffer(new GzipSink(gzipped));
+      body.writeTo(gzipSink);
+      gzipSink.close();
+      body = new BufferRequestBody(body.contentType(), gzipped);
+    }
+    request.post(body);
+    return request.build();
+  }
+
+  OkHttpSender() {
+  }
+
+  static final class BufferRequestBody extends RequestBody {
+    private final MediaType contentType;
+    private final Buffer body;
+
+    public BufferRequestBody(MediaType contentType, Buffer body) {
+      this.contentType = contentType;
+      this.body = body;
+    }
+
+    @Override public MediaType contentType() {
+      return contentType;
+    }
+
+    @Override public void writeTo(BufferedSink sink) throws IOException {
+      sink.write(body, body.size());
+    }
+  }
+
+  static final class CallbackAdapter implements okhttp3.Callback {
+    private final Callback delegate;
+
+    public CallbackAdapter(Callback delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override public void onFailure(Call call, IOException e) {
+      delegate.onError(e);
+    }
+
+    @Override public void onResponse(Call call, Response response) throws IOException {
+      if (response.isSuccessful()) {
+        delegate.onComplete();
+      } else {
+        delegate.onError(new IllegalStateException("response failed: " + response));
+      }
+    }
+
+    @Override public String toString() {
+      return "CallbackAdapter(" + delegate + ")";
+    }
+  }
+}

--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/RequestBodyMessageEncoder.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/RequestBodyMessageEncoder.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.okhttp3;
+
+import java.io.IOException;
+import java.util.List;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+import zipkin.reporter.MessageEncoder;
+
+enum RequestBodyMessageEncoder implements MessageEncoder<RequestBody> {
+  THRIFT {
+    @Override public int overheadInBytes(int spanCount) {
+      return THRIFT_BYTES.overheadInBytes(spanCount);
+    }
+
+    @Override public RequestBody encode(List<byte[]> values) {
+      return new ThriftRequestBody(values);
+    }
+  },
+  JSON {
+    @Override public int overheadInBytes(int spanCount) {
+      return JSON_BYTES.overheadInBytes(spanCount);
+    }
+
+    @Override public RequestBody encode(List<byte[]> values) {
+      return new JsonRequestBody(values);
+    }
+  };
+
+  static abstract class StreamingRequestBody extends RequestBody {
+    final MediaType contentType;
+    final List<byte[]> values;
+    final long contentLength;
+
+    StreamingRequestBody(MessageEncoder<?> encoder, MediaType contentType, List<byte[]> values) {
+      this.contentType = contentType;
+      this.values = values;
+      long contentLength = encoder.overheadInBytes(values.size());
+      for (byte[] value : values) {
+        contentLength += value.length;
+      }
+      this.contentLength = contentLength;
+    }
+
+    @Override public MediaType contentType() {
+      return contentType;
+    }
+
+    @Override public long contentLength() {
+      return contentLength;
+    }
+  }
+
+  static final class ThriftRequestBody extends StreamingRequestBody {
+    static final MediaType CONTENT_TYPE = MediaType.parse("application/x-thrift");
+
+    ThriftRequestBody(List<byte[]> values) {
+      super(MessageEncoder.THRIFT_BYTES, CONTENT_TYPE, values);
+    }
+
+    @Override public void writeTo(BufferedSink sink) throws IOException {
+      // TBinaryProtocol List header is element type followed by count
+      sink.writeByte(11 /* TYPE_STRUCT */);
+      int length = values.size();
+      sink.writeInt(length);
+      for (int i = 0; i < length; i++) {
+        sink.write(values.get(i));
+      }
+    }
+  }
+
+  static final class JsonRequestBody extends StreamingRequestBody {
+    static final MediaType CONTENT_TYPE = MediaType.parse("application/json");
+
+    JsonRequestBody(List<byte[]> values) {
+      super(MessageEncoder.JSON_BYTES, CONTENT_TYPE, values);
+    }
+
+    @Override public void writeTo(BufferedSink sink) throws IOException {
+      sink.writeByte('[');
+      for (int i = 0, length = values.size(); i < length; ) {
+        byte[] next = values.get(i++);
+        sink.write(next);
+        if (i < length) sink.writeByte(',');
+      }
+      sink.writeByte(']');
+    }
+  }
+}

--- a/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.okhttp3;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Span;
+import zipkin.TestObjects;
+import zipkin.junit.HttpFailure;
+import zipkin.junit.ZipkinRule;
+import zipkin.reporter.Encoder;
+import zipkin.reporter.Encoding;
+import zipkin.reporter.internal.AwaitableCallback;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class OkHttpSenderTest {
+  static final Span clientSpan = TestObjects.TRACE.get(2);
+
+  @Rule
+  public ZipkinRule zipkinRule = new ZipkinRule();
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  OkHttpSender sender = OkHttpSender.create(zipkinRule.httpUrl() + "/api/v1/spans");
+
+  @Test
+  public void badUrlIsAnIllegalArgument() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("invalid post url: ");
+
+    OkHttpSender.create("htp://localhost:9411/api/v1/spans");
+  }
+
+  @Test
+  public void sendsSpans() throws Exception {
+    send(TestObjects.TRACE);
+
+    // Ensure only one request was sent
+    assertThat(zipkinRule.httpRequestCount()).isEqualTo(1);
+
+    // Now, let's read back the spans we sent!
+    assertThat(zipkinRule.getTraces()).containsExactly(TestObjects.TRACE);
+  }
+
+  @Test
+  public void sendsSpans_json() throws Exception {
+    sender = sender.toBuilder().spanEncoding(Encoding.JSON).build();
+
+    AwaitableCallback callback = new AwaitableCallback();
+    sender.sendSpans(asList(Encoder.JSON.encode(clientSpan)), callback);
+    callback.await();
+
+    // Ensure only one request was sent
+    assertThat(zipkinRule.httpRequestCount()).isEqualTo(1);
+
+    // Now, let's read back the spans we sent!
+    assertThat(zipkinRule.getTraces()).containsExactly(asList(clientSpan));
+  }
+
+  @Test public void compression() throws Exception {
+    zipkinRule.shutdown(); // shutdown the normal zipkin rule
+
+    MockWebServer server = new MockWebServer();
+    sender = sender.toBuilder().endpoint(server.url("/api/v1/spans").toString()).build();
+    try {
+      List<RecordedRequest> requests = new ArrayList<>();
+      for (boolean compressionEnabled : asList(true, false)) {
+        sender = sender.toBuilder().compressionEnabled(compressionEnabled).build();
+
+        server.enqueue(new MockResponse());
+
+        send(TestObjects.TRACE);
+
+        // block until the request arrived
+        requests.add(server.takeRequest());
+      }
+
+      // we expect the first compressed request to be smaller than the uncompressed one.
+      assertThat(requests.get(0).getBodySize())
+          .isLessThan(requests.get(1).getBodySize());
+    } finally {
+      server.shutdown();
+    }
+  }
+
+  @Test public void mediaTypeBasedOnEncoding() throws Exception {
+    zipkinRule.shutdown(); // shutdown the normal zipkin rule
+    MockWebServer server = new MockWebServer();
+    try {
+      sender = sender.toBuilder()
+          .endpoint(server.url("/api/v1/spans").toString())
+          .spanEncoding(Encoding.JSON)
+          .build();
+
+      server.enqueue(new MockResponse());
+
+      send(TestObjects.TRACE); // objects are in json, but we tell it the wrong thing
+
+      // block until the request arrived
+      assertThat(server.takeRequest().getHeader("Content-Type"))
+          .isEqualTo("application/json");
+    } finally {
+      server.shutdown();
+    }
+  }
+
+  @Test
+  public void onErrorWhenServerErrors() throws Exception {
+    zipkinRule.enqueueFailure(HttpFailure.sendErrorResponse(500, "Server Error!"));
+
+    AwaitableCallback callback = new AwaitableCallback();
+    sender.sendSpans(asList(Encoder.THRIFT.encode(clientSpan)), callback);
+
+    // shouldn't throw until we call await!
+    try {
+      callback.await();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+    }
+  }
+
+  @Test
+  public void onErrorWhenServerDisconnects() throws Exception {
+    zipkinRule.enqueueFailure(HttpFailure.disconnectDuringBody());
+
+    AwaitableCallback callback = new AwaitableCallback();
+    sender.sendSpans(asList(Encoder.THRIFT.encode(clientSpan)), callback);
+
+    // shouldn't throw until we call await!
+    try {
+      callback.await();
+      failBecauseExceptionWasNotThrown(RuntimeException.class);
+    } catch (RuntimeException e) {
+      assertThat(e.getCause()).isInstanceOf(IOException.class);
+    }
+  }
+
+  @Test
+  public void check_ok() throws Exception {
+    assertThat(sender.check().ok).isTrue();
+
+    assertThat(zipkinRule.httpRequestCount()).isEqualTo(1);
+  }
+
+  @Test
+  public void check_fail() throws Exception {
+    zipkinRule.enqueueFailure(HttpFailure.disconnectDuringBody());
+
+    assertThat(sender.check().ok).isFalse();
+  }
+
+  /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
+  void send(List<Span> spans) {
+    AwaitableCallback callback = new AwaitableCallback();
+    sender.sendSpans(spans.stream().map(Encoder.THRIFT::encode).collect(toList()), callback);
+    callback.await();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <module>core</module>
     <module>kafka08</module>
     <module>urlconnection</module>
+    <module>okhttp3</module>
     <module>benchmarks</module>
   </modules>
 


### PR DESCRIPTION
Until now, the only http transport was URLConnection, which has no
dependencies and JRE 6 runtime capability, but isn't asynchronous or
http/2 capable. For example, the URLConnection sender can easily block
the reporter thread and cause a backlog.

This adds an OkHttp sender with parameters for controlling concurrency.