### PR TITLE
Adds libthrift (Scribe) sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/openzipkin/zipkin) [![Build Status](https://travis-ci.org/openzipkin/zipkin-reporter-java.svg?branch=master)](https://travis-ci.org/openzipkin/zipkin-reporter-java) [![Download](https://api.bintray.com/packages/openzipkin/maven/zipkin-reporter-java/images/download.svg) ](https://bintray.com/openzipkin/maven/zipkin-reporter-java/_latestVersion)
 
 # zipkin-reporter-java
-Shared library for reporting zipkin spans onto transports including http and kafka. Requires JRE 6 or later.
+Shared library for reporting zipkin spans onto transports including http, kafka and scribe. Requires JRE 6 or later.
 
 # Usage
 These components can be called when spans have been recorded and ready to send to zipkin.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-libthrift</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
       <version>${jmh.version}</version>
@@ -99,6 +104,12 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <version>2.11.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.facebook.swift</groupId>
+      <artifactId>swift-service</artifactId>
+      <version>0.21.1</version>
     </dependency>
   </dependencies>
 

--- a/benchmarks/src/main/java/zipkin/reporter/LibthriftSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/reporter/LibthriftSenderBenchmarks.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package zipkin.reporter;
+
+import com.facebook.swift.codec.ThriftCodecManager;
+import com.facebook.swift.codec.ThriftEnumValue;
+import com.facebook.swift.codec.ThriftField;
+import com.facebook.swift.codec.ThriftStruct;
+import com.facebook.swift.service.ThriftMethod;
+import com.facebook.swift.service.ThriftServer;
+import com.facebook.swift.service.ThriftServerConfig;
+import com.facebook.swift.service.ThriftService;
+import com.facebook.swift.service.ThriftServiceProcessor;
+import java.io.IOException;
+import java.util.List;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin.reporter.libthrift.LibthriftSender;
+
+import static java.util.Collections.emptyList;
+
+public class LibthriftSenderBenchmarks extends SenderBenchmarks {
+  ThriftServer scribe;
+
+  @ThriftService("Scribe")
+  public static final class Scribe {
+
+    @ThriftMethod(value = "Log")
+    public Scribe.ResultCode log(@ThriftField(value = 1) List<Scribe.LogEntry> messages) {
+      return ResultCode.OK;
+    }
+
+    public enum ResultCode {
+      OK(0), TRY_LATER(1);
+
+      final int value;
+
+      ResultCode(int value) {
+        this.value = value;
+      }
+
+      @ThriftEnumValue
+      public int value() {
+        return value;
+      }
+    }
+
+    @ThriftStruct(value = "LogEntry")
+    public static final class LogEntry {
+
+      @ThriftField(value = 1)
+      public String category;
+
+      @ThriftField(value = 2)
+      public String message;
+    }
+  }
+
+  @Override Sender createSender() throws Exception {
+    ThriftServiceProcessor processor =
+        new ThriftServiceProcessor(new ThriftCodecManager(), emptyList(), new Scribe());
+    scribe = new ThriftServer(processor, new ThriftServerConfig().setPort(9410)).start();
+    return LibthriftSender.create("127.0.0.1");
+  }
+
+  @Override void afterSenderClose() throws IOException {
+    scribe.close();
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(".*" + LibthriftSenderBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.reporter</groupId>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-sender-libthrift</artifactId>
+  <name>Zipkin Sender: libthrift (Scribe)</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.java</groupId>
+      <artifactId>zipkin-collector-scribe</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.libthrift;
+
+import com.google.auto.value.AutoValue;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import zipkin.internal.LazyCloseable;
+import zipkin.reporter.Callback;
+import zipkin.reporter.Encoding;
+import zipkin.reporter.Sender;
+
+/**
+ * Blocking reporter that sends spans to Zipkin via Scribe.
+ *
+ * <p>This sender is not thread-safe.
+ */
+@AutoValue
+public abstract class LibthriftSender extends LazyCloseable<ScribeClient> implements Sender {
+  /** Creates a sender that sends {@link Encoding#THRIFT} messages. */
+  public static LibthriftSender create(String host) {
+    return builder().host(host).build();
+  }
+
+  public static Builder builder() {
+    return new AutoValue_LibthriftSender.Builder()
+        .port(9410)
+        .socketTimeout(60 * 1000)
+        .connectTimeout(10 * 1000)
+        .messageMaxBytes(16384000 /* TFramedTransport.DEFAULT_MAX_LENGTH */);
+  }
+
+  @AutoValue.Builder
+  public interface Builder {
+    /** No default. The host listening for scribe messages. */
+    Builder host(String host);
+
+    /** Default 9410. The port listening for scribe messages. */
+    Builder port(int port);
+
+    /** Default 60 * 1000 milliseconds. 0 implies no timeout. */
+    Builder socketTimeout(int socketTimeout);
+
+    /** Default 10 * 1000 milliseconds. 0 implies no timeout. */
+    Builder connectTimeout(int connectTimeout);
+
+    /** Maximum size of a message. Default 16384000 */
+    Builder messageMaxBytes(int messageMaxBytes);
+
+    LibthriftSender build();
+  }
+
+  public Builder toBuilder() {
+    return new AutoValue_LibthriftSender.Builder(this);
+  }
+
+  abstract String host();
+
+  abstract int port();
+
+  abstract int socketTimeout();
+
+  abstract int connectTimeout();
+
+  @Override public Encoding encoding() {
+    return Encoding.THRIFT;
+  }
+
+  /** Size of the Thrift RPC message */
+  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
+    return ScribeClient.messageSizeInBytes(encodedSpans);
+  }
+
+  @Override protected ScribeClient compute() {
+    return new ScribeClient(host(), port(), socketTimeout(), connectTimeout());
+  }
+
+  /** close is typically called from a different thread */
+  private transient boolean closeCalled;
+
+  @Override public void sendSpans(List<byte[]> encodedSpans, Callback callback) {
+    if (closeCalled) throw new IllegalStateException("closed");
+    try {
+      if (get().log(encodedSpans) == ResultCode.OK) {
+        callback.onComplete();
+      } else {
+        callback.onError(new IllegalStateException(ResultCode.TRY_LATER.name()));
+      }
+    } catch (Throwable e) {
+      callback.onError(e);
+      if (e instanceof Error) throw (Error) e;
+    }
+  }
+
+  /** Sends an empty log message to the configured host. */
+  @Override public CheckResult check() {
+    try {
+      if (get().log(Collections.emptyList()) == ResultCode.OK) {
+        return CheckResult.OK;
+      }
+      throw new IllegalStateException(ResultCode.TRY_LATER.name());
+    } catch (Exception e) {
+      return CheckResult.failed(e);
+    }
+  }
+
+  @Override public void close() throws IOException {
+    if (closeCalled) return;
+    closeCalled = true;
+    ScribeClient maybeNull = maybeNull();
+    if (maybeNull != null) maybeNull.close();
+  }
+
+  LibthriftSender() {
+  }
+}

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/ResultCode.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/ResultCode.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.libthrift;
+
+import org.apache.thrift.TEnum;
+
+enum ResultCode implements TEnum {
+  OK(0),
+  TRY_LATER(1);
+
+  private final int value;
+
+  ResultCode(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  static ResultCode findByValue(int value) {
+    switch (value) {
+      case 0:
+        return OK;
+      case 1:
+        return TRY_LATER;
+      default:
+        return null;
+    }
+  }
+}

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/ScribeClient.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/ScribeClient.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.libthrift;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TList;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
+import org.apache.thrift.protocol.TProtocolUtil;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransportException;
+
+import static org.apache.thrift.TApplicationException.BAD_SEQUENCE_ID;
+import static org.apache.thrift.TApplicationException.MISSING_RESULT;
+
+final class ScribeClient implements Closeable {
+  static final Logger logger = Logger.getLogger(ScribeClient.class.getName());
+  static final byte[] category = "zipkin".getBytes();
+
+  final TSocket socket;
+  final TBinaryProtocol prot;
+
+  ScribeClient(String host, int port, int socketTimeout, int connectTimeout) {
+    socket = new TSocket(host, port, socketTimeout, connectTimeout);
+    prot = new TBinaryProtocol(new TFramedTransport(socket));
+  }
+
+  private int seqid_;
+
+  ResultCode log(List<byte[]> encodedSpans) throws TException {
+    try {
+      if (!socket.isOpen()) socket.open();
+      return doLog(encodedSpans);
+    } catch (TTransportException e) {
+      logger.log(Level.FINE, "Transport exception. recreating socket", e);
+      socket.close();
+      seqid_ = 0;
+      throw e;
+    }
+  }
+
+  private ResultCode doLog(List<byte[]> encodedSpans) throws TException {
+    sendMessage(encodedSpans);
+    prot.getTransport().flush();
+
+    TMessage msg = prot.readMessageBegin();
+    if (msg.type == TMessageType.EXCEPTION) {
+      throw TApplicationException.read(prot);
+    } else if (msg.seqid != seqid_) {
+      throw new TApplicationException(BAD_SEQUENCE_ID, "Log failed: out of sequence response");
+    }
+
+    ResultCode result = parseResponse();
+    if (result != null) return result;
+    throw new TApplicationException(MISSING_RESULT, "Log failed: unknown result");
+  }
+
+  static final TField MESSAGES_FIELD_DESC = new TField("messages", TType.LIST, (short) 1);
+
+  static int messageSizeInBytes(List<byte[]> encodedSpans) {
+    int sizeInBytes = 12 + 3; // messageBegin = overhead + size of "Log"
+    sizeInBytes += 5; // FieldBegin
+    sizeInBytes += 5; // ListBegin
+    for (byte[] encodedSpan : encodedSpans) {
+      sizeInBytes += SpanToLogEntry.sizeOfLogEntry(category, encodedSpan);
+    }
+    sizeInBytes += 1; // FieldStop
+    return sizeInBytes;
+  }
+
+  private void sendMessage(List<byte[]> encodedSpans) throws TException {
+    prot.writeMessageBegin(new TMessage("Log", TMessageType.CALL, ++seqid_));
+    prot.writeFieldBegin(MESSAGES_FIELD_DESC);
+    prot.writeListBegin(new TList(TType.STRUCT, encodedSpans.size()));
+    for (byte[] encodedSpan : encodedSpans) SpanToLogEntry.write(category, encodedSpan, prot);
+    prot.writeFieldStop();
+  }
+
+  private ResultCode parseResponse() throws TException {
+    ResultCode result = null;
+    prot.readStructBegin();
+    TField schemeField;
+    while ((schemeField = prot.readFieldBegin()).type != TType.STOP) {
+      if (schemeField.id == 0 /* SUCCESS */ && schemeField.type == TType.I32) {
+        result = ResultCode.findByValue(prot.readI32());
+      } else {
+        TProtocolUtil.skip(prot, schemeField.type);
+      }
+    }
+    return result;
+  }
+
+  @Override public void close() throws IOException {
+    socket.close();
+  }
+}

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/SpanToLogEntry.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/SpanToLogEntry.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.libthrift;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TType;
+
+final class SpanToLogEntry {
+  static final TField CATEGORY_FIELD_DESC = new TField("category", TType.STRING, (short) 1);
+  static final TField MESSAGE_FIELD_DESC = new TField("message", TType.STRING, (short) 2);
+
+  static int sizeOfLogEntry(byte[] category, byte[] span) {
+    int sizeInBytes = 5 + 4 + category.length;
+    sizeInBytes += 5 + 4 + base64SizeInBytes(span);
+    sizeInBytes++; // stop
+    return sizeInBytes;
+  }
+
+  static void write(byte[] category, byte[] span, TBinaryProtocol oprot) throws TException {
+    oprot.writeFieldBegin(CATEGORY_FIELD_DESC);
+    oprot.writeI32(category.length);
+    oprot.getTransport().write(category, 0, category.length);
+
+    oprot.writeFieldBegin(MESSAGE_FIELD_DESC);
+    byte[] base64 = base64(span);
+    oprot.writeI32(base64.length);
+    oprot.getTransport().write(base64, 0, base64.length);
+    oprot.writeFieldStop();
+  }
+
+  private static final byte[] MAP = new byte[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+      '5', '6', '7', '8', '9', '+', '/'
+  };
+
+  /**
+   * Adapted from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+   *
+   * <p>Original author: Alexander Y. Kleymenov
+   */
+  static byte[] base64(byte[] in) {
+    int length = base64SizeInBytes(in);
+    byte[] out = new byte[length];
+    int index = 0, end = in.length - in.length % 3;
+    for (int i = 0; i < end; i += 3) {
+      out[index++] = MAP[(in[i] & 0xff) >> 2];
+      out[index++] = MAP[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      out[index++] = MAP[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      out[index++] = MAP[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        out[index++] = MAP[(in[end] & 0xff) >> 2];
+        out[index++] = MAP[(in[end] & 0x03) << 4];
+        out[index++] = '=';
+        out[index++] = '=';
+        break;
+      case 2:
+        out[index++] = MAP[(in[end] & 0xff) >> 2];
+        out[index++] = MAP[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        out[index++] = MAP[((in[end + 1] & 0x0f) << 2)];
+        out[index++] = '=';
+        break;
+    }
+    return out;
+  }
+
+  private static int base64SizeInBytes(byte[] in) {
+    return (in.length + 2) * 4 / 3;
+  }
+}

--- a/libthrift/src/test/java/zipkin/reporter/libthrift/LibthriftSenderTest.java
+++ b/libthrift/src/test/java/zipkin/reporter/libthrift/LibthriftSenderTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2016 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin.reporter.libthrift;
+
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin.Span;
+import zipkin.TestObjects;
+import zipkin.collector.CollectorMetrics;
+import zipkin.collector.scribe.ScribeCollector;
+import zipkin.reporter.Encoder;
+import zipkin.reporter.internal.AwaitableCallback;
+import zipkin.storage.InMemoryStorage;
+import zipkin.storage.QueryRequest;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
+public class LibthriftSenderTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  InMemoryStorage storage = new InMemoryStorage();
+  ScribeCollector collector;
+
+  @Before
+  public void start() {
+    collector = ScribeCollector.builder()
+        .metrics(CollectorMetrics.NOOP_METRICS)
+        .storage(storage).build();
+    collector.start();
+  }
+
+  @After
+  public void close() {
+    collector.close();
+  }
+
+  LibthriftSender sender = LibthriftSender.create("127.0.0.1");
+
+  @Test
+  public void sendsSpans() throws Exception {
+    send(TestObjects.TRACE);
+
+    assertThat(storage.spanStore().getTraces(QueryRequest.builder().build()))
+        .containsExactly(TestObjects.TRACE);
+  }
+
+  @Test
+  public void check_okWhenScribeIsListening() throws Exception {
+    assertThat(sender.check().ok)
+        .isTrue();
+  }
+
+  @Test
+  public void check_notOkWhenScribeIsDown() throws Exception {
+    collector.close();
+
+    assertThat(sender.check().ok)
+        .isFalse();
+  }
+
+  @Test
+  public void reconnects() throws Exception {
+    close();
+    try {
+      send(TestObjects.TRACE);
+      failBecauseExceptionWasNotThrown(RuntimeException.class);
+    } catch (RuntimeException e) {
+    }
+    start();
+
+    send(TestObjects.TRACE);
+
+    assertThat(storage.spanStore().getTraces(QueryRequest.builder().build()))
+        .containsExactly(TestObjects.TRACE);
+  }
+
+  @Test
+  public void illegalToSendWhenClosed() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    sender.close();
+
+    send(TestObjects.TRACE);
+  }
+
+  /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
+  void send(List<Span> spans) {
+    AwaitableCallback callback = new AwaitableCallback();
+    sender.sendSpans(spans.stream().map(Encoder.THRIFT::encode).collect(toList()), callback);
+    callback.await();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <module>kafka08</module>
     <module>urlconnection</module>
     <module>okhttp3</module>
+    <module>libthrift</module>
     <module>benchmarks</module>
   </modules>
 
@@ -113,6 +114,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-sender-kafka08</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-libthrift</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
This adds a sender that depends on libthrift. In this case, the
messageMaxSize correlates to the actual size of the thrift RPC message
as that's the thing that breaks the other side when wrong.

This uses the same basic reconnect logic used by Brave and HTrace.