### PR TITLE
Refactors sender benchmarks to focus on throughput

### DIFF
--- a/benchmarks/src/main/java/zipkin/reporter/SenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin/reporter/SenderBenchmarks.java
@@ -15,58 +15,76 @@
 package zipkin.reporter;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Group;
-import org.openjdk.jmh.annotations.GroupThreads;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import zipkin.Component;
+import zipkin.Span;
 import zipkin.TestObjects;
-import zipkin.reporter.internal.AwaitableCallback;
 
 /**
- * These benchmarks measures the throughput of senders by treating them as if they are blocking.
- *
- * <p>By blocking, we can compare performance of each sender somewhat fairly, eventhough in practice
- * many will not block.
+ * This benchmark reports spans as fast as possible. The sender clears the queue as fast as
+ * possible using different max message sizes.
  */
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)
 @Fork(3)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
-@State(Scope.Group)
+@State(Scope.Benchmark)
+@Threads(-1)
 public abstract class SenderBenchmarks {
+  /**
+   * How many spans to keep in the backlog at one time. This number is high to ensure senders aren't
+   * limited by span production speed.
+   */
+  static final int TARGET_BACKLOG = 1_000_000;
+
+  // 256KiB, 512KiB, default for Kafka
+  @Param({"262144", "524288", "1000000"})
+  public int messageMaxBytes;
+
   static final byte[] clientSpan = Encoder.THRIFT.encode(TestObjects.TRACE.get(2));
+
+  static final InMemoryReporterMetrics metrics = new InMemoryReporterMetrics();
 
   @AuxCounters
   @State(Scope.Thread)
-  public static class SendCounters {
-    public int spans;
-    public int spansDropped;
+  public static class InMemoryReporterMetricsAsCounters {
+
+    public long spans() {
+      return metrics.spans() - metrics.spansDropped();
+    }
+
+    public long messages() {
+      return metrics.messages();
+    }
+
+    public long messagesDropped() {
+      return metrics.messagesDropped();
+    }
 
     @Setup(Level.Iteration)
     public void clean() {
-      spans = spansDropped = 0;
+      metrics.clear();
     }
   }
 
   Sender sender;
-  // TODO: is there a way to add another field to JMH output? Ex span size
-  List<byte[]> spans;
+  AsyncReporter.BoundedAsyncReporter<Span> reporter;
 
   @Setup(Level.Trial)
   public void setup() throws Throwable {
@@ -75,43 +93,31 @@ public abstract class SenderBenchmarks {
     Component.CheckResult senderCheck = sender.check();
     if (!senderCheck.ok) throw new IllegalStateException("sender not ok", senderCheck.exception);
 
-    spans = new ArrayList<>();
-    int remaining = sender.messageMaxBytes();
-    for (; clientSpan.length < remaining; remaining -= clientSpan.length) {
-      spans.add(clientSpan);
-    }
-
-    // really, really check everything is ok
-    AwaitableCallback callback = new AwaitableCallback();
-    sender.sendSpans(spans, callback);
-    callback.await();
+    reporter = (AsyncReporter.BoundedAsyncReporter<Span>) AsyncReporter.builder(sender)
+        .messageMaxBytes(messageMaxBytes)
+        .queuedMaxSpans(TARGET_BACKLOG)
+        .metrics(metrics).build();
   }
 
   abstract Sender createSender() throws Exception;
 
-  @Benchmark @Group("no_contention") @GroupThreads(1)
-  public void no_contention_blocking_send(SendCounters counters) {
-    sendSpansBlocking(counters);
+  @Setup(Level.Iteration)
+  public void fillQueue() throws IOException {
+    while (reporter.pending.offer(clientSpan));
   }
 
-  @Benchmark @Group("mild_contention") @GroupThreads(2)
-  public void mild_contention_blocking_send(SendCounters counters) {
-    sendSpansBlocking(counters);
+  @TearDown(Level.Iteration)
+  public void clearQueue() throws IOException {
+    reporter.pending.clear();
   }
 
-  @Benchmark @Group("high_contention") @GroupThreads(8)
-  public void high_contention_blocking_send(SendCounters counters) {
-    sendSpansBlocking(counters);
-  }
-
-  void sendSpansBlocking(SendCounters counters) {
-    AwaitableCallback callback = new AwaitableCallback();
-    try {
-      sender.sendSpans(spans, callback);
-      callback.await();
-      counters.spans += spans.size();
-    } catch (RuntimeException e) {
-      counters.spansDropped += spans.size();
+  @Benchmark
+  public void report(InMemoryReporterMetricsAsCounters counters) throws InterruptedException {
+    // if we were able to add more to the queue, that means the sender sent spans
+    if (reporter.pending.offer(clientSpan)) {
+      metrics.incrementSpans(1);
+    } else {
+      Thread.sleep(10);
     }
   }
 

--- a/core/src/main/java/zipkin/reporter/Sender.java
+++ b/core/src/main/java/zipkin/reporter/Sender.java
@@ -22,6 +22,9 @@ import zipkin.collector.Collector;
  * encoding them into a message and enqueueing them for transport over http or Kafka. The typical
  * end recipient is a zipkin {@link Collector}.
  *
+ * <p>Unless mentioned otherwise, senders are not thread-safe. They were designed to be used by
+ * {@link AsyncReporter}, which has a single reporting thread.
+ *
  * <p>Those looking to initialize eagerly should call {@link #check()}. This can be used to reduce
  * latency on the first send operation, or to fail fast.
  *

--- a/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
@@ -33,6 +33,8 @@ import static zipkin.internal.Util.checkNotNull;
 /**
  * This sends (usually TBinaryProtocol big-endian) encoded spans to a Kafka topic.
  *
+ * <p>This sender is thread-safe.
+ *
  * <p>This sender remains a Kafka 0.8.x consumer, while Zipkin systems update to 0.9+.
  */
 @AutoValue

--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -42,6 +42,8 @@ import static zipkin.internal.Util.checkNotNull;
 
 /**
  * Reports spans to Zipkin, using its <a href="http://zipkin.io/zipkin-api/#/">POST</a> endpoint.
+ *
+ * <p>This sender is thread-safe.
  */
 @AutoValue
 public abstract class OkHttpSender implements Sender {

--- a/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
@@ -31,6 +31,8 @@ import static zipkin.internal.Util.checkNotNull;
 
 /**
  * Reports spans to Zipkin, using its <a href="http://zipkin.io/zipkin-api/#/">POST</a> endpoint.
+ *
+ * <p>This sender is thread-safe.
  */
 @AutoValue
 public abstract class URLConnectionSender implements Sender {


### PR DESCRIPTION
Before, sender benchmarks were not realistic because senders were being
driven by multiple threads. In reality, they will only have one driver
thread, run by AsyncReporter. This refocuses benchmarks around the act
of clearing a queue, changing a variable of message size.

Some senders, such as okhttp and kafka, implicitly spawn multiple
threads. This benchmark will show off the default abilities eventhough
these thread counts can usually be changed.