### PR TITLE
Updates ReporterMetrics with stats used by Finagle and Jaeger

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Here are the most important properties to understand when tuning.
 
 Property | Description
 --- | ---
-`queuedMaxBytes` |  Maximum backlog of span bytes reported vs sent. Default 1% of heap
+`queuedMaxBytes` |  Maximum backlog of span bytes reported vs sent. Corresponds to `ReporterMetrics.updateQueuedBytes`. Default 1% of heap
 `messageMaxBytes` | Maximum bytes sendable per message including overhead. Default `Sender.messageMaxBytes`
 `messageTimeout` |  Maximum time to wait for messageMaxBytes to accumulate before sending. Default 1 second
 


### PR DESCRIPTION
This adds `ReporterMetrics.updateSpanBacklog` and adds the cause for
`ReporterMetrics.incrementDroppedMessages`. These allow AsyncReporter
to produce metrics used by Finagle and Jaeger's tracers.

This is partially paid for by removing the metrics scope functionality.
Especially a client library shouldn't have a concern like this (even if
we do on the server).