### PR TITLE
When a LazyCloseable delegates to a Closeable, prefer default close()

### DIFF
--- a/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
@@ -14,6 +14,7 @@
 package zipkin.reporter.kafka08;
 
 import com.google.auto.value.AutoValue;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -177,11 +178,10 @@ public abstract class KafkaSender extends LazyCloseable<KafkaProducer<byte[], by
     return new KafkaProducer<>(properties());
   }
 
-  @Override public void close() {
+  @Override public void close() throws IOException {
     if (closeCalled) return;
     closeCalled = true;
-    KafkaProducer<byte[], byte[]> maybeNull = maybeNull();
-    if (maybeNull != null) maybeNull.close();
+    super.close();
   }
 
   KafkaSender() {

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
@@ -119,8 +119,7 @@ public abstract class LibthriftSender extends LazyCloseable<ScribeClient> implem
   @Override public void close() throws IOException {
     if (closeCalled) return;
     closeCalled = true;
-    ScribeClient maybeNull = maybeNull();
-    if (maybeNull != null) maybeNull.close();
+    super.close();
   }
 
   LibthriftSender() {


### PR DESCRIPTION
`LazyCloseable.close()` is not final as there's no requirement that its
delegate implements Closeable (ex it could just have a `shutdown()`
method). Due to copy/pasta, we redundantly did the same thing in a
couple subtypes.

Thanks to @autoletics for pointing out this possibility.