### PR TITLE
Support to customize User-Agent header for HTTP request

### DIFF
--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -59,6 +59,7 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
         .encoding(Encoding.THRIFT)
         .compressionEnabled(true)
         .maxRequests(64)
+        .userAgent("zipkin-okhttp3-sender/x.x.x")
         .messageMaxBytes(5 * 1024 * 1024);
   }
 
@@ -106,6 +107,8 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
 
     abstract Builder encoder(RequestBodyMessageEncoder encoder);
 
+    abstract Builder userAgent(String userAgent);
+
     abstract OkHttpSender autoBuild();
 
     Builder() {
@@ -121,6 +124,8 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
   abstract int maxRequests();
 
   abstract boolean compressionEnabled();
+
+  abstract String userAgent();
 
   abstract RequestBodyMessageEncoder encoder();
 
@@ -146,7 +151,7 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
   /** Sends an empty json message to the configured endpoint. */
   @Override public CheckResult check() {
     try {
-      Request request = new Request.Builder().url(endpoint())
+      Request request = new Request.Builder().url(endpoint()).header("User-Agent", userAgent())
           .post(RequestBody.create(MediaType.parse("application/json"), "[]")).build();
       try (Response response = get().newCall(request).execute()) {
         if (!response.isSuccessful()) {
@@ -190,7 +195,7 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
   }
 
   Request newRequest(RequestBody body) throws IOException {
-    Request.Builder request = new Request.Builder().url(endpoint());
+    Request.Builder request = new Request.Builder().url(endpoint()).header("User-Agent", userAgent());
     if (compressionEnabled()) {
       request.addHeader("Content-Encoding", "gzip");
       Buffer gzipped = new Buffer();

--- a/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
@@ -134,6 +134,31 @@ public class OkHttpSenderTest {
     }
   }
 
+  @Test
+  public void customizedUserAgent() throws Exception {
+    zipkinRule.shutdown(); // shutdown the normal zipkin rule
+    MockWebServer server = new MockWebServer();
+    try {
+      final String userAgent = "zipkin-okhttp3-sender/0.0.0";
+      sender = sender.toBuilder()
+                     .endpoint(server.url("/api/v1/spans").toString())
+                     .encoding(Encoding.JSON)
+                     .userAgent(userAgent)
+                     .build();
+
+      server.enqueue(new MockResponse());
+
+      send(TestObjects.TRACE);
+
+      // block until the request arrived
+      assertThat(server.takeRequest().getHeader("User-Agent"))
+              .isEqualTo(userAgent);
+    } finally {
+      server.shutdown();
+    }
+  }
+
+
   @Test public void closeWhileRequestInFlight_cancelsRequest() throws Exception {
     zipkinRule.shutdown(); // shutdown the normal zipkin rule
     sender.close();

--- a/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
@@ -47,6 +47,7 @@ public abstract class URLConnectionSender implements Sender {
         .connectTimeout(10 * 1000)
         .readTimeout(60 * 1000)
         .compressionEnabled(true)
+        .userAgent("zipkin-urlconnection-sender/x.x.x")
         .messageMaxBytes(5 * 1024 * 1024);
   }
 
@@ -98,10 +99,13 @@ public abstract class URLConnectionSender implements Sender {
 
     abstract Builder mediaType(String mediaType);
 
+    abstract Builder userAgent(String userAgent);
+
     abstract URLConnectionSender autoBuild();
 
     Builder() {
     }
+
   }
 
   public Builder toBuilder() {
@@ -119,6 +123,8 @@ public abstract class URLConnectionSender implements Sender {
   abstract boolean compressionEnabled();
 
   abstract String mediaType();
+
+  abstract String userAgent();
 
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
@@ -160,6 +166,7 @@ public abstract class URLConnectionSender implements Sender {
     connection.setConnectTimeout(connectTimeout());
     connection.setReadTimeout(readTimeout());
     connection.setRequestMethod("POST");
+    connection.addRequestProperty("User-Agent", userAgent());
     connection.addRequestProperty("Content-Type", mediaType);
     if (compressionEnabled()) {
       connection.addRequestProperty("Content-Encoding", "gzip");


### PR DESCRIPTION
In my case, a specical `User-Agent` would be nice to reverse proxy to process the HTTP request of POST spans.