### PR TITLE
Fixes queuing problem which delayed send of messages in OkHttp

### DIFF
--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.5.0</version>
+      <version>3.6.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Formerly, when using OkHttp, up to 64 messages would back up on the
queue before another parallel request would be made to clear them.

This interfered with the async sender design, where the primary buffer
was in the AsyncReporter, not the senders. The side effect is slower
clearing, and also more memory usage (up to 63 * 5MiB in worst case).

This changes to a SynchronousQueue which will more eagerly make network
requests. A similar change was made upstream in OkHttp.

See https://github.com/square/okhttp/pull/1353