### PR TITLE
Limit toString() output for Sender implementations

### DIFF
--- a/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
@@ -182,6 +182,10 @@ public abstract class KafkaSender extends LazyCloseable<KafkaProducer<byte[], by
     super.close();
   }
 
+  @Override public final String toString() {
+    return "KafkaSender";
+  }
+
   KafkaSender() {
   }
 }

--- a/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin/reporter/kafka08/KafkaSender.java
@@ -183,7 +183,7 @@ public abstract class KafkaSender extends LazyCloseable<KafkaProducer<byte[], by
   }
 
   @Override public final String toString() {
-    return "KafkaSender";
+    return "KafkaSender(" + properties().getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) + ")";
   }
 
   KafkaSender() {

--- a/kafka08/src/test/java/zipkin/reporter/kafka08/KafkaSenderTest.java
+++ b/kafka08/src/test/java/zipkin/reporter/kafka08/KafkaSenderTest.java
@@ -40,7 +40,8 @@ public class KafkaSenderTest {
   @Rule public KafkaJunitRule kafka = new KafkaJunitRule();
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  KafkaSender sender = KafkaSender.create("localhost:" + kafka.kafkaBrokerPort());
+  String bootstrapServers = "localhost:" + kafka.kafkaBrokerPort();
+  KafkaSender sender = KafkaSender.create(bootstrapServers);
 
   @After
   public void close() throws IOException {
@@ -103,8 +104,8 @@ public class KafkaSenderTest {
    * output is a reasonable length and does not contain sensitive information.
    */
   @Test
-  public void toStringContainsOnlySenderType() throws Exception {
-    assertThat(sender.toString()).isEqualTo("KafkaSender");
+  public void toStringContainsOnlySenderTypeAndBootstrapBrokers() throws Exception {
+    assertThat(sender.toString()).isEqualTo("KafkaSender(" + bootstrapServers + ")");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/kafka08/src/test/java/zipkin/reporter/kafka08/KafkaSenderTest.java
+++ b/kafka08/src/test/java/zipkin/reporter/kafka08/KafkaSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -94,6 +94,17 @@ public class KafkaSenderTest {
     sender.close();
 
     send(TestObjects.TRACE);
+  }
+
+  /**
+   * The output of toString() on {@link zipkin.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderType() throws Exception {
+    assertThat(sender.toString()).isEqualTo("KafkaSender");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/kafka10/src/main/java/zipkin/reporter/kafka10/KafkaSender.java
+++ b/kafka10/src/main/java/zipkin/reporter/kafka10/KafkaSender.java
@@ -182,6 +182,10 @@ public abstract class KafkaSender extends LazyCloseable<KafkaProducer<byte[], by
     super.close();
   }
 
+  @Override public final String toString() {
+    return "KafkaSender";
+  }
+
   KafkaSender() {
   }
 }

--- a/kafka10/src/main/java/zipkin/reporter/kafka10/KafkaSender.java
+++ b/kafka10/src/main/java/zipkin/reporter/kafka10/KafkaSender.java
@@ -183,7 +183,7 @@ public abstract class KafkaSender extends LazyCloseable<KafkaProducer<byte[], by
   }
 
   @Override public final String toString() {
-    return "KafkaSender";
+    return "KafkaSender(" + properties().getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) + ")";
   }
 
   KafkaSender() {

--- a/kafka10/src/test/java/zipkin/reporter/kafka10/KafkaSenderTest.java
+++ b/kafka10/src/test/java/zipkin/reporter/kafka10/KafkaSenderTest.java
@@ -101,6 +101,17 @@ public class KafkaSenderTest {
     send(TestObjects.TRACE);
   }
 
+  /**
+   * The output of toString() on {@link zipkin.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderType() throws Exception {
+    assertThat(sender.toString()).isEqualTo("KafkaSender");
+  }
+
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
   void send(List<Span> spans) {
     AwaitableCallback callback = new AwaitableCallback();

--- a/kafka10/src/test/java/zipkin/reporter/kafka10/KafkaSenderTest.java
+++ b/kafka10/src/test/java/zipkin/reporter/kafka10/KafkaSenderTest.java
@@ -108,8 +108,8 @@ public class KafkaSenderTest {
    * output is a reasonable length and does not contain sensitive information.
    */
   @Test
-  public void toStringContainsOnlySenderType() throws Exception {
-    assertThat(sender.toString()).isEqualTo("KafkaSender");
+  public void toStringContainsOnlySenderTypeAndBootstrapBrokers() throws Exception {
+    assertThat(sender.toString()).isEqualTo("KafkaSender(" + broker.getBrokerList().get() + ")");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
@@ -120,6 +120,10 @@ public abstract class LibthriftSender extends LazyCloseable<ScribeClient> implem
     super.close();
   }
 
+  @Override public final String toString() {
+    return "LibthriftSender";
+  }
+
   LibthriftSender() {
   }
 }

--- a/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin/reporter/libthrift/LibthriftSender.java
@@ -121,7 +121,7 @@ public abstract class LibthriftSender extends LazyCloseable<ScribeClient> implem
   }
 
   @Override public final String toString() {
-    return "LibthriftSender";
+    return "LibthriftSender(" + host() + ":" + port() + ")";
   }
 
   LibthriftSender() {

--- a/libthrift/src/test/java/zipkin/reporter/libthrift/LibthriftSenderTest.java
+++ b/libthrift/src/test/java/zipkin/reporter/libthrift/LibthriftSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -97,6 +97,17 @@ public class LibthriftSenderTest {
     sender.close();
 
     send(TestObjects.TRACE);
+  }
+
+  /**
+   * The output of toString() on {@link zipkin.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderType() throws Exception {
+    assertThat(sender.toString()).isEqualTo("LibthriftSender");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/libthrift/src/test/java/zipkin/reporter/libthrift/LibthriftSenderTest.java
+++ b/libthrift/src/test/java/zipkin/reporter/libthrift/LibthriftSenderTest.java
@@ -106,8 +106,9 @@ public class LibthriftSenderTest {
    * output is a reasonable length and does not contain sensitive information.
    */
   @Test
-  public void toStringContainsOnlySenderType() throws Exception {
-    assertThat(sender.toString()).isEqualTo("LibthriftSender");
+  public void toStringContainsOnlySenderTypeHostAndPort() throws Exception {
+    assertThat(sender.toString())
+        .isEqualTo("LibthriftSender(" + sender.host() + ":" + sender.port() + ")");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/local/src/main/java/zipkin/reporter/local/LocalSender.java
+++ b/local/src/main/java/zipkin/reporter/local/LocalSender.java
@@ -98,7 +98,7 @@ public abstract class LocalSender implements Sender {
   }
 
   @Override public final String toString() {
-    return "LocalSender";
+    return "LocalSender(" + storage().getClass().getSimpleName() + ")";
   }
 
   LocalSender() {

--- a/local/src/main/java/zipkin/reporter/local/LocalSender.java
+++ b/local/src/main/java/zipkin/reporter/local/LocalSender.java
@@ -97,6 +97,10 @@ public abstract class LocalSender implements Sender {
     // not closing the storage component as we didn't create it
   }
 
+  @Override public final String toString() {
+    return "LocalSender";
+  }
+
   LocalSender() {
   }
 

--- a/local/src/test/java/zipkin/reporter/local/LocalSenderTest.java
+++ b/local/src/test/java/zipkin/reporter/local/LocalSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,6 +53,17 @@ public class LocalSenderTest {
     sender.close();
 
     send(TestObjects.TRACE);
+  }
+
+  /**
+   * The output of toString() on {@link zipkin.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderType() throws Exception {
+    assertThat(sender.toString()).isEqualTo("LocalSender");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/local/src/test/java/zipkin/reporter/local/LocalSenderTest.java
+++ b/local/src/test/java/zipkin/reporter/local/LocalSenderTest.java
@@ -62,8 +62,9 @@ public class LocalSenderTest {
    * output is a reasonable length and does not contain sensitive information.
    */
   @Test
-  public void toStringContainsOnlySenderType() throws Exception {
-    assertThat(sender.toString()).isEqualTo("LocalSender");
+  public void toStringContainsOnlySenderTypeAndStorageType() throws Exception {
+    assertThat(sender.toString())
+        .isEqualTo("LocalSender(" + storage.getClass().getSimpleName() + ")");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -207,7 +207,7 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
   }
 
   @Override public final String toString() {
-    return "OkHttpSender";
+    return "OkHttpSender(" + endpoint() + ")";
   }
 
   OkHttpSender() {

--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -206,6 +206,10 @@ public abstract class OkHttpSender extends LazyCloseable<OkHttpClient> implement
     return request.build();
   }
 
+  @Override public final String toString() {
+    return "OkHttpSender";
+  }
+
   OkHttpSender() {
   }
 

--- a/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
@@ -46,7 +46,8 @@ public class OkHttpSenderTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  OkHttpSender sender = OkHttpSender.create(zipkinRule.httpUrl() + "/api/v1/spans");
+  String endpoint = zipkinRule.httpUrl() + "/api/v1/spans";
+  OkHttpSender sender = OkHttpSender.create(endpoint);
 
   @Test
   public void badUrlIsAnIllegalArgument() throws Exception {
@@ -300,8 +301,8 @@ public class OkHttpSenderTest {
    * output is a reasonable length and does not contain sensitive information.
    */
   @Test
-  public void toStringContainsOnlySenderType() throws Exception {
-    assertThat(sender.toString()).isEqualTo("OkHttpSender");
+  public void toStringContainsOnlySenderTypeAndEndpoint() throws Exception {
+    assertThat(sender.toString()).isEqualTo("OkHttpSender(" + endpoint + ")");
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */

--- a/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
@@ -293,6 +293,17 @@ public class OkHttpSenderTest {
     send(TestObjects.TRACE);
   }
 
+  /**
+   * The output of toString() on {@link zipkin.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderType() throws Exception {
+    assertThat(sender.toString()).isEqualTo("OkHttpSender");
+  }
+
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
   void send(List<Span> spans) {
     AwaitableCallback callback = new AwaitableCallback();

--- a/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
@@ -183,6 +183,10 @@ public abstract class URLConnectionSender implements Sender {
     }
   }
 
+  @Override public final String toString() {
+    return "URLConnectionSender";
+  }
+
   URLConnectionSender() {
   }
 }

--- a/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin/reporter/urlconnection/URLConnectionSender.java
@@ -184,7 +184,7 @@ public abstract class URLConnectionSender implements Sender {
   }
 
   @Override public final String toString() {
-    return "URLConnectionSender";
+    return "URLConnectionSender(" + endpoint() + ")";
   }
 
   URLConnectionSender() {

--- a/urlconnection/src/test/java/zipkin/reporter/urlconnection/URLConnectionSenderTest.java
+++ b/urlconnection/src/test/java/zipkin/reporter/urlconnection/URLConnectionSenderTest.java
@@ -59,10 +59,12 @@ public class URLConnectionSenderTest {
 
   private URLConnectionSender sender;
 
+  private String endpoint = zipkinRule.httpUrl() + "/api/v1/spans";
+
   @Before
   public void setUp() throws Exception {
     sender = URLConnectionSender.builder()
-            .endpoint(zipkinRule.httpUrl() + "/api/v1/spans")
+            .endpoint(endpoint)
             .encoding(encoding)
             .build();
     encoder = encoderFor(encoding);
@@ -206,8 +208,8 @@ public class URLConnectionSenderTest {
    * output is a reasonable length and does not contain sensitive information.
    */
   @Test
-  public void toStringContainsOnlySenderType() throws Exception {
-    assertThat(sender.toString()).isEqualTo("URLConnectionSender");
+  public void toStringContainsOnlySenderTypeAndEndpoint() throws Exception {
+    assertThat(sender.toString()).isEqualTo("URLConnectionSender(" + endpoint + ")");
   }
 
   void thenCallbackCatchesTheThrowable() {

--- a/urlconnection/src/test/java/zipkin/reporter/urlconnection/URLConnectionSenderTest.java
+++ b/urlconnection/src/test/java/zipkin/reporter/urlconnection/URLConnectionSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -197,6 +197,17 @@ public class URLConnectionSenderTest {
     assertThat(zipkinRule.httpRequestCount()).isEqualTo(1);
     assertThat(zipkinRule.collectorMetrics().messages()).isEqualTo(1);
     assertThat(zipkinRule.collectorMetrics().spans()).isEqualTo(3);
+  }
+
+  /**
+   * The output of toString() on {@link zipkin.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderType() throws Exception {
+    assertThat(sender.toString()).isEqualTo("URLConnectionSender");
   }
 
   void thenCallbackCatchesTheThrowable() {


### PR DESCRIPTION
Changed implementations of zipkin.reporter.Sender to provide an explicit toString() implementation that only includes the classname of the sender. Previously, toString() was generated by AutoValue and included all fields.

The output of toString() on zipkin.reporter.Sender implementations appears in thread names created by zipkin.reporter.AsyncReporter. Since thread names are likely to be exposed in logs and other monitoring tools, these changes are meant to ensure the toString() output is a reasonable length for display in those contexts and does not contain sensitive information. One example of potentially sensitive information being include is the Kafka producer configuration properties previously output for KafkaSender. These properties can contain values such as keystore passwords.

The feedback on #42 was the "tighten up" the toString output. Are these changes too aggressive in limiting the output of toString? Leaving out all of the fields on Senders could make it hard to differentiate between AsyncReporter flush threads, if there are multiple running with different Senders of the same type, but that seems like an unlikely scenario. I can't think of a reason to have, e.g., two instances of KafkaSender running in the same service or application.

Fixes #42