### PR TITLE
Adds bug prevention test case for OkHttpClient configuration

### DIFF
--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -16,7 +16,6 @@ package zipkin.reporter.okhttp3;
 import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;

--- a/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin/reporter/okhttp3/OkHttpSenderTest.java
@@ -305,6 +305,13 @@ public class OkHttpSenderTest {
     assertThat(sender.toString()).isEqualTo("OkHttpSender(" + endpoint + ")");
   }
 
+  @Test public void bugGuardCache() throws Exception {
+    sender = sender.toBuilder().encoding(Encoding.JSON).build();
+    assertThat(sender.compute().cache())
+        .withFailMessage("senders should not open a disk cache")
+        .isNull();
+  }
+
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
   void send(List<Span> spans) {
     AwaitableCallback callback = new AwaitableCallback();


### PR DESCRIPTION
If we open a disk cache, we should close it. However, there's no use
case for a disk cache on POST. This ensures no-one accidentally opens
one.