### PR TITLE
Adds AsyncReporter.create(Sender)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ AsyncReporter is how you actually get spans to zipkin. By default, it waits up t
 before flushes any pending spans out of process via a Sender.
 
 ```java
-reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
-                        .build();
+reporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v1/spans"));
 
 // Schedules the span to be sent, and won't block the calling thread on I/O
 reporter.report(span);

--- a/core/src/main/java/zipkin/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin/reporter/AsyncReporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 The OpenZipkin Authors
+ * Copyright 2016-2017 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -42,6 +42,11 @@ public abstract class AsyncReporter<S> implements Reporter<S>, Flushable, Compon
    * After a certain threshold, spans are drained and {@link Sender#sendSpans(List, Callback) sent}
    * to Zipkin collectors.
    */
+  public static AsyncReporter<zipkin.Span> create(Sender sender) {
+    return new Builder(sender).build();
+  }
+
+  /** Like {@link #create(Sender)}, except you can configure settings such as the timeout. */
   public static Builder builder(Sender sender) {
     return new Builder(sender);
   }


### PR DESCRIPTION
A lot of code and examples say `AsyncReporter.builder(sender).build()`.
Conventionally, `AsyncReporter.create(Sender)` would be simpler. This
also works in old spring XML files.