### PR TITLE
Sends whatever we have on AsyncReporter.close

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Property | Description
 `queuedMaxBytes` |  Maximum backlog of span bytes reported vs sent. Corresponds to `ReporterMetrics.updateQueuedBytes`. Default 1% of heap
 `messageMaxBytes` | Maximum bytes sendable per message including overhead. Default `Sender.messageMaxBytes`
 `messageTimeout` |  Maximum time to wait for messageMaxBytes to accumulate before sending. Default 1 second
+`closeTimeout` |  Maximum time to block for in-flight spans to send on close. Default 1 second
 
 #### Dealing with span backlog
 When `messageTimeout` is non-zero, a single thread is responsible for

--- a/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin/reporter/okhttp3/OkHttpSender.java
@@ -16,7 +16,6 @@ package zipkin.reporter.okhttp3;
 import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Before, we tried to fill up a message before returning from close. This
could end up blocking up to messageTimeout, especially if there aren't
many spans coming in.

Now, we send whatever we have. This also reduces the blocking time on
close to bounded at 1second vs whatever messageTimeout was. This is
because the latency is now related to how long it takes for a sender to
complete: we have no way of knowing this, so arbitrarily choose 1
second.

See #29