### PR TITLE
Allows kafka overrides via properties

### DIFF
--- a/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
+++ b/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
@@ -105,7 +105,7 @@ public abstract class KafkaSender extends Sender {
      *
      * @see ProducerConfig
      */
-    public final Builder overrides(Map<String, String> overrides) {
+    public final Builder overrides(Map<String, ?> overrides) {
       if (overrides == null) throw new NullPointerException("overrides == null");
       properties().putAll(overrides);
       return this;


### PR DESCRIPTION
Before, you couldn't override with a Properties object, which is commonly used in Kafka