### PR TITLE
Adds spring beans XML config for legacy applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ reporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:941
 reporter.report(span);
 ```
 
+## Spring Beans
+If you are trying to trace legacy applications, you may be interested in
+[Spring XML Configuration](spring-beans/). This allows you to trace legacy
+Spring 2.5+ applications without any custom code.
+
 ### Tuning
 
 By default AsyncReporter starts a thread to flush the queue of reported

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <module>amqp-client</module>
     <module>urlconnection</module>
     <module>okhttp3</module>
+    <module>spring-beans</module>
     <module>benchmarks</module>
   </modules>
 
@@ -127,6 +128,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-sender-amqp-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter-spring-beans</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -1,0 +1,40 @@
+# zipkin-reporter-spring-beans
+This module contains Spring Factory Beans that allow you to configure
+tracing with only XML. Notably, this requires minimally Spring version 2.5.
+
+## Configuration
+Bean Factories exist for the following types:
+* AsyncReporterFactoryBean - for configuring how often spans are sent to Zipkin
+* OkHttpSenderFactoryBean - for [zipkin-sender-okhttp3](../okhttp3)
+* KafkaSenderFactoryBean - for [zipkin-sender-kafka11](../kafka11)
+* RabbitMQSenderFactoryBean - for [zipkin-sender-amqp-client](../amqp-client)
+* URLConnectionSenderFactoryBean - for [zipkin-sender-urlconnection](../urlconnection)
+
+Here's a basic example
+```xml
+  <bean id="spanReporter" class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
+    <property name="encoder" value="JSON_V2"/>
+    <property name="sender">
+      <bean class="zipkin2.reporter.beans.OkHttpSenderFactoryBean">
+        <property name="endpoint" value="http://localhost:9411/api/v2/spans"/>
+      </bean>
+    </property>
+    <!-- wait up to half a second for any in-flight spans on close -->
+    <property name="closeTimeout" value="500"/>
+  </bean>
+```
+
+Here's an example with Kafka configuration:
+```xml
+  <bean id="sender" class="zipkin2.reporter.beans.KafkaSenderFactoryBean">
+    <property name="bootstrapServers" value="your_host"/>
+    <property name="topic" value="test_zipkin"/>
+  </bean>
+
+  <bean id="spanReporter" class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
+    <property name="encoder" value="JSON_V2"/>
+    <property name="sender" ref="sender"/>
+    <!-- wait up to half a second for any in-flight spans on close -->
+    <property name="closeTimeout" value="500"/>
+  </bean>
+```

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2016-2017 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <version>2.1.5-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>zipkin-reporter-spring-beans</artifactId>
+  <name>Zipkin Reporter Spring Factory Beans</name>
+  <description>Allows you to configure Zipkin Reporter using XML</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <main.java.version>1.6</main.java.version>
+    <main.signature.artifact>java16</main.signature.artifact>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-urlconnection</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-kafka11</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-amqp-client</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>2.5.6</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ReporterMetrics;
+import zipkin2.reporter.Sender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class AsyncReporterFactoryBean extends AbstractFactoryBean {
+  Sender sender;
+  SpanBytesEncoder encoder = SpanBytesEncoder.JSON_V1;
+  ReporterMetrics metrics;
+  Integer messageMaxBytes;
+  Integer messageTimeout;
+  Integer closeTimeout;
+  Integer queuedMaxSpans;
+  Integer queuedMaxBytes;
+
+  @Override public Class<? extends AsyncReporter> getObjectType() {
+    return AsyncReporter.class;
+  }
+
+  @Override protected AsyncReporter createInstance() throws Exception {
+    AsyncReporter.Builder builder = AsyncReporter.builder(sender);
+    if (metrics != null) builder.metrics(metrics);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    if (messageTimeout != null) builder.messageTimeout(messageTimeout, TimeUnit.MILLISECONDS);
+    if (closeTimeout != null) builder.closeTimeout(closeTimeout, TimeUnit.MILLISECONDS);
+    if (queuedMaxSpans != null) builder.queuedMaxSpans(queuedMaxSpans);
+    if (queuedMaxBytes != null) builder.queuedMaxBytes(queuedMaxBytes);
+    return builder.build(encoder);
+  }
+
+  @Override protected void destroyInstance(Object instance) throws Exception {
+    ((AsyncReporter) instance).close();
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setSender(Sender sender) {
+    this.sender = sender;
+  }
+
+  public void setEncoder(SpanBytesEncoder encoder) {
+    this.encoder = encoder;
+  }
+
+  public void setMetrics(ReporterMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+
+  public void setMessageTimeout(Integer messageTimeout) {
+    this.messageTimeout = messageTimeout;
+  }
+
+  public void setCloseTimeout(Integer closeTimeout) {
+    this.closeTimeout = closeTimeout;
+  }
+
+  public void setQueuedMaxSpans(Integer queuedMaxSpans) {
+    this.queuedMaxSpans = queuedMaxSpans;
+  }
+
+  public void setQueuedMaxBytes(Integer queuedMaxBytes) {
+    this.queuedMaxBytes = queuedMaxBytes;
+  }
+}

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/KafkaSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/KafkaSenderFactoryBean.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.kafka11.KafkaSender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class KafkaSenderFactoryBean extends AbstractFactoryBean {
+
+  String bootstrapServers, topic;
+  Integer messageMaxBytes;
+
+  @Override protected KafkaSender createInstance() throws Exception {
+    KafkaSender.Builder builder = KafkaSender.newBuilder();
+    if (bootstrapServers != null) builder.bootstrapServers(bootstrapServers);
+    if (topic != null) builder.topic(topic);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    return builder.build();
+  }
+
+  @Override public Class<? extends KafkaSender> getObjectType() {
+    return KafkaSender.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  @Override protected void destroyInstance(Object instance) throws Exception {
+    ((KafkaSender) instance).close();
+  }
+
+  public void setBootstrapServers(String bootstrapServers) {
+    this.bootstrapServers = bootstrapServers;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+}

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
+
+  String endpoint;
+  Integer maxRequests;
+  Boolean compressionEnabled;
+  Integer messageMaxBytes;
+
+  @Override protected OkHttpSender createInstance() throws Exception {
+    OkHttpSender.Builder builder = OkHttpSender.newBuilder();
+    if (endpoint != null) builder.endpoint(endpoint);
+    if (maxRequests != null) builder.maxRequests(maxRequests);
+    if (compressionEnabled != null) builder.compressionEnabled(compressionEnabled);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    return builder.build();
+  }
+
+  @Override public Class<? extends OkHttpSender> getObjectType() {
+    return OkHttpSender.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  @Override protected void destroyInstance(Object instance) throws Exception {
+    ((OkHttpSender) instance).close();
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public void setMaxRequests(Integer maxRequests) {
+    this.maxRequests = maxRequests;
+  }
+
+  public void setCompressionEnabled(Boolean compressionEnabled) {
+    this.compressionEnabled = compressionEnabled;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+}

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBean.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.amqp.RabbitMQSender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class RabbitMQSenderFactoryBean extends AbstractFactoryBean {
+
+  String addresses, queue;
+  Integer connectionTimeout;
+  String virtualHost;
+  String username, password;
+  Integer messageMaxBytes;
+
+  @Override protected RabbitMQSender createInstance() throws Exception {
+    RabbitMQSender.Builder builder = RabbitMQSender.newBuilder();
+    if (addresses != null) builder.addresses(addresses);
+    if (queue != null) builder.queue(queue);
+    if (connectionTimeout != null) builder.connectionTimeout(connectionTimeout);
+    if (virtualHost != null) builder.virtualHost(virtualHost);
+    if (username != null) builder.username(username);
+    if (password != null) builder.password(password);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    return builder.build();
+  }
+
+  @Override public Class<? extends RabbitMQSender> getObjectType() {
+    return RabbitMQSender.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  @Override protected void destroyInstance(Object instance) throws Exception {
+    ((RabbitMQSender) instance).close();
+  }
+
+  public void setAddresses(String addresses) {
+    this.addresses = addresses;
+  }
+
+  public void setQueue(String queue) {
+    this.queue = queue;
+  }
+
+  public void setConnectionTimeout(Integer connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
+  public void setVirtualHost(String virtualHost) {
+    this.virtualHost = virtualHost;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+}

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
+
+  String endpoint;
+  Integer connectTimeout, readTimeout;
+  Boolean compressionEnabled;
+  Integer messageMaxBytes;
+
+  @Override protected URLConnectionSender createInstance() throws Exception {
+    URLConnectionSender.Builder builder = URLConnectionSender.newBuilder();
+    if (endpoint != null) builder.endpoint(endpoint);
+    if (connectTimeout != null) builder.connectTimeout(connectTimeout);
+    if (readTimeout != null) builder.readTimeout(readTimeout);
+    if (compressionEnabled != null) builder.compressionEnabled(compressionEnabled);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    return builder.build();
+  }
+
+  @Override public Class<? extends URLConnectionSender> getObjectType() {
+    return URLConnectionSender.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  @Override protected void destroyInstance(Object instance) throws Exception {
+    ((URLConnectionSender) instance).close();
+  }
+
+  public void setEndpoint(String endpoint) {
+    this.endpoint = endpoint;
+  }
+
+  public void setConnectTimeout(Integer connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
+
+  public void setReadTimeout(Integer readTimeout) {
+    this.readTimeout = readTimeout;
+  }
+
+  public void setCompressionEnabled(Boolean compressionEnabled) {
+    this.compressionEnabled = compressionEnabled;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncReporterFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncReporterFactoryBeanTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ReporterMetrics;
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsyncReporterFactoryBeanTest {
+
+  public static Sender SENDER = URLConnectionSender.create("http://localhost:9411/api/v2/spans");
+  public static ReporterMetrics METRICS = ReporterMetrics.NOOP_METRICS;
+
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void sender() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("sender")
+        .containsExactly(SENDER);
+  }
+
+  @Test public void metrics() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"metrics\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".METRICS\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("metrics")
+        .containsExactly(METRICS);
+  }
+
+  @Test public void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"512\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(512);
+  }
+
+  @Test public void messageTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"messageTimeout\" value=\"500\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("messageTimeoutNanos")
+        .containsExactly(TimeUnit.MILLISECONDS.toNanos(500));
+  }
+
+  @Test public void closeTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"closeTimeout\" value=\"500\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("closeTimeoutNanos")
+        .containsExactly(TimeUnit.MILLISECONDS.toNanos(500));
+  }
+
+  @Test public void queuedMaxSpans() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"queuedMaxSpans\" value=\"10\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("pending.maxSize")
+        .containsExactly(10);
+  }
+
+  @Test public void queuedMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"queuedMaxBytes\" value=\"512\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("pending.maxBytes")
+        .containsExactly(512);
+  }
+
+  @Test public void encoder() {
+    context = new XmlBeans(""
+        + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
+        + "  <property name=\"sender\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"encoder\" value=\"JSON_V2\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("asyncReporter", AsyncReporter.class))
+        .extracting("encoder")
+        .containsExactly(SpanBytesEncoder.JSON_V2);
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.amqp.RabbitMQSender;
+import zipkin2.reporter.kafka11.KafkaSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KafkaSenderFactoryBeanTest {
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void bootstrapServers() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
+        + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", KafkaSender.class))
+        .isEqualToComparingFieldByField(KafkaSender.newBuilder()
+            .bootstrapServers("localhost:9092")
+            .build());
+  }
+
+  @Test public void topic() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
+        + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
+        + "  <property name=\"topic\" value=\"zipkin2\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", KafkaSender.class))
+        .isEqualToComparingFieldByField(KafkaSender.newBuilder()
+            .bootstrapServers("localhost:9092")
+            .topic("zipkin2").build());
+  }
+
+  @Test public void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
+        + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"1024\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", KafkaSender.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(1024);
+  }
+
+  @Test(expected = IllegalStateException.class) public void close_closesSender() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
+        + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
+        + "</bean>"
+    );
+
+    KafkaSender sender = context.getBean("sender", KafkaSender.class);
+    context.close();
+
+    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.util.Arrays;
+import okhttp3.HttpUrl;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OkHttpSenderFactoryBeanTest {
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void endpoint() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", OkHttpSender.class))
+        .extracting("endpoint")
+        .containsExactly(HttpUrl.parse("http://localhost:9411/api/v2/spans"));
+  }
+
+  @Test public void maxRequests() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"maxRequests\" value=\"4\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", OkHttpSender.class))
+        .extracting("client.dispatcher.maxRequests")
+        .containsExactly(4);
+  }
+
+  @Test public void compressionEnabled() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"compressionEnabled\" value=\"false\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", OkHttpSender.class))
+        .extracting("compressionEnabled")
+        .containsExactly(false);
+  }
+
+  @Test public void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"1024\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", OkHttpSender.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(1024);
+  }
+
+  @Test(expected = IllegalStateException.class) public void close_closesSender() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "</bean>"
+    );
+
+    OkHttpSender sender = context.getBean("sender", OkHttpSender.class);
+    context.close();
+
+    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import com.rabbitmq.client.Address;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.amqp.RabbitMQSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RabbitMQSenderFactoryBeanTest {
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void addresses() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("addresses")
+        .containsExactly(Arrays.asList(new Address("localhost")));
+  }
+
+  @Test public void queue() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "  <property name=\"queue\" value=\"zipkin2\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("queue")
+        .containsExactly("zipkin2");
+  }
+
+  @Test public void connectionTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "  <property name=\"connectionTimeout\" value=\"0\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("connectionFactory.connectionTimeout")
+        .containsExactly(0);
+  }
+
+  @Test public void virtualHost() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "  <property name=\"virtualHost\" value=\"zipkin3\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("connectionFactory.virtualHost")
+        .containsExactly("zipkin3");
+  }
+
+  @Test public void usernamePassword() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "  <property name=\"username\" value=\"foo\"/>\n"
+        + "  <property name=\"password\" value=\"bar\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("connectionFactory.username", "connectionFactory.password")
+        .containsExactly("foo", "bar");
+  }
+
+  @Test public void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"1024\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(1024);
+  }
+
+  @Test(expected = IllegalStateException.class) public void close_closesSender() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "</bean>"
+    );
+
+    RabbitMQSender sender = context.getBean("sender", RabbitMQSender.class);
+    context.close();
+
+    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class URLConnectionSenderFactoryBeanTest {
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void endpoint() throws MalformedURLException {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", URLConnectionSender.class))
+        .extracting("endpoint")
+        .containsExactly(URI.create("http://localhost:9411/api/v2/spans").toURL());
+  }
+
+  @Test public void connectTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"connectTimeout\" value=\"0\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", URLConnectionSender.class))
+        .isEqualToComparingFieldByField(URLConnectionSender.newBuilder()
+            .endpoint("http://localhost:9411/api/v2/spans")
+            .connectTimeout(0)
+            .build());
+  }
+
+  @Test public void readTimeout() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"readTimeout\" value=\"0\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", URLConnectionSender.class))
+        .isEqualToComparingFieldByField(URLConnectionSender.newBuilder()
+            .endpoint("http://localhost:9411/api/v2/spans")
+            .readTimeout(0).build());
+  }
+
+  @Test public void compressionEnabled() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"compressionEnabled\" value=\"false\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", URLConnectionSender.class))
+        .extracting("compressionEnabled")
+        .containsExactly(false);
+  }
+
+  @Test public void messageMaxBytes() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"messageMaxBytes\" value=\"1024\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", URLConnectionSender.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(1024);
+  }
+
+  @Test(expected = IllegalStateException.class) public void close_closesSender() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "</bean>"
+    );
+
+    URLConnectionSender sender = context.getBean("sender", URLConnectionSender.class);
+    context.close();
+
+    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/XmlBeans.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/XmlBeans.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2016-2017 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.nio.charset.Charset;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.core.io.ByteArrayResource;
+
+class XmlBeans {
+  static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+  XmlBeans(String... beans) {
+    StringBuilder joined = new StringBuilder();
+    for (String bean : beans) {
+      joined.append(bean).append('\n');
+    }
+    new XmlBeanDefinitionReader(beanFactory).loadBeanDefinitions(
+        new ByteArrayResource(beans(joined.toString()).getBytes(UTF_8))
+    );
+  }
+
+  static String beans(String bean) {
+    return "<beans xmlns=\"http://www.springframework.org/schema/beans\"\n"
+        + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+        + "    xmlns:util=\"http://www.springframework.org/schema/util\"\n"
+        + "    xsi:schemaLocation=\"\n"
+        + "        http://www.springframework.org/schema/beans\n"
+        + "        http://www.springframework.org/schema/beans/spring-beans-2.5.xsd\n"
+        + "        http://www.springframework.org/schema/util\n"
+        + "        http://www.springframework.org/schema/util/spring-util-2.5.xsd\">\n"
+        + bean
+        + "</beans>";
+  }
+
+  <T> T getBean(String name, Class<T> requiredType) {
+    return (T) beanFactory.getBean(name, requiredType);
+  }
+
+  void close(){
+    beanFactory.destroySingletons();
+  }
+}

--- a/spring-beans/src/test/resources/log4j2.properties
+++ b/spring-beans/src/test/resources/log4j2.properties
@@ -1,0 +1,8 @@
+appenders=console
+appender.console.type=Console
+appender.console.name=STDOUT
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{ABSOLUTE} %-5p [%t] %C{2} (%F:%L) - %m%n
+rootLogger.level=info
+rootLogger.appenderRefs=stdout
+rootLogger.appenderRef.stdout.ref=STDOUT


### PR DESCRIPTION
This adds the ability to configure all properties for senders,
notably Kafka topic.

Fixes https://github.com/openzipkin/brave-webmvc-example/issues/19