### PR TITLE
Reduces overhead by deferring codec to async thread

### DIFF
--- a/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
+++ b/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
@@ -158,6 +158,10 @@ public abstract class RabbitMQSender extends Sender {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding().listSizeInBytes(encodedSizeInBytes);
+  }
+
   /** This sends all of the spans as a single message. */
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new IllegalStateException("closed");

--- a/benchmarks/src/main/java/zipkin2/reporter/NoopSender.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/NoopSender.java
@@ -43,6 +43,10 @@ final class NoopSender extends Sender {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding().listSizeInBytes(encodedSizeInBytes);
+  }
+
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     messageEncoder.encode(encodedSpans);
     return Call.create(null);

--- a/core/src/main/java/zipkin2/reporter/BufferNextMessage.java
+++ b/core/src/main/java/zipkin2/reporter/BufferNextMessage.java
@@ -14,18 +14,27 @@
 package zipkin2.reporter;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Iterator;
+import zipkin2.codec.Encoding;
 
-final class BufferNextMessage implements ByteBoundedQueue.Consumer {
-  private final Sender sender;
-  private final int maxBytes;
-  private final long timeoutNanos;
-  private final List<byte[]> buffer = new LinkedList<>();
+/** Use of this type happens off the application's main thread. This type is not thread-safe */
+abstract class BufferNextMessage<S> implements SpanWithSizeConsumer<S> {
+
+  static <S> BufferNextMessage<S> create(Sender sender, int maxBytes, long timeoutNanos) {
+    if (sender.encoding() != Encoding.JSON) { // TODO update this once we support protobuf
+      throw new UnsupportedOperationException("sender.encoding() != Encoding.JSON");
+    }
+    return new BufferNextJsonMessage<>(sender, maxBytes, timeoutNanos);
+  }
+
+  final Sender sender;
+  final int maxBytes;
+  final long timeoutNanos;
+  final ArrayList<S> spans = new ArrayList<>();
+  final ArrayList<Integer> sizes = new ArrayList<>();
 
   long deadlineNanoTime;
-  int sizeInBytes;
+  int messageSizeInBytes;
   boolean bufferFull;
 
   BufferNextMessage(Sender sender, int maxBytes, long timeoutNanos) {
@@ -34,29 +43,67 @@ final class BufferNextMessage implements ByteBoundedQueue.Consumer {
     this.timeoutNanos = timeoutNanos;
   }
 
-  @Override
-  public boolean accept(byte[] next) {
-    buffer.add(next); // speculatively add to the buffer so we can size it
-    int x = sender.messageSizeInBytes(buffer);
-    int y = maxBytes;
-    int includingNextVsMaxBytes = (x < y) ? -1 : ((x == y) ? 0 : 1);
+  abstract int messageSizeInBytes(int nextSizeInBytes);
 
-    // If we can fit queued spans and the next into one message...
-    if (includingNextVsMaxBytes <= 0) {
-      sizeInBytes = x;
+  abstract void resetMessageSizeInBytes();
 
-      if (includingNextVsMaxBytes == 0) {
-        bufferFull = true;
+  static final class BufferNextJsonMessage<S> extends BufferNextMessage<S> {
+    boolean hasAtLeastOneSpan;
+
+    BufferNextJsonMessage(Sender sender, int maxBytes, long timeoutNanos) {
+      super(sender, maxBytes, timeoutNanos);
+      messageSizeInBytes = 2;
+      hasAtLeastOneSpan = false;
+    }
+
+    @Override int messageSizeInBytes(int nextSizeInBytes) {
+      return messageSizeInBytes + nextSizeInBytes + (hasAtLeastOneSpan ? 1 : 0);
+    }
+
+    @Override void resetMessageSizeInBytes() {
+      int length = sizes.size();
+      messageSizeInBytes = 2 + length - 1; // [] and commas
+      hasAtLeastOneSpan = length > 2;
+
+      for (int i = 0; i < length; i++) {
+        messageSizeInBytes += sizes.get(i);
       }
-      return true;
-    } else {
-      buffer.remove(buffer.size() - 1);
-      return false; // we couldn't fit the next message into this buffer
+    }
+
+    @Override void addSpanToBuffer(S next, int nextSizeInBytes) {
+      super.addSpanToBuffer(next, nextSizeInBytes);
+      hasAtLeastOneSpan = true;
+    }
+
+    @Override void drain(SpanWithSizeConsumer<S> consumer) {
+      super.drain(consumer);
+      messageSizeInBytes = 2;
+      hasAtLeastOneSpan = false;
     }
   }
 
+  /** This is done inside a lock that holds up writers, so has to be fast. No encoding! */
+  @Override public boolean offer(S next, int nextSizeInBytes) {
+    int x = messageSizeInBytes(nextSizeInBytes);
+    int y = maxBytes;
+    int includingNextVsMaxBytes = (x < y) ? -1 : ((x == y) ? 0 : 1); // Integer.compare, but JRE 6
+
+    if (includingNextVsMaxBytes > 0) return false; // can't fit the next message into this buffer
+
+    addSpanToBuffer(next, nextSizeInBytes);
+    messageSizeInBytes = x;
+
+    if (includingNextVsMaxBytes == 0) bufferFull = true;
+    return true;
+  }
+
+  void addSpanToBuffer(S next, int nextSizeInBytes) {
+    spans.add(next);
+    sizes.add(nextSizeInBytes);
+  }
+
   long remainingNanos() {
-    if (buffer.isEmpty()) {
+    if (spans.isEmpty()) {
       deadlineNanoTime = System.nanoTime() + timeoutNanos;
     }
     return Math.max(deadlineNanoTime - System.nanoTime(), 0);
@@ -66,17 +113,28 @@ final class BufferNextMessage implements ByteBoundedQueue.Consumer {
     return bufferFull || remainingNanos() <= 0;
   }
 
-  List<byte[]> drain() {
-    if (buffer.isEmpty()) return Collections.emptyList();
-    ArrayList<byte[]> result = new ArrayList<>(buffer);
-    buffer.clear();
-    sizeInBytes = 0;
-    bufferFull = false;
+  // this occurs off the application thread
+  void drain(SpanWithSizeConsumer<S> consumer) {
+    Iterator<S> spanIterator = spans.iterator();
+    Iterator<Integer> sizeIterator = sizes.iterator();
+    while (spanIterator.hasNext()) {
+      if (consumer.offer(spanIterator.next(), sizeIterator.next())) {
+        bufferFull = false;
+        spanIterator.remove();
+        sizeIterator.remove();
+      }
+    }
+
+    resetMessageSizeInBytes();
+    // regardless, reset the clock
     deadlineNanoTime = 0;
-    return result;
+  }
+
+  int count() {
+    return spans.size();
   }
 
   int sizeInBytes() {
-    return sizeInBytes;
+    return messageSizeInBytes;
   }
 }

--- a/core/src/main/java/zipkin2/reporter/Reporter.java
+++ b/core/src/main/java/zipkin2/reporter/Reporter.java
@@ -24,8 +24,23 @@ import zipkin2.Span;
  * zipkin2.Span).
  */
 public interface Reporter<S> {
-  Reporter<Span> NOOP = s -> {};
-  Reporter<Span> CONSOLE = s -> System.out.println(s.toString());
+  Reporter<Span> NOOP = new Reporter<Span>() {
+    @Override public void report(Span span) {
+    }
+
+    @Override public String toString() {
+      return "NoopReporter{}";
+    }
+  };
+  Reporter<Span> CONSOLE = new Reporter<Span>() {
+    @Override public void report(Span span) {
+      System.out.println(span.toString());
+    }
+
+    @Override public String toString() {
+      return "ConsoleReporter{}";
+    }
+  };
 
   /**
    * Schedules the span to be sent onto the transport.

--- a/core/src/main/java/zipkin2/reporter/Sender.java
+++ b/core/src/main/java/zipkin2/reporter/Sender.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.reporter;
 
+import java.util.Collections;
 import java.util.List;
 import zipkin2.Call;
 import zipkin2.Component;
@@ -62,6 +63,19 @@ public abstract class Sender extends Component {
    * inefficient list encoding. For example, Scribe base64's then tags each span with a category.
    */
   public abstract int messageSizeInBytes(List<byte[]> encodedSpans);
+
+  /**
+   * Like {@link #messageSizeInBytes(List)}, except for a single-span. This is used to ensure a span
+   * is never accepted that can never be sent.
+   *
+   * <p>Always override this, which is only abstract as added after version 2.0
+   *
+   * @param encodedSizeInBytes the {@link BytesEncoder#sizeInBytes(Object) encoded size} of a span
+   * @since 2.2
+   */
+  public int messageSizeInBytes(int encodedSizeInBytes) {
+    return messageSizeInBytes(Collections.singletonList(new byte[encodedSizeInBytes]));
+  }
 
   /**
    * Sends a list of encoded spans to a transport such as http or Kafka.

--- a/core/src/test/java/zipkin2/reporter/ByteBoundedQueueTest.java
+++ b/core/src/test/java/zipkin2/reporter/ByteBoundedQueueTest.java
@@ -20,26 +20,26 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ByteBoundedQueueTest {
-  ByteBoundedQueue queue = new ByteBoundedQueue(10, 10);
+  ByteBoundedQueue<byte[]> queue = new ByteBoundedQueue<>(10, 10);
 
   @Test
   public void offer_failsWhenFull_size() {
     for (int i = 0; i < queue.maxSize; i++) {
-      assertThat(queue.offer(new byte[1])).isTrue();
+      assertThat(queue.offer(new byte[1], 1)).isTrue();
     }
-    assertThat(queue.offer(new byte[1])).isFalse();
+    assertThat(queue.offer(new byte[1], 1)).isFalse();
   }
 
   @Test
   public void offer_failsWhenFull_sizeInBytes() {
-    assertThat(queue.offer(new byte[10])).isTrue();
-    assertThat(queue.offer(new byte[1])).isFalse();
+    assertThat(queue.offer(new byte[10], 10)).isTrue();
+    assertThat(queue.offer(new byte[1], 1)).isFalse();
   }
 
   @Test
   public void offer_updatesCount() {
     for (int i = 0; i < queue.maxSize; i++) {
-      queue.offer(new byte[1]);
+      queue.offer(new byte[1], 1);
     }
     assertThat(queue.count).isEqualTo(10);
   }
@@ -47,25 +47,25 @@ public class ByteBoundedQueueTest {
   @Test
   public void offer_sizeInBytes() {
     for (int i = 0; i < queue.maxSize; i++) {
-      queue.offer(new byte[1]);
+      queue.offer(new byte[1], 1);
     }
     assertThat(queue.sizeInBytes).isEqualTo(queue.maxSize);
   }
 
   @Test
   public void circular() {
-    ByteBoundedQueue queue = new ByteBoundedQueue(10, 10);
+    ByteBoundedQueue<Integer> queue = new ByteBoundedQueue<>(10, 10);
 
     List<Integer> polled = new ArrayList<>();
-    ByteBoundedQueue.Consumer consumer = buffer -> polled.add((int) buffer[0]);
+    SpanWithSizeConsumer<Integer> consumer = (next, ignored) -> polled.add(next);
 
     // Offer more than the capacity, flushing via poll on interval
-    for (byte i = 0; i < 15; i++) {
-      queue.offer(new byte[] {i});
+    for (int i = 0; i < 15; i++) {
+      queue.offer(i, 1);
       queue.drainTo(consumer, 1);
     }
 
-    // ensure we have all of the elements
+    // ensure we have all of the spans
     assertThat(polled)
         .containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
   }

--- a/core/src/test/java/zipkin2/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeSender.java
@@ -74,6 +74,10 @@ public abstract class FakeSender extends Sender {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding().listSizeInBytes(encodedSizeInBytes);
+  }
+
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
 

--- a/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
+++ b/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
@@ -142,6 +142,10 @@ public abstract class KafkaSender extends Sender {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding().listSizeInBytes(encodedSizeInBytes);
+  }
+
   /**
    * This sends all of the spans as a single message.
    *

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -146,6 +146,10 @@ public abstract class OkHttpSender extends Sender {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding().listSizeInBytes(encodedSizeInBytes);
+  }
+
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <zipkin.version>2.2.2</zipkin.version>
+    <zipkin.version>2.4.1</zipkin.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -125,6 +125,10 @@ public abstract class URLConnectionSender extends Sender {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
+  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+    return encoding().listSizeInBytes(encodedSizeInBytes);
+  }
+
   /** The returned call sends spans as a POST to {@link #endpoint()}. */
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new IllegalStateException("close");


### PR DESCRIPTION
We calculate a span size in bytes before offering it to the async queue
to ensure we don't add a poison message (a span too big to encode).
However, we don't have to encode it on the application calling thread.

This operation reduces overhead by about 18us in benchmarking.

End-to-end benchmarks from Brave, running on jdk9.01
```
Benchmark                               Mode  Cnt    Score   Error  Units
EndToEndBenchmarks.server_get           avgt   15  133.535 ± 5.378  us/op
EndToEndBenchmarks.unsampledServer_get  avgt   15  145.541 ± 2.757  us/op

Before:
Benchmark                               Mode  Cnt    Score   Error  Units
EndToEndBenchmarks.traced128Server_get  avgt   15  207.332 ± 3.377  us/op

After:
Benchmark                               Mode  Cnt    Score   Error  Units
EndToEndBenchmarks.traced128Server_get  avgt   15  189.703 ± 3.342  us/op
```

See #81