### PR TITLE
Adds zipkin-reporter-bom and uses it in spring beans and benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,50 @@ You can switch to v1 encoding like so:
 reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
                         .build(SpanBytesEncoder.JSON_V1);
 ```
+
+
+## Artifacts
+All artifacts publish to the group ID "io.zipkin.zipkin2". We use a
+common release version for all components.
+### Library Releases
+Releases are uploaded to [Bintray](https://bintray.com/openzipkin/maven/brave) and synchronized to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.zipkin.reporter2%22)
+### Library Snapshots
+Snapshots are uploaded to [JFrog](http://oss.jfrog.org/artifactory/oss-snapshot-local) after commits to master.
+### Version alignments
+When using multiple reporter components, you'll want to align versions
+in one place. This allows you to more safely upgrade, with less worry
+about conflicts.
+
+You can use our Maven instrumentation BOM (Bill of Materials) for this:
+
+Ex. in your dependencies section, import the BOM like this:
+```xml
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.zipkin.reporter2</groupId>
+        <artifactId>zipkin-reporter-bom</artifactId>
+        <version>${zipkin-reporter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+```
+
+Now, you can leave off the version when choosing any supported
+instrumentation. Also any indirect use will have versions aligned:
+```xml
+<dependency>
+  <groupId>io.zipkin.reporter2</groupId>
+  <artifactId>zipkin-sender-okhttp3</artifactId>
+</dependency>
+```
+
+With this in place, you can use the built-in properties
+`zipkin-reporter.version` and `zipkin.version` to override dependency
+versions coherently. This is most commonly to test a new feature or fix.
+
+Note: If you override a version, always double check that your version
+is valid (equal to or later) than what you are updating. This will avoid
+class conflicts.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -34,6 +34,18 @@
     <main.signature.artifact>java18</main.signature.artifact>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,122 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.zipkin.reporter2</groupId>
+  <artifactId>zipkin-reporter-bom</artifactId>
+  <name>Zipkin Reporter BOM</name>
+  <version>2.3.4-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <description>Bill Of Materials POM for all Zipkin reporter artifacts</description>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <!-- allows someone to update the version via property when importing the pom -->
+    <zipkin-reporter.version>${project.version}</zipkin-reporter.version>
+
+    <!-- use the same value in ../pom.xml -->
+    <zipkin.version>2.5.1</zipkin.version>
+  </properties>
+
+  <url>https://github.com/openzipkin/zipkin-reporter-java</url>
+  <inceptionYear>2016</inceptionYear>
+
+  <organization>
+    <name>OpenZipkin</name>
+    <url>http://zipkin.io/</url>
+  </organization>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <url>https://github.com/openzipkin/zipkin-reporter-java</url>
+    <connection>scm:git:https://github.com/openzipkin/zipkin-reporter-java.git</connection>
+    <developerConnection>scm:git:https://github.com/openzipkin/zipkin-reporter-java.git
+    </developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <!-- Developer section is needed for Maven Central, but doesn't need to include each person -->
+  <developers>
+    <developer>
+      <id>openzipkin</id>
+      <name>OpenZipkin Gitter</name>
+      <url>https://gitter.im/openzipkin/zipkin</url>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <repository>
+      <id>bintray</id>
+      <url>https://api.bintray.com/maven/openzipkin/maven/zipkin-reporter-java/;publish=1</url>
+    </repository>
+    <snapshotRepository>
+      <id>jfrog-snapshots</id>
+      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+    </snapshotRepository>
+  </distributionManagement>
+
+  <issueManagement>
+    <system>Github</system>
+    <url>https://github.com/openzipkin/zipkin-reporter-java/issues</url>
+  </issueManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.zipkin.zipkin2</groupId>
+        <artifactId>zipkin</artifactId>
+        <version>${zipkin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter</artifactId>
+        <type>test-jar</type>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-okhttp3</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-urlconnection</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-kafka08</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-kafka11</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-amqp-client</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter-spring-beans</artifactId>
+        <version>${zipkin-reporter.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>bom</module>
     <module>core</module>
     <module>kafka08</module>
     <module>kafka11</module>
@@ -43,7 +44,8 @@
 
     <main.basedir>${project.basedir}</main.basedir>
 
-    <zipkin.version>2.5.0</zipkin.version>
+    <!-- use the same value in bom/pom.xml -->
+    <zipkin.version>2.5.1</zipkin.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 
@@ -109,36 +111,6 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-reporter</artifactId>
         <type>test-jar</type>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-sender-okhttp3</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-sender-urlconnection</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-sender-kafka08</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-sender-kafka11</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-sender-amqp-client</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-reporter-spring-beans</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -30,11 +30,22 @@
     <main.basedir>${project.basedir}/..</main.basedir>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This adds a BOM which allows easy version alignment. As noted in the
README, you can use zipkin.version and zipkin-reporter.version to
change deps.