### PR TITLE
Allows reporting of proto3-encoded spans

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.5.1</zipkin.version>
+    <zipkin.version>2.6.1</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>

--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -171,7 +171,7 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
 
       if (messageTimeoutNanos > 0) { // Start a thread that flushes the queue in a loop.
         final BufferNextMessage<S> consumer =
-            BufferNextMessage.create(sender, messageMaxBytes, messageTimeoutNanos);
+            BufferNextMessage.create(encoder.encoding(), messageMaxBytes, messageTimeoutNanos);
         final Thread flushThread = new Thread("AsyncReporter{" + sender + "}") {
           @Override public void run() {
             try {
@@ -234,7 +234,7 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
     }
 
     @Override public final void flush() {
-      flush(BufferNextMessage.create(sender, messageMaxBytes, 0));
+      flush(BufferNextMessage.create(encoder.encoding(), messageMaxBytes, 0));
     }
 
     void flush(BufferNextMessage<S> bundler) {

--- a/core/src/main/java/zipkin2/reporter/BytesMessageEncoder.java
+++ b/core/src/main/java/zipkin2/reporter/BytesMessageEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,6 +41,33 @@ public enum BytesMessageEncoder {
         if (i < length) buf[pos++] = ',';
       }
       buf[pos] = ']';
+      return buf;
+    }
+  },
+  /**
+   * This function simply concatenates the byte arrays.
+   *
+   * <p>The list of byte arrays represents a repeated (type 2) field. As such, each byte array is
+   * expected to have a prefix of the field number, followed by the encoded length of the span,
+   * finally, the actual span bytes.
+   *
+   * @see Encoding#PROTO3
+   */
+  PROTO3 {
+    @Override public byte[] encode(List<byte[]> values) {
+      int sizeOfArray = 0;
+      int length = values.size();
+      for (int i = 0; i < length; ) {
+        sizeOfArray += values.get(i++).length;
+      }
+
+      byte[] buf = new byte[sizeOfArray];
+      int pos = 0;
+      for (int i = 0; i < length; ) {
+        byte[] v = values.get(i++);
+        System.arraycopy(v, 0, buf, pos, v.length);
+        pos += v.length;
+      }
       return buf;
     }
   };

--- a/core/src/test/java/zipkin2/reporter/BufferNextMessageTest.java
+++ b/core/src/test/java/zipkin2/reporter/BufferNextMessageTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter;
+
+import org.junit.Test;
+import zipkin2.codec.Encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BufferNextMessageTest {
+
+  @Test public void empty_json() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
+
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(2 /* [] */);
+  }
+
+  @Test public void offer_json() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
+    pending.offer(1, 1);
+
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(3 /* [1] */);
+
+    pending.offer(2, 1);
+
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(5 /* [1,2] */);
+  }
+
+  @Test public void offerWhenFull_json() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
+    for (int i = 0; i < 4; i++) {
+      assertThat(pending.offer(i, 1))
+          .isTrue();
+    }
+    // buffer is not quite full
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(9 /* [0,1,2,3] */);
+
+    // but another element will put it over the edge, so drops
+    assertThat(pending.offer(4, 1))
+        // should drop because 4 implies ",4" which makes the total length 11
+        .isFalse();
+  }
+
+  @Test public void drain_json() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
+    for (int i = 0; i < 4; i++) {
+      pending.offer(i, 1);
+    }
+
+    // fully drain
+    pending.drain((s, n) -> true);
+
+    // back to initial state
+    assertThat(pending).isEqualToComparingFieldByField(
+        BufferNextMessage.create(Encoding.JSON, 10, 0L)
+    );
+  }
+
+  @Test public void drain_incrementally_json() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
+    for (int i = 0; i < 4; i++) {
+      pending.offer(i, 1);
+    }
+
+    // partial drain
+    pending.drain((s, n) -> s < 2);
+
+    assertThat(pending.spans)
+        .containsExactly(2, 3);
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(5 /* [2,3] */);
+
+    // partial drain again
+    pending.drain((s, n) -> s < 3);
+
+    assertThat(pending.spans)
+        .containsExactly(3);
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(3 /* [3] */);
+  }
+
+  @Test public void empty_proto3() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
+
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isZero();
+  }
+
+  @Test public void offer_proto3() {
+    BufferNextMessage<Character> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
+    pending.offer('a', 1);
+
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(1 /* a */);
+
+    pending.offer('b', 1);
+
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(2 /* ab */);
+  }
+
+  @Test public void offerWhenFull_proto3() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
+    for (int i = 0; i < 3; i++) {
+      assertThat(pending.offer(i, 3))
+          .isTrue();
+    }
+    // buffer is not quite full
+    assertThat(pending.bufferFull)
+        .isFalse();
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(9 /* 012 */);
+
+    // but another element will put it over the edge, so drops
+    assertThat(pending.offer(3, 3))
+        // should drop because this implies adding 3 bytes which makes the total length 12
+        .isFalse();
+  }
+
+  @Test public void drain_proto3() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
+    for (int i = 0; i < 4; i++) {
+      pending.offer(i, 1);
+    }
+
+    // fully drain
+    pending.drain((s, n) -> true);
+
+    // back to initial state
+    assertThat(pending).isEqualToComparingFieldByField(
+        BufferNextMessage.create(Encoding.PROTO3, 10, 0L)
+    );
+  }
+
+  @Test public void drain_incrementally_proto3() {
+    BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
+    for (int i = 0; i < 4; i++) {
+      pending.offer(i, 1);
+    }
+
+    // partial drain
+    pending.drain((s, n) -> s < 2);
+
+    assertThat(pending.spans)
+        .containsExactly(2, 3);
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(2 /* 23 */);
+
+    // partial drain again
+    pending.drain((s, n) -> s < 3);
+
+    assertThat(pending.spans)
+        .containsExactly(3);
+    assertThat(pending.messageSizeInBytes)
+        .isEqualTo(1 /* 3 */);
+  }
+}

--- a/core/src/test/java/zipkin2/reporter/BytesMessageEncoderTest.java
+++ b/core/src/test/java/zipkin2/reporter/BytesMessageEncoderTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BytesMessageEncoderTest {
+
+  @Test public void emptyList_json() {
+    List<byte[]> encoded = Arrays.asList();
+    assertThat(BytesMessageEncoder.JSON.encode(encoded))
+        .containsExactly('[', ']');
+  }
+
+  @Test public void singletonList_json() {
+    List<byte[]> encoded = Arrays.asList(new byte[] {'{', '}'});
+
+    assertThat(BytesMessageEncoder.JSON.encode(encoded))
+        .containsExactly('[', '{', '}', ']');
+  }
+
+  @Test public void multiItemList_json() {
+    List<byte[]> encoded = Arrays.asList(
+        "{\"k\":\"1\"}".getBytes(),
+        "{\"k\":\"2\"}".getBytes(),
+        "{\"k\":\"3\"}".getBytes()
+    );
+    assertThat(new String(BytesMessageEncoder.JSON.encode(encoded)))
+        .isEqualTo("[{\"k\":\"1\"},{\"k\":\"2\"},{\"k\":\"3\"}]");
+  }
+
+  @Test public void emptyList_proto3() {
+    List<byte[]> encoded = Arrays.asList();
+    assertThat(BytesMessageEncoder.PROTO3.encode(encoded))
+        .isEmpty();
+  }
+
+  @Test public void singletonList_proto3() {
+    List<byte[]> encoded = Arrays.asList(new byte[] {1, 1, 'a'});
+
+    assertThat(BytesMessageEncoder.PROTO3.encode(encoded))
+        .containsExactly(1, 1, 'a');
+  }
+
+  @Test public void multiItemList_proto3() {
+    List<byte[]> encoded = Arrays.asList(
+        new byte[] {1, 1, 'a'},
+        new byte[] {1, 1, 'b'},
+        new byte[] {1, 1, 'c'}
+    );
+    assertThat(BytesMessageEncoder.PROTO3.encode(encoded)).containsExactly(
+        1, 1, 'a',
+        1, 1, 'b',
+        1, 1, 'c'
+    );
+  }
+}

--- a/core/src/test/java/zipkin2/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -37,6 +37,17 @@ public abstract class FakeSender extends Sender {
         SpanBytesDecoder.JSON_V2,
         spans -> {
         }
+    );
+  }
+
+  FakeSender encoding(Encoding encoding) {
+    return new AutoValue_FakeSender(
+        encoding,
+        messageMaxBytes(),
+        messageEncoder(), // invalid but not needed, yet
+        encoder(), // invalid but not needed, yet
+        decoder(), // invalid but not needed, yet
+        onSpans()
     );
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.5.1</zipkin.version>
+    <zipkin.version>2.6.1</zipkin.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
While zipkin's proto3 format isn't yet defined, this allows us to
develop one. It also allows other protobuf formats, like Stackdriver,
to use the AsyncReporter.

Depends on https://github.com/openzipkin/zipkin/pull/1961
Needed by https://github.com/openzipkin/zipkin-gcp/issues/59