### PR TITLE
Enables proto3 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,26 @@ class CustomReporter implements Flushable {
   }
 ```
 
+
+### Protocol Buffers Encoding
+By default, senders use json v2 encoding, which is easy to understand, but
+twice as large as binary encoding for normal spans. If you are running a
+recent (2.8+) version of Zipkin server, consider [Protocol Buffers](https://developers.google.com/protocol-buffers/docs/proto3)
+when you want to optimize for least size.
+
+You can switch to proto3 encoding like so:
+
+```java
+sender = KafkaSender.newBuilder()
+                    .encoding(Encoding.PROTO3)
+                    .bootstrapServers("192.168.99.100:9092")
+                    .build()
+```
+
 ### Legacy Encoding
-V2 builders use json v2 encoding, which is easy to understand and twice
-as efficient as the v1 json encoding. However, it relies on recent (1.31+)
-versions of zipkin server.
+By default, senders use json v2 encoding, which is easy to understand and
+twice as efficient as the v1 json encoding. However, it relies on recent
+(1.31+) versions of zipkin server.
 
 You can switch to v1 encoding like so:
 

--- a/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
+++ b/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -72,7 +72,7 @@ public abstract class RabbitMQSender extends Sender {
       return this;
     }
 
-    /** Comma-separated list of host:port pairs */
+    /** Comma-separated list of host:port pairs. ex "192.168.99.100:5672" No Default. */
     public Builder addresses(String addresses) {
       if (addresses == null) throw new NullPointerException("addresses == null");
       this.addresses = convertAddresses(addresses);
@@ -86,6 +86,11 @@ public abstract class RabbitMQSender extends Sender {
       return this;
     }
 
+    /**
+     * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
+     *
+     * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
+     */
     public Builder encoding(Encoding encoding) {
       if (encoding == null) throw new NullPointerException("encoding == null");
       this.encoding = encoding;

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.6.1</zipkin.version>
+    <zipkin.version>2.8.0</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>

--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -154,6 +154,8 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
       switch (sender.encoding()) {
         case JSON:
           return build(SpanBytesEncoder.JSON_V2);
+        case PROTO3:
+          return build(SpanBytesEncoder.PROTO3);
         default:
           throw new UnsupportedOperationException(sender.encoding().name());
       }

--- a/core/src/main/java/zipkin2/reporter/BytesMessageEncoder.java
+++ b/core/src/main/java/zipkin2/reporter/BytesMessageEncoder.java
@@ -87,6 +87,8 @@ public enum BytesMessageEncoder {
     switch (encoding) {
       case JSON:
         return JSON;
+      case PROTO3:
+        return PROTO3;
       default:
         throw new UnsupportedOperationException(encoding.name());
     }

--- a/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
@@ -398,14 +398,13 @@ public class AsyncReporterTest {
     }
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void build_proto3_unsupportedByDefaultBytesEncoder() {
+  @Test public void build_proto3() {
     AsyncReporter.builder(FakeSender.create().encoding(Encoding.PROTO3))
         .messageTimeout(0, TimeUnit.MILLISECONDS)
         .build();
   }
 
-  @Test public void build_proto3_allowedWithCustomBytesEncoder() {
+  @Test public void build_proto3_withCustomBytesEncoder() {
     AsyncReporter.builder(FakeSender.create().encoding(Encoding.PROTO3))
         .messageTimeout(0, TimeUnit.MILLISECONDS)
         // there's no builtin protobuf format of zipkin spans, yet, so there's no encoder

--- a/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
@@ -33,7 +33,7 @@ import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.Sender;
 
 /**
- * This sends (usually TBinaryProtocol big-endian) encoded spans to a Kafka topic.
+ * This sends (usually json v2) encoded spans to a Kafka topic.
  *
  * <p>This sender is thread-safe.
  *
@@ -42,6 +42,7 @@ import zipkin2.reporter.Sender;
 @AutoValue
 public abstract class KafkaSender extends Sender {
 
+  /** Creates a sender that sends {@link Encoding#JSON} messages. */
   public static KafkaSender create(String bootstrapServers) {
     return newBuilder().bootstrapServers(bootstrapServers).build();
   }
@@ -74,7 +75,7 @@ public abstract class KafkaSender extends Sender {
 
     /**
      * Initial set of kafka servers to connect to, rest of cluster will be discovered (comma
-     * separated). No default
+     * separated). Ex "192.168.99.100:9092" No default
      *
      * @see ProducerConfig#BOOTSTRAP_SERVERS_CONFIG
      */
@@ -110,6 +111,11 @@ public abstract class KafkaSender extends Sender {
       return this;
     }
 
+    /**
+     * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
+     *
+     * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
+     */
     public abstract Builder encoding(Encoding encoding);
 
     abstract Encoding encoding();
@@ -120,7 +126,7 @@ public abstract class KafkaSender extends Sender {
 
     abstract Builder encoder(BytesMessageEncoder encoder);
 
-    public abstract KafkaSender autoBuild();
+    abstract KafkaSender autoBuild();
 
     Builder() {
     }

--- a/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
+++ b/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,7 @@ import zipkin2.reporter.Sender;
 import zipkin2.reporter.AwaitableCallback;
 
 /**
- * This sends (usually TBinaryProtocol big-endian) encoded spans to a Kafka topic.
+ * This sends (usually json v2) encoded spans to a Kafka topic.
  *
  * <p>This sender is thread-safe.
  *
@@ -42,7 +42,7 @@ import zipkin2.reporter.AwaitableCallback;
  */
 @AutoValue
 public abstract class KafkaSender extends Sender {
-
+  /** Creates a sender that sends {@link Encoding#JSON} messages. */
   public static KafkaSender create(String bootstrapServers) {
     return newBuilder().bootstrapServers(bootstrapServers).build();
   }
@@ -75,7 +75,7 @@ public abstract class KafkaSender extends Sender {
 
     /**
      * Initial set of kafka servers to connect to, rest of cluster will be discovered (comma
-     * separated). No default
+     * separated). Ex "192.168.99.100:9092" No default
      *
      * @see ProducerConfig#BOOTSTRAP_SERVERS_CONFIG
      */
@@ -111,6 +111,11 @@ public abstract class KafkaSender extends Sender {
       return this;
     }
 
+    /**
+     * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
+     *
+     * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
+     */
     public abstract Builder encoding(Encoding encoding);
 
     abstract Encoding encoding();
@@ -121,7 +126,7 @@ public abstract class KafkaSender extends Sender {
 
     abstract Builder encoder(BytesMessageEncoder encoder);
 
-    public abstract KafkaSender autoBuild();
+    abstract KafkaSender autoBuild();
 
     Builder() {
     }

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -31,11 +31,12 @@ import org.junit.rules.ExpectedException;
 import zipkin2.Call;
 import zipkin2.Callback;
 import zipkin2.Span;
+import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.Sender;
 import zipkin2.reporter.AwaitableCallback;
+import zipkin2.reporter.Sender;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -86,6 +87,21 @@ public class OkHttpSenderTest {
 
     // Now, let's read back the spans we sent!
     assertThat(SpanBytesDecoder.JSON_V2.decodeList(server.takeRequest().getBody().readByteArray()))
+        .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test public void sendsSpans_PROTO3() throws Exception {
+    sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
+
+    server.enqueue(new MockResponse());
+
+    send(CLIENT_SPAN, CLIENT_SPAN).execute();
+
+    // Ensure only one request was sent
+    assertThat(server.getRequestCount()).isEqualTo(1);
+
+    // Now, let's read back the spans we sent!
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(server.takeRequest().getBody().readByteArray()))
         .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
@@ -278,8 +294,8 @@ public class OkHttpSenderTest {
   }
 
   Call<Void> send(Span... spans) {
-    return sender.sendSpans(Stream.of(spans)
-        .map(SpanBytesEncoder.JSON_V2::encode)
-        .collect(toList()));
+    SpanBytesEncoder bytesEncoder = sender.encoding() == Encoding.JSON
+        ? SpanBytesEncoder.JSON_V2 : SpanBytesEncoder.PROTO3;
+    return sender.sendSpans(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.6.1</zipkin.version>
+    <zipkin.version>2.8.1</zipkin.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -24,13 +24,13 @@ Here's a basic example
 Here's an example with Kafka configuration and extended configuration:
 ```xml
   <bean id="sender" class="zipkin2.reporter.beans.KafkaSenderFactoryBean">
-    <property name="bootstrapServers" value="your_host"/>
+    <property name="bootstrapServers" value="192.168.99.100:9092"/>
+    <!-- if using a zipkin server 2.8+, you can send in binary format -->
+    <property name="encoding" value="PROTO3"/>
     <property name="topic" value="test_zipkin"/>
   </bean>
 
   <bean id="spanReporter" class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
-    <!-- if using an old zipkin server, you can send in v1 format -->
-    <property name="encoder" value="JSON_V1"/>
     <property name="sender" ref="sender"/>
     <!-- wait up to half a second for any in-flight spans on close -->
     <property name="closeTimeout" value="500"/>

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,7 +23,7 @@ import zipkin2.reporter.Sender;
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class AsyncReporterFactoryBean extends AbstractFactoryBean {
   Sender sender;
-  SpanBytesEncoder encoder = SpanBytesEncoder.JSON_V2;
+  SpanBytesEncoder encoder;
   ReporterMetrics metrics;
   Integer messageMaxBytes;
   Integer messageTimeout;
@@ -43,7 +43,7 @@ public class AsyncReporterFactoryBean extends AbstractFactoryBean {
     if (closeTimeout != null) builder.closeTimeout(closeTimeout, TimeUnit.MILLISECONDS);
     if (queuedMaxSpans != null) builder.queuedMaxSpans(queuedMaxSpans);
     if (queuedMaxBytes != null) builder.queuedMaxBytes(queuedMaxBytes);
-    return builder.build(encoder);
+    return encoder != null ? builder.build(encoder) : builder.build();
   }
 
   @Override protected void destroyInstance(Object instance) throws Exception {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/KafkaSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/KafkaSenderFactoryBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,17 +14,20 @@
 package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.kafka11.KafkaSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class KafkaSenderFactoryBean extends AbstractFactoryBean {
 
   String bootstrapServers, topic;
+  Encoding encoding;
   Integer messageMaxBytes;
 
   @Override protected KafkaSender createInstance() throws Exception {
     KafkaSender.Builder builder = KafkaSender.newBuilder();
     if (bootstrapServers != null) builder.bootstrapServers(bootstrapServers);
+    if (encoding != null) builder.encoding(encoding);
     if (topic != null) builder.topic(topic);
     if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
     return builder.build();
@@ -48,6 +51,10 @@ public class KafkaSenderFactoryBean extends AbstractFactoryBean {
 
   public void setTopic(String topic) {
     this.topic = topic;
+  }
+
+  public void setEncoding(Encoding encoding) {
+    this.encoding = encoding;
   }
 
   public void setMessageMaxBytes(Integer messageMaxBytes) {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
@@ -14,12 +14,14 @@
 package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
 
   String endpoint;
+  Encoding encoding;
   Integer maxRequests;
   Integer connectTimeout, readTimeout, writeTimeout;
   Boolean compressionEnabled;
@@ -28,6 +30,7 @@ public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
   @Override protected OkHttpSender createInstance() throws Exception {
     OkHttpSender.Builder builder = OkHttpSender.newBuilder();
     if (endpoint != null) builder.endpoint(endpoint);
+    if (encoding != null) builder.encoding(encoding);
     if (connectTimeout != null) builder.connectTimeout(connectTimeout);
     if (readTimeout != null) builder.readTimeout(readTimeout);
     if (writeTimeout != null) builder.writeTimeout(writeTimeout);
@@ -51,6 +54,10 @@ public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
 
   public void setEndpoint(String endpoint) {
     this.endpoint = endpoint;
+  }
+
+  public void setEncoding(Encoding encoding) {
+    this.encoding = encoding;
   }
 
   public void setMaxRequests(Integer maxRequests) {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,12 +14,14 @@
 package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.amqp.RabbitMQSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class RabbitMQSenderFactoryBean extends AbstractFactoryBean {
 
   String addresses, queue;
+  Encoding encoding;
   Integer connectionTimeout;
   String virtualHost;
   String username, password;
@@ -28,6 +30,7 @@ public class RabbitMQSenderFactoryBean extends AbstractFactoryBean {
   @Override protected RabbitMQSender createInstance() throws Exception {
     RabbitMQSender.Builder builder = RabbitMQSender.newBuilder();
     if (addresses != null) builder.addresses(addresses);
+    if (encoding != null) builder.encoding(encoding);
     if (queue != null) builder.queue(queue);
     if (connectionTimeout != null) builder.connectionTimeout(connectionTimeout);
     if (virtualHost != null) builder.virtualHost(virtualHost);
@@ -55,6 +58,10 @@ public class RabbitMQSenderFactoryBean extends AbstractFactoryBean {
 
   public void setQueue(String queue) {
     this.queue = queue;
+  }
+
+  public void setEncoding(Encoding encoding) {
+    this.encoding = encoding;
   }
 
   public void setConnectionTimeout(Integer connectionTimeout) {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,12 +14,14 @@
 package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
 
   String endpoint;
+  Encoding encoding;
   Integer connectTimeout, readTimeout;
   Boolean compressionEnabled;
   Integer messageMaxBytes;
@@ -27,6 +29,7 @@ public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
   @Override protected URLConnectionSender createInstance() throws Exception {
     URLConnectionSender.Builder builder = URLConnectionSender.newBuilder();
     if (endpoint != null) builder.endpoint(endpoint);
+    if (encoding != null) builder.encoding(encoding);
     if (connectTimeout != null) builder.connectTimeout(connectTimeout);
     if (readTimeout != null) builder.readTimeout(readTimeout);
     if (compressionEnabled != null) builder.compressionEnabled(compressionEnabled);
@@ -48,6 +51,10 @@ public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
 
   public void setEndpoint(String endpoint) {
     this.endpoint = endpoint;
+  }
+
+  public void setEncoding(Encoding encoding) {
+    this.encoding = encoding;
   }
 
   public void setConnectTimeout(Integer connectTimeout) {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ package zipkin2.reporter.beans;
 import java.util.Arrays;
 import org.junit.After;
 import org.junit.Test;
-import zipkin2.reporter.amqp.RabbitMQSender;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.kafka11.KafkaSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,6 +66,19 @@ public class KafkaSenderFactoryBeanTest {
     assertThat(context.getBean("sender", KafkaSender.class))
         .extracting("messageMaxBytes")
         .containsExactly(1024);
+  }
+
+  @Test public void encoding() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
+        + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
+        + "  <property name=\"encoding\" value=\"PROTO3\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", KafkaSender.class))
+        .extracting("encoding")
+        .containsExactly(Encoding.PROTO3);
   }
 
   @Test(expected = IllegalStateException.class) public void close_closesSender() {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import okhttp3.HttpUrl;
 import org.junit.After;
 import org.junit.Test;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -116,6 +117,19 @@ public class OkHttpSenderFactoryBeanTest {
     assertThat(context.getBean("sender", OkHttpSender.class))
         .extracting("messageMaxBytes")
         .containsExactly(1024);
+  }
+
+  @Test public void encoding() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"encoding\" value=\"PROTO3\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", OkHttpSender.class))
+        .extracting("encoding")
+        .containsExactly(Encoding.PROTO3);
   }
 
   @Test(expected = IllegalStateException.class) public void close_closesSender() {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ import com.rabbitmq.client.Address;
 import java.util.Arrays;
 import org.junit.After;
 import org.junit.Test;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.amqp.RabbitMQSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,6 +105,19 @@ public class RabbitMQSenderFactoryBeanTest {
     assertThat(context.getBean("sender", RabbitMQSender.class))
         .extracting("messageMaxBytes")
         .containsExactly(1024);
+  }
+
+  @Test public void encoding() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+        + "  <property name=\"encoding\" value=\"PROTO3\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", RabbitMQSender.class))
+        .extracting("encoding")
+        .containsExactly(Encoding.PROTO3);
   }
 
   @Test(expected = IllegalStateException.class) public void close_closesSender() {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import java.net.URI;
 import java.util.Arrays;
 import org.junit.After;
 import org.junit.Test;
+import zipkin2.codec.Encoding;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,6 +95,19 @@ public class URLConnectionSenderFactoryBeanTest {
     assertThat(context.getBean("sender", URLConnectionSender.class))
         .extracting("messageMaxBytes")
         .containsExactly(1024);
+  }
+
+  @Test public void encoding() {
+    context = new XmlBeans(""
+        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+        + "  <property name=\"encoding\" value=\"PROTO3\"/>\n"
+        + "</bean>"
+    );
+
+    assertThat(context.getBean("sender", URLConnectionSender.class))
+        .extracting("encoding")
+        .containsExactly(Encoding.PROTO3);
   }
 
   @Test(expected = IllegalStateException.class) public void close_closesSender() {

--- a/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
+++ b/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 import zipkin2.Call;
 import zipkin2.Callback;
 import zipkin2.Span;
+import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
@@ -69,6 +70,21 @@ public class URLConnectionSenderTest {
 
     // Now, let's read back the spans we sent!
     assertThat(SpanBytesDecoder.JSON_V2.decodeList(server.takeRequest().getBody().readByteArray()))
+        .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test public void sendsSpans_PROTO3() throws Exception {
+    sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
+
+    server.enqueue(new MockResponse());
+
+    send(CLIENT_SPAN, CLIENT_SPAN).execute();
+
+    // Ensure only one request was sent
+    assertThat(server.getRequestCount()).isEqualTo(1);
+
+    // Now, let's read back the spans we sent!
+    assertThat(SpanBytesDecoder.PROTO3.decodeList(server.takeRequest().getBody().readByteArray()))
         .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
@@ -144,8 +160,8 @@ public class URLConnectionSenderTest {
   }
 
   Call<Void> send(Span... spans) {
-    return sender.sendSpans(Stream.of(spans)
-        .map(SpanBytesEncoder.JSON_V2::encode)
-        .collect(toList()));
+    SpanBytesEncoder bytesEncoder = sender.encoding() == Encoding.JSON
+        ? SpanBytesEncoder.JSON_V2 : SpanBytesEncoder.PROTO3;
+    return sender.sendSpans(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
   }
 }


### PR DESCRIPTION
By default, senders use json v2 encoding, which is easy to understand, but 
twice as large as binary encoding for normal spans. If you are running a
recent (2.8+) version of Zipkin server, consider [Protocol Buffers](https://developers.google.com/protocol-buffers/docs/proto3)
when you want to optimize for least size.

You can switch to proto3 encoding like so:

```java
sender = KafkaSender.newBuilder()
                    .encoding(Encoding.PROTO3)
                    .bootstrapServers("192.168.99.100:9092")
                    .build()
```