### PR TITLE
Removes auto-value as it now has a mandatory dependency

### DIFF
--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
@@ -56,7 +56,7 @@ public class RabbitMQSenderTest {
       throw new AssumptionViolatedException(check.error().getMessage(), check.error());
     }
 
-    declareQueue(sender.queue());
+    declareQueue(sender.queue);
   }
 
   @After public void close() throws IOException {
@@ -77,7 +77,7 @@ public class RabbitMQSenderTest {
     Thread.sleep(100);
 
     sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
-    declareQueue(sender.queue());
+    declareQueue(sender.queue);
 
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
@@ -91,7 +91,7 @@ public class RabbitMQSenderTest {
     Thread.sleep(100);
 
     sender = sender.toBuilder().queue("zipkin-test2").build();
-    declareQueue(sender.queue());
+    declareQueue(sender.queue);
 
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
@@ -136,7 +136,7 @@ public class RabbitMQSenderTest {
   @Test
   public void toStringContainsOnlySummaryInformation() throws Exception {
     assertThat(sender.toString()).isEqualTo(
-        "RabbitMQSender{addresses=" + sender.addresses() + ", queue=zipkin-test1}"
+        "RabbitMQSender{addresses=" + sender.addresses + ", queue=zipkin-test1}"
     );
   }
 
@@ -164,7 +164,7 @@ public class RabbitMQSenderTest {
 
     Channel channel = sender.get().createChannel();
     try {
-      channel.basicConsume(sender.queue(), true, new DefaultConsumer(channel) {
+      channel.basicConsume(sender.queue, true, new DefaultConsumer(channel) {
         @Override public void handleDelivery(String consumerTag, Envelope envelope,
             AMQP.BasicProperties properties, byte[] body) throws IOException {
           result.set(body);

--- a/benchmarks/src/main/java/zipkin2/reporter/amqp/RabbitMQSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/amqp/RabbitMQSenderBenchmarks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,8 @@
  */
 package zipkin2.reporter.amqp;
 
-import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
-import com.rabbitmq.client.Envelope;
 import java.io.IOException;
 import org.junit.AssumptionViolatedException;
 import org.openjdk.jmh.runner.Runner;
@@ -41,14 +39,14 @@ public class RabbitMQSenderBenchmarks extends SenderBenchmarks {
     }
 
     channel = result.get().createChannel();
-    channel.queueDelete(result.queue());
-    channel.queueDeclare(result.queue(), false, true, true, null);
+    channel.queueDelete(result.queue);
+    channel.queueDeclare(result.queue, false, true, true, null);
 
     Thread.sleep(500L);
 
     new Thread(() -> {
       try {
-        channel.basicConsume(result.queue(), true, new DefaultConsumer(channel));
+        channel.basicConsume(result.queue, true, new DefaultConsumer(channel));
       } catch (IOException e) {
         e.printStackTrace();
       }

--- a/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
@@ -13,9 +13,6 @@
  */
 package zipkin2.reporter.kafka08;
 
-import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -39,8 +36,7 @@ import zipkin2.reporter.Sender;
  *
  * <p>This sender remains a Kafka 0.8.x consumer, while Zipkin systems update to 0.9+.
  */
-@AutoValue
-public abstract class KafkaSender extends Sender {
+public final class KafkaSender extends Sender {
 
   /** Creates a sender that sends {@link Encoding#JSON} messages. */
   public static KafkaSender create(String bootstrapServers) {
@@ -55,23 +51,34 @@ public abstract class KafkaSender extends Sender {
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
-    return new AutoValue_KafkaSender.Builder()
-        .encoding(Encoding.JSON)
-        .properties(properties)
-        .topic("zipkin")
-        .overrides(Collections.EMPTY_MAP)
-        .messageMaxBytes(1000000);
+    return new Builder(properties);
   }
 
   /** Configuration including defaults needed to send spans to a Kafka topic. */
-  @AutoValue.Builder
-  public static abstract class Builder {
-    abstract Builder properties(Properties properties);
+  public static final class Builder {
+    final Properties properties;
+    Encoding encoding = Encoding.JSON;
+    String topic = "zipkin";
+    int messageMaxBytes = 1000000;
+
+    Builder(Properties properties) {
+      this.properties = properties;
+    }
+
+    Builder(KafkaSender sender) {
+      properties = new Properties();
+      properties.putAll(sender.properties);
+      encoding = sender.encoding;
+      topic = sender.topic;
+      messageMaxBytes = sender.messageMaxBytes;
+    }
 
     /** Topic zipkin spans will be send to. Defaults to "zipkin" */
-    public abstract Builder topic(String topic);
-
-    abstract Properties properties();
+    public Builder topic(String topic) {
+      if (topic == null) throw new NullPointerException("topic == null");
+      this.topic = topic;
+      return this;
+    }
 
     /**
      * Initial set of kafka servers to connect to, rest of cluster will be discovered (comma
@@ -81,7 +88,7 @@ public abstract class KafkaSender extends Sender {
      */
     public final Builder bootstrapServers(String bootstrapServers) {
       if (bootstrapServers == null) throw new NullPointerException("bootstrapServers == null");
-      properties().put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+      properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
       return this;
     }
 
@@ -89,7 +96,10 @@ public abstract class KafkaSender extends Sender {
      * Maximum size of a message. Must be equal to or less than the server's "message.max.bytes".
      * Default 1000000.
      */
-    public abstract Builder messageMaxBytes(int messageMaxBytes);
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      this.messageMaxBytes = messageMaxBytes;
+      return this;
+    }
 
     /**
      * By default, a producer will be created, targeted to {@link #bootstrapServers(String)} with 0
@@ -105,9 +115,9 @@ public abstract class KafkaSender extends Sender {
      *
      * @see ProducerConfig
      */
-    public final Builder overrides(Map<String, ?> overrides) {
+    public Builder overrides(Map<String, ?> overrides) {
       if (overrides == null) throw new NullPointerException("overrides == null");
-      properties().putAll(overrides);
+      properties.putAll(overrides);
       return this;
     }
 
@@ -116,39 +126,55 @@ public abstract class KafkaSender extends Sender {
      *
      * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
      */
-    public abstract Builder encoding(Encoding encoding);
-
-    abstract Encoding encoding();
-
-    public final KafkaSender build() {
-      return encoder(BytesMessageEncoder.forEncoding(encoding())).autoBuild();
+    public Builder encoding(Encoding encoding) {
+      if (encoding == null) throw new NullPointerException("encoding == null");
+      this.encoding = encoding;
+      return this;
     }
 
-    abstract Builder encoder(BytesMessageEncoder encoder);
 
-    abstract KafkaSender autoBuild();
-
-    Builder() {
+    public KafkaSender build() {
+      return new KafkaSender(this);
     }
   }
 
-  public abstract Builder toBuilder();
+  final Properties properties;
+  final String topic;
+  final Encoding encoding;
+  final BytesMessageEncoder encoder;
+  final int messageMaxBytes;
 
-  abstract BytesMessageEncoder encoder();
+  KafkaSender(Builder builder) {
+    properties = new Properties();
+    properties.putAll(builder.properties);
+    topic = builder.topic;
+    encoding = builder.encoding;
+    encoder = BytesMessageEncoder.forEncoding(builder.encoding);
+    messageMaxBytes = builder.messageMaxBytes;
+  }
 
-  abstract String topic();
-
-  abstract Properties properties();
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
 
   /** get and close are typically called from different threads */
-  volatile boolean provisioned, closeCalled;
+  volatile KafkaProducer<byte[], byte[]> producer;
+  volatile boolean closeCalled;
 
   @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
     return encoding().listSizeInBytes(encodedSpans);
   }
 
   @Override public int messageSizeInBytes(int encodedSizeInBytes) {
-    return encoding().listSizeInBytes(encodedSizeInBytes);
+    return encoding.listSizeInBytes(encodedSizeInBytes);
+  }
+
+  @Override public Encoding encoding() {
+    return encoding;
+  }
+
+  @Override public int messageMaxBytes() {
+    return messageMaxBytes;
   }
 
   /**
@@ -158,40 +184,43 @@ public abstract class KafkaSender extends Sender {
    */
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new IllegalStateException("closed");
-    byte[] message = encoder().encode(encodedSpans);
+    byte[] message = encoder.encode(encodedSpans);
     return new KafkaCall(message);
   }
 
   /** Ensures there are no problems reading metadata about the topic. */
   @Override public CheckResult check() {
     try {
-      get().partitionsFor(topic()); // make sure we can query the metadata
+      get().partitionsFor(topic); // make sure we can query the metadata
       return CheckResult.OK;
     } catch (RuntimeException e) {
       return CheckResult.failed(e);
     }
   }
 
-  @Memoized KafkaProducer<byte[], byte[]> get() {
-    KafkaProducer<byte[], byte[]> result = new KafkaProducer<>(properties());
-    provisioned = true;
-    return result;
+  KafkaProducer<byte[], byte[]> get() {
+    if (producer == null) {
+      synchronized (this) {
+        if (producer == null) {
+          producer = new KafkaProducer<>(properties);
+        }
+      }
+    }
+    return producer;
   }
 
   @Override public synchronized void close() {
     if (closeCalled) return;
-    if (provisioned) get().close();
+    KafkaProducer<byte[], byte[]>  producer = this.producer;
+    if (producer != null) producer.close();
     closeCalled = true;
   }
 
   @Override public final String toString() {
     return "KafkaSender{"
-        + "bootstrapServers=" + properties().get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
-        + ", topic=" + topic()
+        + "bootstrapServers=" + properties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+        + ", topic=" + topic
         + "}";
-  }
-
-  KafkaSender() {
   }
 
   class KafkaCall extends Call.Base<Void> { // KafkaFuture is not cancelable
@@ -203,13 +232,13 @@ public abstract class KafkaSender extends Sender {
 
     @Override protected Void doExecute() {
       AwaitableCallback callback = new AwaitableCallback();
-      get().send(new ProducerRecord<>(topic(), message), new CallbackAdapter(callback));
+      get().send(new ProducerRecord<>(topic, message), new CallbackAdapter(callback));
       callback.await();
       return null;
     }
 
     @Override protected void doEnqueue(Callback<Void> callback) {
-      get().send(new ProducerRecord<>(topic(), message), new CallbackAdapter(callback));
+      get().send(new ProducerRecord<>(topic, message), new CallbackAdapter(callback));
     }
 
     @Override public Call<Void> clone() {

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -13,7 +13,6 @@
  */
 package zipkin2.reporter.okhttp3;
 
-import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.SynchronousQueue;
@@ -42,8 +41,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  *
  * <p>This sender is thread-safe.
  */
-@AutoValue
-public abstract class OkHttpSender extends Sender {
+public final class OkHttpSender extends Sender {
 
   /** Creates a sender that posts {@link Encoding#JSON} messages. */
   public static OkHttpSender create(String endpoint) {
@@ -51,38 +49,65 @@ public abstract class OkHttpSender extends Sender {
   }
 
   public static Builder newBuilder() {
-    return new AutoValue_OkHttpSender.Builder()
-        .encoding(Encoding.JSON)
-        .compressionEnabled(true)
-        .maxRequests(64)
-        .messageMaxBytes(5 * 1024 * 1024);
+    return new Builder(new OkHttpClient.Builder());
   }
 
-  @AutoValue.Builder
-  public static abstract class Builder {
+  public static final class Builder {
+    final OkHttpClient.Builder clientBuilder;
+    HttpUrl endpoint;
+    Encoding encoding = Encoding.JSON;
+    boolean compressionEnabled = true;
+    int maxRequests = 64;
+    int messageMaxBytes = 5 * 1024 * 1024;
+
+    Builder(OkHttpClient.Builder clientBuilder) {
+      this.clientBuilder = clientBuilder;
+    }
+
+    Builder(OkHttpSender sender) {
+      clientBuilder = sender.client.newBuilder();
+      endpoint = sender.endpoint;
+      maxRequests = sender.client.dispatcher().getMaxRequests();
+      compressionEnabled = sender.compressionEnabled;
+      encoding = sender.encoding;
+      messageMaxBytes = sender.messageMaxBytes;
+    }
 
     /**
      * No default. The POST URL for zipkin's <a href="http://zipkin.io/zipkin-api/#/">v2 api</a>,
      * usually "http://zipkinhost:9411/api/v2/spans"
      */
     // customizable so that users can re-map /api/v2/spans ex for browser-originated traces
-    public final Builder endpoint(String endpoint) {
+    public Builder endpoint(String endpoint) {
       if (endpoint == null) throw new NullPointerException("endpoint == null");
       HttpUrl parsed = HttpUrl.parse(endpoint);
       if (parsed == null) throw new IllegalArgumentException("invalid post url: " + endpoint);
       return endpoint(parsed);
     }
 
-    public abstract Builder endpoint(HttpUrl endpoint);
+    public Builder endpoint(HttpUrl endpoint) {
+      if (endpoint == null) throw new NullPointerException("endpoint == null");
+      this.endpoint = endpoint;
+      return this;
+    }
 
     /** Default true. true implies that spans will be gzipped before transport. */
-    public abstract Builder compressionEnabled(boolean compressSpans);
+    public Builder compressionEnabled(boolean compressionEnabled) {
+      this.compressionEnabled = compressionEnabled;
+      return this;
+    }
 
     /** Maximum size of a message. Default 5MiB */
-    public abstract Builder messageMaxBytes(int messageMaxBytes);
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      this.messageMaxBytes = messageMaxBytes;
+      return this;
+    }
 
     /** Maximum in-flight requests. Default 64 */
-    public abstract Builder maxRequests(int maxRequests);
+    public Builder maxRequests(int maxRequests) {
+      this.maxRequests = maxRequests;
+      return this;
+    }
 
     /**
      * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
@@ -90,62 +115,84 @@ public abstract class OkHttpSender extends Sender {
      *
      * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
      */
-    public abstract Builder encoding(Encoding encoding);
+    public Builder encoding(Encoding encoding) {
+      if (encoding == null) throw new NullPointerException("encoding == null");
+      this.encoding = encoding;
+      return this;
+    }
 
     /** Sets the default connect timeout (in milliseconds) for new connections. Default 10000 */
     public final Builder connectTimeout(int connectTimeoutMillis) {
-      clientBuilder().connectTimeout(connectTimeoutMillis, MILLISECONDS);
+      clientBuilder.connectTimeout(connectTimeoutMillis, MILLISECONDS);
       return this;
     }
 
     /** Sets the default read timeout (in milliseconds) for new connections. Default 10000 */
     public final Builder readTimeout(int readTimeoutMillis) {
-      clientBuilder().readTimeout(readTimeoutMillis, MILLISECONDS);
+      clientBuilder.readTimeout(readTimeoutMillis, MILLISECONDS);
       return this;
     }
 
     /** Sets the default write timeout (in milliseconds) for new connections. Default 10000 */
     public final Builder writeTimeout(int writeTimeoutMillis) {
-      clientBuilder().writeTimeout(writeTimeoutMillis, MILLISECONDS);
+      clientBuilder.writeTimeout(writeTimeoutMillis, MILLISECONDS);
       return this;
     }
 
-    public abstract OkHttpClient.Builder clientBuilder();
-
-    abstract int maxRequests();
-
-    abstract Encoding encoding();
+    public OkHttpClient.Builder clientBuilder() {
+      return clientBuilder;
+    }
 
     public final OkHttpSender build() {
-      // bound the executor so that we get consistent performance
-      ThreadPoolExecutor dispatchExecutor =
-          new ThreadPoolExecutor(0, maxRequests(), 60, TimeUnit.SECONDS,
-              // Using a synchronous queue means messages will send immediately until we hit max
-              // in-flight requests. Once max requests are hit, send will block the caller, which is
-              // the AsyncReporter flush thread. This is ok, as the AsyncReporter has a buffer of
-              // unsent spans for this purpose.
-              new SynchronousQueue<>(),
-              Util.threadFactory("OkHttpSender Dispatcher", false));
-      Dispatcher dispatcher = new Dispatcher(dispatchExecutor);
-      dispatcher.setMaxRequests(maxRequests());
-      dispatcher.setMaxRequestsPerHost(maxRequests());
-      clientBuilder().dispatcher(dispatcher).build();
-      switch (encoding()) {
-        case JSON:
-          return encoder(RequestBodyMessageEncoder.JSON).autoBuild();
-        case PROTO3:
-          return encoder(RequestBodyMessageEncoder.PROTO3).autoBuild();
-        default:
-          throw new UnsupportedOperationException("Unsupported encoding: " + encoding().name());
-      }
+      return new OkHttpSender(this);
     }
+  }
 
-    abstract Builder encoder(RequestBodyMessageEncoder encoder);
+  final HttpUrl endpoint;
+  final OkHttpClient client;
+  final RequestBodyMessageEncoder encoder;
+  final Encoding encoding;
+  final int messageMaxBytes, maxRequests;
+  final boolean compressionEnabled;
 
-    abstract OkHttpSender autoBuild();
-
-    Builder() {
+  OkHttpSender(Builder builder) {
+    if (builder.endpoint == null) throw new NullPointerException("endpoint == null");
+    endpoint = builder.endpoint;
+    encoding = builder.encoding;
+    switch (encoding) {
+      case JSON:
+        encoder = RequestBodyMessageEncoder.JSON;
+        break;
+      case PROTO3:
+        encoder = RequestBodyMessageEncoder.PROTO3;
+        break;
+      default:
+        throw new UnsupportedOperationException("Unsupported encoding: " + encoding.name());
     }
+    maxRequests = builder.maxRequests;
+    messageMaxBytes = builder.messageMaxBytes;
+    compressionEnabled = builder.compressionEnabled;
+    Dispatcher dispatcher = newDispatcher(maxRequests);
+
+    // doing the extra "build" here prevents us from leaking our dispatcher to the builder
+    client = builder.clientBuilder().build().newBuilder().dispatcher(dispatcher).build();
+  }
+
+  static Dispatcher newDispatcher(int maxRequests) {
+    // bound the executor so that we get consistent performance
+    ThreadPoolExecutor dispatchExecutor =
+        new ThreadPoolExecutor(0, maxRequests, 60, TimeUnit.SECONDS,
+            // Using a synchronous queue means messages will send immediately until we hit max
+            // in-flight requests. Once max requests are hit, send will block the caller, which is
+            // the AsyncReporter flush thread. This is ok, as the AsyncReporter has a buffer of
+            // unsent spans for this purpose.
+            new SynchronousQueue<>(),
+            Util.threadFactory("OkHttpSender Dispatcher", false));
+
+    Dispatcher dispatcher = new Dispatcher(dispatchExecutor);
+    dispatcher.setMaxRequests(maxRequests);
+    dispatcher.setMaxRequestsPerHost(maxRequests);
+    return dispatcher;
   }
 
   /**
@@ -153,53 +200,46 @@ public abstract class OkHttpSender extends Sender {
    * customized, you'll need to re-apply those customizations.
    */
   public final Builder toBuilder() {
-    return new AutoValue_OkHttpSender.Builder()
-        .endpoint(endpoint())
-        .maxRequests(client().dispatcher().getMaxRequests())
-        .compressionEnabled(compressionEnabled())
-        .encoding(encoding())
-        .messageMaxBytes(messageMaxBytes());
+    return new Builder(this);
   }
 
-  abstract HttpUrl endpoint();
-
-  abstract OkHttpClient client();
-
-  abstract int maxRequests();
-
-  abstract boolean compressionEnabled();
-
-  abstract RequestBodyMessageEncoder encoder();
-
   @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
-    return encoding().listSizeInBytes(encodedSpans);
+    return encoding.listSizeInBytes(encodedSpans);
   }
 
   @Override public int messageSizeInBytes(int encodedSizeInBytes) {
-    return encoding().listSizeInBytes(encodedSizeInBytes);
+    return encoding.listSizeInBytes(encodedSizeInBytes);
+  }
+
+  @Override public Encoding encoding() {
+    return encoding;
+  }
+
+  @Override public int messageMaxBytes() {
+    return messageMaxBytes;
   }
 
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
 
-  /** The returned call sends spans as a POST to {@link #endpoint()}. */
+  /** The returned call sends spans as a POST to {@link Builder#endpoint(String)}. */
   @Override public zipkin2.Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new IllegalStateException("closed");
     Request request;
     try {
-      request = newRequest(encoder().encode(encodedSpans));
+      request = newRequest(encoder.encode(encodedSpans));
     } catch (IOException e) {
       throw zipkin2.internal.Platform.get().uncheckedIOException(e);
     }
-    return new HttpCall(client().newCall(request));
+    return new HttpCall(client.newCall(request));
   }
 
   /** Sends an empty json message to the configured endpoint. */
   @Override public CheckResult check() {
     try {
-      Request request = new Request.Builder().url(endpoint())
+      Request request = new Request.Builder().url(endpoint)
           .post(RequestBody.create(MediaType.parse("application/json"), "[]")).build();
-      try (Response response = client().newCall(request).execute()) {
+      try (Response response = client.newCall(request).execute()) {
         if (!response.isSuccessful()) {
           throw new IllegalStateException("check response failed: " + response);
         }
@@ -215,7 +255,7 @@ public abstract class OkHttpSender extends Sender {
     if (closeCalled) return;
     closeCalled = true;
 
-    Dispatcher dispatcher = client().dispatcher();
+    Dispatcher dispatcher = client.dispatcher();
     dispatcher.executorService().shutdown();
     try {
       if (!dispatcher.executorService().awaitTermination(1, TimeUnit.SECONDS)) {
@@ -227,8 +267,8 @@ public abstract class OkHttpSender extends Sender {
   }
 
   Request newRequest(RequestBody body) throws IOException {
-    Request.Builder request = new Request.Builder().url(endpoint());
-    if (compressionEnabled()) {
+    Request.Builder request = new Request.Builder().url(endpoint);
+    if (compressionEnabled) {
       request.addHeader("Content-Encoding", "gzip");
       Buffer gzipped = new Buffer();
       BufferedSink gzipSink = Okio.buffer(new GzipSink(gzipped));
@@ -241,10 +281,7 @@ public abstract class OkHttpSender extends Sender {
   }
 
   @Override public final String toString() {
-    return "OkHttpSender{" + endpoint() + "}";
-  }
-
-  OkHttpSender() {
+    return "OkHttpSender{" + endpoint + "}";
   }
 
   static final class BufferRequestBody extends RequestBody {

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -288,7 +288,7 @@ public class OkHttpSenderTest {
   }
 
   @Test public void bugGuardCache() throws Exception {
-    assertThat(sender.client().cache())
+    assertThat(sender.client.cache())
         .withFailMessage("senders should not open a disk cache")
         .isNull();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -132,25 +132,6 @@
       <artifactId>zipkin</artifactId>
       <version>${zipkin.version}</version>
     </dependency>
-    <!-- TODO: reconsider auto-value as it now requires an annotation jar dep -->
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value-annotations</artifactId>
-      <version>1.6</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
-      <version>1.6</version>
-      <scope>provided</scope>
-    </dependency>
-    <!-- generated code includes Generated annotations! -->
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.3.1</version>
-      <scope>provided</scope>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Before, auto-value could be provided. Now it requires a mandatory
annotation jar. This removes it vs staining the dependency tree.