### PR TITLE
Avoids use of IllegalStateException for server errors

### DIFF
--- a/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
+++ b/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
@@ -217,7 +217,7 @@ public final class RabbitMQSender extends Sender {
     try {
       return connectionFactory.newConnection(addresses);
     } catch (IOException | TimeoutException e) {
-      throw new IllegalStateException("Unable to establish connection to RabbitMQ server", e);
+      throw new RuntimeException("Unable to establish connection to RabbitMQ server", e);
     }
   }
 

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
@@ -107,7 +107,7 @@ public class RabbitMQSenderTest {
     CheckResult check = sender.check();
     assertThat(check.ok()).isFalse();
     assertThat(check.error())
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(RuntimeException.class);
   }
 
   @Test

--- a/benchmarks/src/main/java/zipkin2/reporter/SenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/SenderBenchmarks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2017 The OpenZipkin Authors
+ * Copyright 2016-2018 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -94,7 +94,7 @@ public abstract class SenderBenchmarks {
     sender = createSender();
 
     CheckResult senderCheck = sender.check();
-    if (!senderCheck.ok()) throw new IllegalStateException("sender not ok", senderCheck.error());
+    if (!senderCheck.ok()) throw senderCheck.error();
 
     reporter = (AsyncReporter.BoundedAsyncReporter<Span>) AsyncReporter.builder(sender)
         .messageMaxBytes(messageMaxBytes)

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/HttpCall.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/HttpCall.java
@@ -80,7 +80,7 @@ final class HttpCall extends Call<Void> {
       if (response.isSuccessful()) {
         return;
       } else {
-        throw new IllegalStateException("response failed: " + response);
+        throw new RuntimeException("response failed: " + response);
       }
     }
     try (ResponseBody responseBody = response.body()) {
@@ -89,7 +89,7 @@ final class HttpCall extends Call<Void> {
         content = Okio.buffer(new GzipSource(responseBody.source()));
       }
       if (!response.isSuccessful()) {
-        throw new IllegalStateException(
+        throw new RuntimeException(
             "response for " + response.request().tag() + " failed: " + content.readUtf8());
       }
     }

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -241,7 +241,7 @@ public final class OkHttpSender extends Sender {
           .post(RequestBody.create(MediaType.parse("application/json"), "[]")).build();
       try (Response response = client.newCall(request).execute()) {
         if (!response.isSuccessful()) {
-          throw new IllegalStateException("check response failed: " + response);
+          return CheckResult.failed(new RuntimeException("check response failed: " + response));
         }
       }
       return CheckResult.OK;


### PR DESCRIPTION
ISE isn't a great choice for server errors. Notably, it will kill the
reporter thread for scenarios that are sometimes resolvable. This
reserves IllegalStateException for state machine errors instead.

Fixes #108