### PR TITLE
Re-adds libthrift (scribe) sender

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <main.basedir>${project.basedir}/../..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.8.4</zipkin.version>
+    <zipkin.version>2.9.0</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>
@@ -84,6 +84,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-sender-okhttp3</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-sender-libthrift</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2018 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <version>2.6.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>zipkin-sender-libthrift</artifactId>
+  <name>Zipkin Sender: libthrift (Scribe)</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-collector-scribe</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>zipkin2.reporter.libthrift</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/InternalScribeCodec.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/InternalScribeCodec.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.libthrift;
+
+import java.util.List;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TList;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TMessageType;
+import org.apache.thrift.protocol.TProtocolUtil;
+import org.apache.thrift.protocol.TType;
+
+import static org.apache.thrift.TApplicationException.BAD_SEQUENCE_ID;
+import static org.apache.thrift.TApplicationException.MISSING_RESULT;
+
+final class InternalScribeCodec {
+
+  static final TField CATEGORY_FIELD_DESC = new TField("category", TType.STRING, (short) 1);
+  static final TField MESSAGE_FIELD_DESC = new TField("message", TType.STRING, (short) 2);
+  static final TField MESSAGES_FIELD_DESC = new TField("messages", TType.LIST, (short) 1);
+
+  static int messageSizeInBytes(byte[] category, List<byte[]> encodedSpans) {
+    int sizeInBytes = 12 + 3; // messageBegin = overhead + size of "Log"
+    sizeInBytes += 5; // FieldBegin
+    sizeInBytes += 5; // ListBegin
+    for (byte[] encodedSpan : encodedSpans) {
+      sizeInBytes += sizeOfLogEntry(category, encodedSpan);
+    }
+    sizeInBytes += 1; // FieldStop
+    return sizeInBytes;
+  }
+
+  static void writeLogRequest(
+      byte[] category, List<byte[]> encodedSpans, int seqid, TBinaryProtocol oprot)
+      throws TException {
+    oprot.writeMessageBegin(new TMessage("Log", TMessageType.CALL, seqid));
+    oprot.writeFieldBegin(MESSAGES_FIELD_DESC);
+    oprot.writeListBegin(new TList(TType.STRUCT, encodedSpans.size()));
+    for (byte[] encodedSpan : encodedSpans) write(category, encodedSpan, oprot);
+    oprot.writeFieldStop();
+  }
+
+  /** Returns false if the scribe response was try later. */
+  public static boolean readLogResponse(int seqid, TBinaryProtocol iprot) throws TException {
+    TMessage msg = iprot.readMessageBegin();
+    if (msg.type == TMessageType.EXCEPTION) {
+      throw TApplicationException.read(iprot);
+    } else if (msg.seqid != seqid) {
+      throw new TApplicationException(BAD_SEQUENCE_ID, "Log failed: out of sequence response");
+    }
+    return parseResponse(iprot);
+  }
+
+  static boolean parseResponse(TBinaryProtocol iprot) throws TException {
+    iprot.readStructBegin();
+    TField schemeField;
+    while ((schemeField = iprot.readFieldBegin()).type != TType.STOP) {
+      if (schemeField.id == 0 /* SUCCESS */ && schemeField.type == TType.I32) {
+        return iprot.readI32() == 0;
+      } else {
+        TProtocolUtil.skip(iprot, schemeField.type);
+      }
+    }
+    throw new TApplicationException(MISSING_RESULT, "Log failed: unknown result");
+  }
+
+  static int sizeOfLogEntry(byte[] category, byte[] span) {
+    int sizeInBytes = 5 + 4 + category.length;
+    sizeInBytes += 5 + 4 + base64SizeInBytes(span);
+    sizeInBytes++; // stop
+    return sizeInBytes;
+  }
+
+  static void write(byte[] category, byte[] span, TBinaryProtocol oprot) throws TException {
+    oprot.writeFieldBegin(CATEGORY_FIELD_DESC);
+    oprot.writeI32(category.length);
+    oprot.getTransport().write(category, 0, category.length);
+
+    oprot.writeFieldBegin(MESSAGE_FIELD_DESC);
+    byte[] base64 = base64(span);
+    oprot.writeI32(base64.length);
+    oprot.getTransport().write(base64, 0, base64.length);
+    oprot.writeFieldStop();
+  }
+
+  static final byte[] MAP =
+      new byte[] {
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+            'S',
+        'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
+            'l',
+        'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3',
+            '4',
+        '5', '6', '7', '8', '9', '+', '/'
+      };
+
+  /**
+   * Adapted from okio.Base64 as JRE 6 doesn't have a base64Url encoder
+   *
+   * <p>Original author: Alexander Y. Kleymenov
+   */
+  static byte[] base64(byte[] in) {
+    int length = base64SizeInBytes(in);
+    byte[] out = new byte[length];
+    int index = 0, end = in.length - in.length % 3;
+    for (int i = 0; i < end; i += 3) {
+      out[index++] = MAP[(in[i] & 0xff) >> 2];
+      out[index++] = MAP[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      out[index++] = MAP[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      out[index++] = MAP[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        out[index++] = MAP[(in[end] & 0xff) >> 2];
+        out[index++] = MAP[(in[end] & 0x03) << 4];
+        out[index++] = '=';
+        out[index++] = '=';
+        break;
+      case 2:
+        out[index++] = MAP[(in[end] & 0xff) >> 2];
+        out[index++] = MAP[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        out[index++] = MAP[((in[end + 1] & 0x0f) << 2)];
+        out[index++] = '=';
+        break;
+    }
+    return out;
+  }
+
+  static int base64SizeInBytes(byte[] in) {
+    return (in.length + 2) * 4 / 3;
+  }
+}

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/LibthriftSender.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.libthrift;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.apache.thrift.TException;
+import zipkin2.Call;
+import zipkin2.Callback;
+import zipkin2.CheckResult;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.Sender;
+
+/**
+ * Blocking reporter that sends spans to Zipkin via Scribe.
+ *
+ * <p>This sender is not thread-safe.
+ */
+public final class LibthriftSender extends Sender {
+  /** Creates a sender that sends {@link Encoding#THRIFT} messages. */
+  public static LibthriftSender create(String host) {
+    return newBuilder().host(host).build();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    String host;
+    int port = 9410;
+    int messageMaxBytes = 16384000; // TFramedTransport.DEFAULT_MAX_LENGTH
+    int connectTimeout = 10 * 1000, socketTimeout = 60 * 1000;
+
+    Builder(LibthriftSender sender) {
+      this.host = sender.host;
+      this.messageMaxBytes = sender.messageMaxBytes;
+      this.connectTimeout = sender.connectTimeout;
+      this.socketTimeout = sender.socketTimeout;
+      this.port = sender.port;
+    }
+
+    /** No default. The host listening for scribe messages. */
+    public Builder host(String host) {
+      if (host == null) throw new NullPointerException("host == null");
+      this.host = host;
+      return this;
+    }
+
+    /** Default 9410. The port listening for scribe messages. */
+    public Builder port(int port) {
+      this.port = port;
+      return this;
+    }
+
+    /** Default 60 * 1000 milliseconds. 0 implies no timeout. */
+    public Builder socketTimeout(int socketTimeout) {
+      this.socketTimeout = socketTimeout;
+      return this;
+    }
+    /** Default 10 * 1000 milliseconds. 0 implies no timeout. */
+    public Builder connectTimeout(int connectTimeout) {
+      this.connectTimeout = connectTimeout;
+      return this;
+    }
+
+    /** Maximum size of a message. Default 16384000 */
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      this.messageMaxBytes = messageMaxBytes;
+      return this;
+    }
+
+    public final LibthriftSender build() {
+      return new LibthriftSender(this);
+    }
+
+    Builder() {}
+  }
+
+  final String host;
+  final int port;
+  final int messageMaxBytes;
+  final int connectTimeout, socketTimeout;
+
+  LibthriftSender(Builder builder) {
+    if (builder.host == null) throw new NullPointerException("host == null");
+    this.host = builder.host;
+    this.messageMaxBytes = builder.messageMaxBytes;
+    this.connectTimeout = builder.connectTimeout;
+    this.socketTimeout = builder.socketTimeout;
+    this.port = builder.port;
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public Encoding encoding() {
+    return Encoding.THRIFT;
+  }
+
+  @Override public int messageMaxBytes() {
+    return messageMaxBytes;
+  }
+
+  /** Size of the Thrift RPC message */
+  @Override
+  public int messageSizeInBytes(List<byte[]> encodedSpans) {
+    return ScribeClient.messageSizeInBytes(encodedSpans);
+  }
+
+  @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+    if (closeCalled) throw new IllegalStateException("closed");
+    return new ScribeCall(encodedSpans);
+  }
+
+  ScribeClient get() {
+    if (client == null) {
+      synchronized (this) {
+        if (client == null) {
+          client = new ScribeClient(host, port, socketTimeout, connectTimeout);
+        }
+      }
+    }
+    return client;
+  }
+
+  /** close is typically called from a different thread */
+  private volatile boolean closeCalled;
+  private volatile ScribeClient client;
+
+  /** Sends an empty log message to the configured host. */
+  @Override
+  public CheckResult check() {
+    try {
+      if (get().log(Collections.emptyList())) {
+        return CheckResult.OK;
+      }
+      throw new IllegalStateException("try later");
+    } catch (Exception e) {
+      return CheckResult.failed(e);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (closeCalled) return;
+    closeCalled = true;
+    super.close();
+  }
+
+  @Override
+  public final String toString() {
+    return "LibthriftSender(" + host + ":" + port + ")";
+  }
+
+  class ScribeCall extends Call.Base<Void> {
+    final List<byte[]> encodedSpans;
+
+    ScribeCall(List<byte[]> encodedSpans) {
+      this.encodedSpans = encodedSpans;
+    }
+
+    @Override protected Void doExecute() throws IOException {
+      try {
+        if (!get().log(encodedSpans)) {
+          throw new IllegalStateException("try later");
+        }
+      } catch (TException e) {
+        throw new IOException(e);
+      }
+      return null;
+    }
+
+    @Override protected void doEnqueue(Callback<Void> callback) {
+      try {
+        if (get().log(encodedSpans)) {
+          callback.onSuccess(null);
+        } else {
+          callback.onError(new IllegalStateException("try later"));
+        }
+        callback.onSuccess(null);
+      } catch (TException |RuntimeException | Error e) {
+        callback.onError(e);
+      }
+    }
+
+    @Override public Call<Void> clone() {
+      return new ScribeCall(encodedSpans);
+    }
+  }
+}

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/ScribeClient.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/ScribeClient.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.libthrift;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransportException;
+
+final class ScribeClient implements Closeable {
+  static final Logger logger = Logger.getLogger(ScribeClient.class.getName());
+  static final byte[] category = new byte[] {'z', 'i', 'p', 'k', 'i', 'n'};
+
+  final TSocket socket;
+  final TBinaryProtocol prot;
+
+  ScribeClient(String host, int port, int socketTimeout, int connectTimeout) {
+    socket = new TSocket(host, port, socketTimeout, connectTimeout);
+    prot = new TBinaryProtocol(new TFramedTransport(socket));
+  }
+
+  static int messageSizeInBytes(List<byte[]> encodedSpans) {
+    return InternalScribeCodec.messageSizeInBytes(category, encodedSpans);
+  }
+
+  private int seqid_;
+
+  boolean log(List<byte[]> encodedSpans) throws TException {
+    try {
+      if (!socket.isOpen()) socket.open();
+      InternalScribeCodec.writeLogRequest(category, encodedSpans, ++seqid_, prot);
+      prot.getTransport().flush();
+      return InternalScribeCodec.readLogResponse(seqid_, prot);
+    } catch (TTransportException e) {
+      logger.log(Level.FINE, "Transport exception. recreating socket", e);
+      socket.close();
+      seqid_ = 0;
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() {
+    socket.close();
+  }
+}

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/LibthriftSenderTest.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/LibthriftSenderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.libthrift;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.collector.CollectorMetrics;
+import zipkin2.collector.scribe.ScribeCollector;
+import zipkin2.storage.InMemoryStorage;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static zipkin2.reporter.TestObjects.CLIENT_SPAN;
+
+public class LibthriftSenderTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  InMemoryStorage storage = InMemoryStorage.newBuilder().build();
+  ScribeCollector collector;
+
+  @Before
+  public void start() {
+    collector =
+        ScribeCollector.newBuilder()
+            .metrics(CollectorMetrics.NOOP_METRICS)
+            .storage(storage)
+            .build();
+    collector.start();
+  }
+
+  @After
+  public void close() {
+    collector.close();
+  }
+
+  LibthriftSender sender = LibthriftSender.create("127.0.0.1");
+
+  @Test
+  public void sendsSpans() throws Exception {
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat(storage.spanStore().getTraces()).containsExactly(asList(CLIENT_SPAN, CLIENT_SPAN));
+  }
+
+  @Test
+  public void check_okWhenScribeIsListening() {
+    assertThat(sender.check().ok()).isTrue();
+  }
+
+  @Test
+  public void check_notOkWhenScribeIsDown() throws Exception {
+    collector.close();
+
+    assertThat(sender.check().ok()).isFalse();
+  }
+
+  @Test
+  public void reconnects() throws Exception {
+    close();
+    try {
+      send(CLIENT_SPAN, CLIENT_SPAN);
+      failBecauseExceptionWasNotThrown(IOException.class);
+    } catch (IOException e) {
+    }
+    start();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat(storage.spanStore().getTraces()).containsExactly(asList(CLIENT_SPAN, CLIENT_SPAN));
+  }
+
+  @Test
+  public void illegalToSendWhenClosed() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    sender.close();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  /**
+   * The output of toString() on {@link zipkin2.reporter.Sender} implementations appears in thread
+   * names created by {@link zipkin2.reporter.AsyncReporter}. Since thread names are likely to be
+   * exposed in logs and other monitoring tools, care should be taken to ensure the toString()
+   * output is a reasonable length and does not contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySenderTypeHostAndPort() {
+    assertThat(sender.toString())
+        .isEqualTo("LibthriftSender(" + sender.host + ":" + sender.port + ")");
+  }
+
+  /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
+  void send(Span... spans) throws IOException {
+    List<byte[]> encodedSpans =
+        Stream.of(spans).map(SpanBytesEncoder.THRIFT::encode).collect(toList());
+    sender.sendSpans(encodedSpans).execute();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>amqp-client</module>
     <module>urlconnection</module>
     <module>okhttp3</module>
+    <module>libthrift</module>
     <module>spring-beans</module>
     <module>benchmarks</module>
   </modules>
@@ -45,7 +46,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.8.4</zipkin.version>
+    <zipkin.version>2.9.0</zipkin.version>
     <license-maven-plugin.version>2.11</license-maven-plugin.version>
   </properties>
 

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -49,12 +49,12 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <artifactId>zipkin-sender-libthrift</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/LibthriftSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/LibthriftSenderFactoryBean.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.libthrift.LibthriftSender;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class LibthriftSenderFactoryBean extends AbstractFactoryBean {
+
+  String host;
+  Integer connectTimeout, socketTimeout;
+  Integer port;
+  Integer messageMaxBytes;
+
+  @Override
+  protected LibthriftSender createInstance() throws Exception {
+    LibthriftSender.Builder builder = LibthriftSender.newBuilder();
+    if (host != null) builder.host(host);
+    if (port != null) builder.port(port);
+    if (socketTimeout != null) builder.socketTimeout(socketTimeout);
+    if (connectTimeout != null) builder.connectTimeout(connectTimeout);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    return builder.build();
+  }
+
+  @Override
+  public Class<? extends LibthriftSender> getObjectType() {
+    return LibthriftSender.class;
+  }
+
+  @Override
+  public boolean isSingleton() {
+    return true;
+  }
+
+  @Override
+  protected void destroyInstance(Object instance) throws Exception {
+    ((LibthriftSender) instance).close();
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public void setSocketTimeout(Integer socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
+
+  public void setConnectTimeout(Integer connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/LibthriftSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/LibthriftSenderFactoryBeanTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.libthrift.LibthriftSender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LibthriftSenderFactoryBeanTest {
+  XmlBeans context;
+
+  @After
+  public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test
+  public void host() throws MalformedURLException {
+    context =
+        new XmlBeans(
+            ""
+                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                + "  <property name=\"host\" value=\"myhost\"/>\n"
+                + "</bean>");
+
+    assertThat(context.getBean("sender", LibthriftSender.class))
+        .extracting("host")
+        .containsExactly("myhost");
+  }
+
+  @Test
+  public void connectTimeout() {
+    context =
+        new XmlBeans(
+            ""
+                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                + "  <property name=\"host\" value=\"myhost\"/>\n"
+                + "  <property name=\"connectTimeout\" value=\"0\"/>\n"
+                + "</bean>");
+
+    assertThat(context.getBean("sender", LibthriftSender.class))
+        .isEqualToComparingFieldByField(
+            LibthriftSender.newBuilder().host("myhost").connectTimeout(0).build());
+  }
+
+  @Test
+  public void socketTimeout() {
+    context =
+        new XmlBeans(
+            ""
+                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                + "  <property name=\"host\" value=\"myhost\"/>\n"
+                + "  <property name=\"socketTimeout\" value=\"0\"/>\n"
+                + "</bean>");
+
+    assertThat(context.getBean("sender", LibthriftSender.class))
+        .isEqualToComparingFieldByField(
+            LibthriftSender.newBuilder().host("myhost").socketTimeout(0).build());
+  }
+
+  @Test
+  public void port() {
+    context =
+        new XmlBeans(
+            ""
+                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                + "  <property name=\"host\" value=\"myhost\"/>\n"
+                + "  <property name=\"port\" value=\"1000\"/>\n"
+                + "</bean>");
+
+    assertThat(context.getBean("sender", LibthriftSender.class))
+        .extracting("port")
+        .containsExactly(1000);
+  }
+
+  @Test
+  public void messageMaxBytes() {
+    context =
+        new XmlBeans(
+            ""
+                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                + "  <property name=\"host\" value=\"myhost\"/>\n"
+                + "  <property name=\"messageMaxBytes\" value=\"1024\"/>\n"
+                + "</bean>");
+
+    assertThat(context.getBean("sender", LibthriftSender.class))
+        .extracting("messageMaxBytes")
+        .containsExactly(1024);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void close_closesSender() {
+    context =
+        new XmlBeans(
+            ""
+                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                + "  <property name=\"host\" value=\"myhost\"/>\n"
+                + "</bean>");
+
+    LibthriftSender sender = context.getBean("sender", LibthriftSender.class);
+    context.close();
+
+    sender.sendSpans(Arrays.asList(new byte[0]));
+  }
+}


### PR DESCRIPTION
Re-adding the libthrift (scribe) sender to help folks migrate code.
This is possible as zipkin 2.9 has backported thrift encoding.

See #95
See https://github.com/openzipkin/zipkin/issues/2047