### PR TITLE
Adds thrift encoding

### DIFF
--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -162,6 +162,8 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
           return build(SpanBytesEncoder.JSON_V2);
         case PROTO3:
           return build(SpanBytesEncoder.PROTO3);
+        case THRIFT:
+          return build(SpanBytesEncoder.THRIFT);
         default:
           throw new UnsupportedOperationException(sender.encoding().name());
       }

--- a/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
@@ -426,4 +426,33 @@ public class AsyncReporterTest {
           }
         });
   }
+
+  @Test public void build_thrift() {
+    AsyncReporter.builder(FakeSender.create().encoding(Encoding.THRIFT))
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        .build();
+  }
+
+  @Test public void build_thrift_withCustomBytesEncoder() {
+    AsyncReporter.builder(FakeSender.create().encoding(Encoding.THRIFT))
+        .messageTimeout(0, TimeUnit.MILLISECONDS)
+        // there's no builtin protobuf format of zipkin spans, yet, so there's no encoder
+        .build(new BytesEncoder<Span>() {
+          @Override public Encoding encoding() {
+            return Encoding.THRIFT;
+          }
+
+          @Override public int sizeInBytes(Span input) {
+            return 0;
+          }
+
+          @Override public byte[] encode(Span input) {
+            return new byte[0];
+          }
+
+          @Override public byte[] encodeList(List<Span> input) {
+            return new byte[0];
+          }
+        });
+  }
 }

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -32,6 +32,7 @@ import okio.GzipSink;
 import okio.Okio;
 import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
+import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.Sender;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -162,6 +163,9 @@ public final class OkHttpSender extends Sender {
     switch (encoding) {
       case JSON:
         encoder = RequestBodyMessageEncoder.JSON;
+        break;
+      case THRIFT:
+        this.encoder = RequestBodyMessageEncoder.THRIFT;
         break;
       case PROTO3:
         encoder = RequestBodyMessageEncoder.PROTO3;

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -105,6 +105,21 @@ public class OkHttpSenderTest {
         .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
+  @Test public void sendsSpans_THRIFT() throws Exception {
+    sender = sender.toBuilder().encoding(Encoding.THRIFT).build();
+
+    server.enqueue(new MockResponse());
+
+    send(CLIENT_SPAN, CLIENT_SPAN).execute();
+
+    // Ensure only one request was sent
+    assertThat(server.getRequestCount()).isEqualTo(1);
+
+    // Now, let's read back the spans we sent!
+    assertThat(SpanBytesDecoder.THRIFT.decodeList(server.takeRequest().getBody().readByteArray()))
+        .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
   @Test public void compression() throws Exception {
     List<RecordedRequest> requests = new ArrayList<>();
     for (boolean compressionEnabled : asList(true, false)) {
@@ -294,8 +309,20 @@ public class OkHttpSenderTest {
   }
 
   Call<Void> send(Span... spans) {
-    SpanBytesEncoder bytesEncoder = sender.encoding() == Encoding.JSON
-        ? SpanBytesEncoder.JSON_V2 : SpanBytesEncoder.PROTO3;
+    SpanBytesEncoder bytesEncoder;
+    switch (sender.encoding()) {
+      case JSON:
+        bytesEncoder = SpanBytesEncoder.JSON_V2;
+        break;
+      case THRIFT:
+        bytesEncoder = SpanBytesEncoder.THRIFT;
+        break;
+      case PROTO3:
+        bytesEncoder = SpanBytesEncoder.PROTO3;
+        break;
+      default:
+        throw new UnsupportedOperationException("encoding: " + sender.encoding());
+    }
     return sender.sendSpans(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
   }
 }

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -141,6 +141,10 @@ public final class URLConnectionSender extends Sender {
         this.mediaType = "application/json";
         this.encoder = BytesMessageEncoder.JSON;
         break;
+      case THRIFT:
+        this.mediaType = "application/x-thrift";
+        this.encoder = BytesMessageEncoder.THRIFT;
+        break;
       case PROTO3:
         this.mediaType = "application/x-protobuf";
         this.encoder = BytesMessageEncoder.PROTO3;


### PR DESCRIPTION
This adds backported thrift encoding needed for Scribe and any kafka or http senders to old collectors.