### PR TITLE
Changed how dropped messages are counted in InMemoryReporterMetrics t…

### DIFF
--- a/core/src/main/java/zipkin2/reporter/InMemoryReporterMetrics.java
+++ b/core/src/main/java/zipkin2/reporter/InMemoryReporterMetrics.java
@@ -30,9 +30,9 @@ public final class InMemoryReporterMetrics implements ReporterMetrics {
   }
 
   private final ConcurrentHashMap<MetricKey, AtomicLong> metrics =
-      new ConcurrentHashMap<MetricKey, AtomicLong>();
-  private final ConcurrentHashMap<Throwable, AtomicLong> messagesDropped =
-      new ConcurrentHashMap<Throwable, AtomicLong>();
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Class<? extends Throwable>, AtomicLong> messagesDropped =
+      new ConcurrentHashMap<>();
 
   @Override public void incrementMessages() {
     increment(MetricKey.messages, 1);
@@ -43,12 +43,12 @@ public final class InMemoryReporterMetrics implements ReporterMetrics {
   }
 
   @Override public void incrementMessagesDropped(Throwable cause) {
-    increment(messagesDropped, cause, 1);
+    increment(messagesDropped, cause.getClass(), 1);
   }
 
-  public Map<Throwable, Long> messagesDroppedByCause() {
-    Map<Throwable, Long> result = new LinkedHashMap<Throwable, Long>(messagesDropped.size());
-    for (Map.Entry<Throwable, AtomicLong> kv : messagesDropped.entrySet()) {
+  public Map<Class<? extends Throwable>, Long> messagesDroppedByCause() {
+    Map<Class<? extends Throwable>, Long> result = new LinkedHashMap<>(messagesDropped.size());
+    for (Map.Entry<Class<? extends Throwable>, AtomicLong> kv : messagesDropped.entrySet()) {
       result.put(kv.getKey(), kv.getValue().longValue());
     }
     return result;

--- a/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
@@ -289,7 +289,7 @@ public class AsyncReporterTest {
     assertThat(metrics.spansDropped()).isEqualTo(1);
     assertThat(metrics.messagesDropped()).isEqualTo(1);
     assertThat(metrics.messagesDroppedByCause().keySet().iterator().next())
-        .isInstanceOf(IllegalStateException.class);
+        .isEqualTo(IllegalStateException.class);
   }
 
   @Test

--- a/core/src/test/java/zipkin2/reporter/InMemoryReporterMetricsTest.java
+++ b/core/src/test/java/zipkin2/reporter/InMemoryReporterMetricsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2018 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InMemoryReporterMetricsTest {
+  @Test
+  public void incrementMessagesDropped_sameExceptionTypeIsNotCountedMoreThanOnce() {
+    InMemoryReporterMetrics inMemoryReporterMetrics = new InMemoryReporterMetrics();
+
+    inMemoryReporterMetrics.incrementMessagesDropped(new RuntimeException());
+    inMemoryReporterMetrics.incrementMessagesDropped(new RuntimeException());
+    inMemoryReporterMetrics.incrementMessagesDropped(new IllegalStateException());
+
+    assertThat(inMemoryReporterMetrics.messagesDroppedByCause().get(RuntimeException.class)).isEqualTo(2);
+    assertThat(inMemoryReporterMetrics.messagesDroppedByCause().get(IllegalStateException.class)).isEqualTo(1);
+    assertThat(inMemoryReporterMetrics.messagesDroppedByCause().size()).isEqualTo(2);
+  }
+
+  @Test
+  public void incrementMessagesDropped_multipleOccurrencesOfSameExceptionTypeAreCounted() {
+    InMemoryReporterMetrics inMemoryReporterMetrics = new InMemoryReporterMetrics();
+
+    inMemoryReporterMetrics.incrementMessagesDropped(new RuntimeException());
+    inMemoryReporterMetrics.incrementMessagesDropped(new RuntimeException());
+    inMemoryReporterMetrics.incrementMessagesDropped(new IllegalStateException());
+
+    assertThat(inMemoryReporterMetrics.messagesDropped()).isEqualTo(3);
+  }
+}


### PR DESCRIPTION
…o prevent unbounded memory usage.

The current implementation of `InMemoryReporterMetrics` keeps a `Map<Throwable, Long>` to count the number of dropped messages. Most `Throwable`s don't override `equals` so every dropped message results in a new entry, causing the memory usage to grow over time. 

(I'm not sure if `InMemoryReporterMetrics` is even intended to be used outside of tests, but `spring-cloud-sleuth` does use it as its autoconfigured `ReporterMetrics` implementation)