### PR TITLE
Bug: Fix the criterion for judging whether the span buffer is full

### DIFF
--- a/core/src/main/java/zipkin2/reporter/BufferNextMessage.java
+++ b/core/src/main/java/zipkin2/reporter/BufferNextMessage.java
@@ -134,7 +134,10 @@ abstract class BufferNextMessage<S> implements SpanWithSizeConsumer<S> {
     int y = maxBytes;
     int includingNextVsMaxBytes = (x < y) ? -1 : ((x == y) ? 0 : 1); // Integer.compare, but JRE 6
 
-    if (includingNextVsMaxBytes > 0) return false; // can't fit the next message into this buffer
+    if (includingNextVsMaxBytes > 0) {
+      bufferFull = true;
+      return false; // can't fit the next message into this buffer
+    }
 
     addSpanToBuffer(next, nextSizeInBytes);
     messageSizeInBytes = x;

--- a/core/src/test/java/zipkin2/reporter/BufferNextMessageTest.java
+++ b/core/src/test/java/zipkin2/reporter/BufferNextMessageTest.java
@@ -62,6 +62,8 @@ public class BufferNextMessageTest {
     assertThat(pending.offer(4, 1))
         // should drop because 4 implies ",4" which makes the total length 11
         .isFalse();
+    // then we should consider buffer is full and drain all
+    assertThat(pending.bufferFull).isTrue();
   }
 
   @Test public void drain_json() {
@@ -144,6 +146,8 @@ public class BufferNextMessageTest {
     assertThat(pending.offer(3, 3))
         // should drop because this implies adding 3 bytes which makes the total length 12
         .isFalse();
+    // then we should consider buffer is full and drain all
+    assertThat(pending.bufferFull).isTrue();
   }
 
   @Test public void drain_proto3() {


### PR DESCRIPTION
It is nearly impossible to meet the the ```bufferFull``` criterion of BufferNextMessage, because the total span bytes size in buffer is almost impossible to be exactly equal to the ```maxBytes``` threshold. 

In our use case, we use KafkaSender with default value for ```maxBytes```(1000000 bytes),  when the span generation speed is over 1MiB per second, reporter began to drop spans, and the ```Messages Sended Per Second``` metric stabilized at 1/s due to buffer timeout.

The solution for this issue is quite straightforward, just set ```bufferFull``` to 'true' when the total span bytes size greater than or equal to ```maxBytes```.