### PR TITLE
Add .editorconfig file to encourage consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Copied from the Zipkin repo.

I wanted to add this when I was working on a contribution and my IDE decided to make the new file with 4 space indenting because it didn't know any better.