### PR TITLE
Micrometer implementation of ReporterMetrics

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -121,6 +121,11 @@
         <artifactId>zipkin-reporter-spring-beans</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter-metrics-micrometer</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/metrics-micrometer/README.md
+++ b/metrics-micrometer/README.md
@@ -1,0 +1,23 @@
+Zipkin Reporter Metrics by Micrometer
+=====
+
+This module provides an implementation of Zipkin Reporter's `ReporterMetrics` for [Micrometer](https://micrometer.io).
+
+Usage
+---
+
+Pass an instance of `MicrometerReporterMetrics` to the `AsyncReporter` builder like below.
+
+```java
+reporter = AsyncReporter.builder(sender).metrics(MicrometerReporterMetrics.create(meterRegistry)).build();
+```
+
+### Extra tags
+
+You may optionally configure Micrometer tags to add to all reporter metrics created using the builder.
+
+For example, if an equivalent common tag is not already configured, you will want the Zipkin service name to be tagged so reporter metrics can be differentiated by service.
+
+```java
+MicrometerReporterMetrics reporterMetrics = MicrometerReporterMetrics.builder(meterRegistry).extraTags(reporterTags).build();
+```

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <version>2.7.16-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <artifactId>zipkin-reporter-metrics-micrometer</artifactId>
+  <name>Zipkin Reporter Metrics by Micrometer</name>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+    <!-- Micrometer is Java 1.8 bytecode -->
+    <main.java.version>1.8</main.java.version>
+    <main.signature.artifact>java18</main.signature.artifact>
+    <micrometer.version>1.0.9</micrometer.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>${micrometer.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- disable retrolambda as we allow language level 1.8 benchmark classes -->
+      <plugin>
+        <groupId>net.orfjackal.retrolambda</groupId>
+        <artifactId>retrolambda-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>zipkin2.reporter.metrics.micrometer</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/metrics-micrometer/src/main/java/zipkin2/reporter/metrics/micrometer/MicrometerReporterMetrics.java
+++ b/metrics-micrometer/src/main/java/zipkin2/reporter/metrics/micrometer/MicrometerReporterMetrics.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.metrics.micrometer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import zipkin2.reporter.ReporterMetrics;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Implementation of {@link ReporterMetrics} with Micrometer.
+ */
+public class MicrometerReporterMetrics implements ReporterMetrics {
+
+  private static final String PREFIX = "zipkin.reporter.";
+
+  final MeterRegistry meterRegistry;
+  final Iterable<Tag> extraTags;
+
+  final Counter messages;
+  final Counter messageBytes;
+  final Counter spans;
+  final Counter spanBytes;
+  final Counter spansDropped;
+  final AtomicInteger queuedSpans;
+  final AtomicInteger queuedBytes;
+
+  /**
+   * Creates a {@link MicrometerReporterMetrics} instance that registers all metrics to the given {@link MeterRegistry}.
+   * Any other options use the default. To customize other options, use {@link #builder(MeterRegistry)} instead.
+   *
+   * @param meterRegistry all metrics will be registered to this registry
+   */
+  public static MicrometerReporterMetrics create(MeterRegistry meterRegistry) {
+    return new Builder(meterRegistry).build();
+  }
+
+  /**
+   * Like {@link #create(MeterRegistry)} but returns a builder where you can customize optional settings like extra tags.
+   */
+  public static Builder builder(MeterRegistry meterRegistry) {
+    return new Builder(meterRegistry);
+  }
+
+  private MicrometerReporterMetrics(MeterRegistry meterRegistry, Tag... extraTags) {
+    this.meterRegistry = meterRegistry;
+    this.extraTags = Arrays.asList(extraTags);
+
+    messages = Counter.builder(PREFIX + "messages.total")
+      .description("Messages reported (or attempted to be reported)")
+      .tags(this.extraTags).register(meterRegistry);
+    messageBytes = Counter.builder(PREFIX + "messages")
+      .description("Total bytes of messages reported")
+      .baseUnit("bytes")
+      .tags(this.extraTags).register(meterRegistry);
+    spans = Counter.builder(PREFIX + "spans.total")
+      .description("Spans reported")
+      .tags(this.extraTags).register(meterRegistry);
+    spanBytes = Counter.builder(PREFIX + "spans")
+      .description("Total bytes of encoded spans reported")
+      .baseUnit("bytes")
+      .tags(this.extraTags).register(meterRegistry);
+    spansDropped = Counter.builder(PREFIX + "spans.dropped")
+      .description("Spans dropped (failed to report)")
+      .tags(this.extraTags).register(meterRegistry);
+    queuedSpans = new AtomicInteger();
+    Gauge.builder(PREFIX + "queue.spans", queuedSpans, AtomicInteger::get)
+      .description("Spans queued for reporting")
+      .tags(this.extraTags).register(meterRegistry);
+    queuedBytes = new AtomicInteger();
+    Gauge.builder(PREFIX + "queue.bytes", queuedBytes, AtomicInteger::get)
+      .description("Total size of all encoded spans queued for reporting")
+      .baseUnit("bytes")
+      .tags(this.extraTags).register(meterRegistry);
+  }
+
+  @Override
+  public void incrementMessages() {
+    messages.increment();
+  }
+
+  @Override
+  public void incrementMessageBytes(int i) {
+    messageBytes.increment(i);
+  }
+
+  @Override
+  public void incrementMessagesDropped(Throwable cause) {
+    Iterable<Tag> tags = Tags.concat(extraTags, "cause", cause.getClass().getSimpleName());
+    meterRegistry.counter(PREFIX + "messages.dropped", tags).increment();
+  }
+
+  @Override
+  public void incrementSpans(int i) {
+    spans.increment(i);
+  }
+
+  @Override
+  public void incrementSpanBytes(int i) {
+    spanBytes.increment(i);
+  }
+
+  @Override
+  public void incrementSpansDropped(int i) {
+    spansDropped.increment(i);
+  }
+
+  @Override
+  public void updateQueuedSpans(int i) {
+    queuedSpans.set(i);
+  }
+
+  @Override
+  public void updateQueuedBytes(int i) {
+    queuedBytes.set(i);
+  }
+
+  public static final class Builder {
+    final MeterRegistry meterRegistry;
+    Tag[] extraTags = new Tag[0];
+
+    Builder(MeterRegistry meterRegistry) {
+      this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Additional tags to attach to all Zipkin Reporter metrics.
+     */
+    public Builder extraTags(Tag... extraTags) {
+      this.extraTags = extraTags;
+      return this;
+    }
+
+    public MicrometerReporterMetrics build() {
+      return new MicrometerReporterMetrics(meterRegistry, extraTags);
+    }
+  }
+}

--- a/metrics-micrometer/src/test/java/zipkin2/reporter/metrics/micrometer/MicrometerReporterMetricsTest.java
+++ b/metrics-micrometer/src/test/java/zipkin2/reporter/metrics/micrometer/MicrometerReporterMetricsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.metrics.micrometer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MicrometerReporterMetricsTest {
+  MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  MicrometerReporterMetrics reporterMetrics = MicrometerReporterMetrics.create(meterRegistry);
+
+  @Test
+  public void expectedMetricsRegistered() {
+    assertThat(meterRegistry.getMeters())
+      .extracting(Meter::getId).extracting(Meter.Id::getName)
+      .containsExactlyInAnyOrder(
+        "zipkin.reporter.messages.total",
+        "zipkin.reporter.messages",
+        "zipkin.reporter.spans.total",
+        "zipkin.reporter.spans",
+        "zipkin.reporter.spans.dropped",
+        "zipkin.reporter.queue.spans",
+        "zipkin.reporter.queue.bytes"
+      );
+  }
+
+  @Test
+  public void incrementMessagesDropped_sameExceptionTypeIsNotTaggedMoreThanOnce() {
+    reporterMetrics.incrementMessagesDropped(new RuntimeException("boo"));
+    reporterMetrics.incrementMessagesDropped(new RuntimeException("shh"));
+    reporterMetrics.incrementMessagesDropped(new IllegalStateException());
+
+    assertThat(meterRegistry.get("zipkin.reporter.messages.dropped").counters())
+      .hasSize(2); // two distinct meters for each cause
+    assertThat(meterRegistry.get("zipkin.reporter.messages.dropped").tag("cause", RuntimeException.class.getSimpleName()).counter().count()).isEqualTo(2);
+    assertThat(meterRegistry.get("zipkin.reporter.messages.dropped").tag("cause", IllegalStateException.class.getSimpleName()).counter().count()).isEqualTo(1);
+    double messagesDroppedTotal = meterRegistry.get("zipkin.reporter.messages.dropped").counters().stream().mapToDouble(Counter::count).sum();
+    assertThat(messagesDroppedTotal).isEqualTo(3); // 3 total messages dropped
+  }
+
+  @Test
+  public void gaugesSurviveGc() {
+    reporterMetrics.updateQueuedBytes(53);
+    reporterMetrics.updateQueuedSpans(2);
+
+    System.gc();
+
+    assertThat(meterRegistry.get("zipkin.reporter.queue.bytes").gauge().value()).isEqualTo(53);
+    assertThat(meterRegistry.get("zipkin.reporter.queue.spans").gauge().value()).isEqualTo(2);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <module>libthrift</module>
     <module>spring-beans</module>
     <module>benchmarks</module>
+    <module>metrics-micrometer</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
Adds a Micrometer-based implementation of the `ReporterMetrics` interface. This will help users easily export reporter metrics to a backend where they can query and alert to find reporting issues.

Closes #103

---

Most of the credit goes to @devinsba for the bulk of the implementation.