### PR TITLE
Remove inaccurate statement about BOM properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ instrumentation. Also any indirect use will have versions aligned:
 </dependency>
 ```
 
-With this in place, you can use the built-in properties
-`zipkin-reporter.version` and `zipkin.version` to override dependency
+With this in place, you can use the property `zipkin-reporter.version` to override dependency
 versions coherently. This is most commonly to test a new feature or fix.
 
 Note: If you override a version, always double check that your version


### PR DESCRIPTION
Properties in a BOM are not inherited by POMs importing that BOM. Properties are only inherited from parent POMs. Therefore, this removes the statement telling users they can use `zipkin.version` defined in the BOM.