### PR TITLE
Fixes Kafka config to honor messageMaxBytes

### DIFF
--- a/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
@@ -50,7 +50,7 @@ public final class KafkaSender extends Sender {
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
-    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "1"); // defer to messageMaxBytes
+    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "0"); // don't batch
     properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
     return new Builder(properties);

--- a/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -50,6 +50,8 @@ public final class KafkaSender extends Sender {
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
+    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "1"); // defer to messageMaxBytes
+    properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
     return new Builder(properties);
   }
@@ -98,6 +100,7 @@ public final class KafkaSender extends Sender {
      */
     public Builder messageMaxBytes(int messageMaxBytes) {
       this.messageMaxBytes = messageMaxBytes;
+      properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, messageMaxBytes);
       return this;
     }
 

--- a/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
+++ b/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The OpenZipkin Authors
+ * Copyright 2016-2019 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -54,6 +54,8 @@ public final class KafkaSender extends Sender {
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
+    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "1"); // defer to messageMaxBytes
+    properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
     return new Builder(properties);
   }
@@ -102,6 +104,7 @@ public final class KafkaSender extends Sender {
      */
     public Builder messageMaxBytes(int messageMaxBytes) {
       this.messageMaxBytes = messageMaxBytes;
+      properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, messageMaxBytes);
       return this;
     }
 

--- a/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
+++ b/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
@@ -54,7 +54,7 @@ public final class KafkaSender extends Sender {
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
-    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "1"); // defer to messageMaxBytes
+    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "0"); // don't batch
     properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
     return new Builder(properties);


### PR DESCRIPTION
Before this change, we'd actually overrun kafka's max message size due
to batching. This forces one message per batch and aligns config
properties. Tested against a real kafka server and
`RecordTooLargeException` went away.