### PR TITLE
Updates to latest zipkin and removes redundant batch setting

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.12.3</zipkin.version>
+    <zipkin.version>2.12.5</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>

--- a/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
@@ -50,7 +50,6 @@ public final class KafkaSender extends Sender {
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
-    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "0"); // don't batch
     properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
     return new Builder(properties);

--- a/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
+++ b/kafka11/src/main/java/zipkin2/reporter/kafka11/KafkaSender.java
@@ -54,7 +54,6 @@ public final class KafkaSender extends Sender {
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
-    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, "0"); // don't batch
     properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
     return new Builder(properties);

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <errorprone.args />
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.12.3</zipkin.version>
+    <zipkin.version>2.12.5</zipkin.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
   </properties>
 


### PR DESCRIPTION
@jeqo noticed the prior change included a distracting batch setting that
wasn't necessary. The key fix there was correctly applying the max size,
not the batch size.