### PR TITLE
Add support to log first exception in flush() at warning-level

### DIFF
--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -299,11 +299,11 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
           shouldWarnException = false;
         }
 
-        logger.log(logLevel, t, () ->
-          format("Dropped %s spans due to %s(%s)",
-            count,
-            t.getClass().getSimpleName(),
-            t.getMessage() == null ? "" : t.getMessage()));
+        if (logger.isLoggable(logLevel)) {
+          logger.log(logLevel,
+            format("Dropped %s spans due to %s(%s)", count, t.getClass().getSimpleName(),
+              t.getMessage() == null ? "" : t.getMessage()), t);
+        }
 
         // Raise in case the sender was closed out-of-band.
         if (t instanceof IllegalStateException) throw (IllegalStateException) t;


### PR DESCRIPTION
This makes a change in `BoundedAsyncReporter` to log the first exception thrown as a warning with a "check more at FINE" message; subsequent exceptions are logged to FINE level.

Fixes #154.

cc/ @meltsufin @elefeint