### PR TITLE
Lightens the AwaitableCallback a bit

### DIFF
--- a/core/src/main/java/zipkin2/reporter/AwaitableCallback.java
+++ b/core/src/main/java/zipkin2/reporter/AwaitableCallback.java
@@ -14,7 +14,6 @@
 package zipkin2.reporter;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 import zipkin2.Callback;
 
 /**
@@ -22,7 +21,7 @@ import zipkin2.Callback;
  */
 public final class AwaitableCallback implements Callback<Void> {
   final CountDownLatch countDown = new CountDownLatch(1);
-  final AtomicReference<Throwable> throwable = new AtomicReference<>();
+  Throwable throwable; // thread visibility guaranteed by the countdown latch
 
   /**
    * Blocks until {@link Callback#onSuccess(Object)} or {@link Callback#onError(Throwable)}.
@@ -36,14 +35,12 @@ public final class AwaitableCallback implements Callback<Void> {
       while (true) {
         try {
           countDown.await();
-          Object result = throwable.get();
-          if (result == null) return;
-          if (result instanceof Throwable) {
-            if (result instanceof Error) throw (Error) result;
-            if (result instanceof RuntimeException) throw (RuntimeException) result;
-            // Don't set interrupted status when the callback received InterruptedException
-            throw new RuntimeException((Throwable) result);
-          }
+          Throwable result = throwable;
+          if (result == null) return; // void return
+          if (result instanceof Error) throw (Error) result;
+          if (result instanceof RuntimeException) throw (RuntimeException) result;
+          // Don't set interrupted status when the callback received InterruptedException
+          throw new RuntimeException(result);
         } catch (InterruptedException e) {
           interrupted = true;
         }
@@ -60,7 +57,7 @@ public final class AwaitableCallback implements Callback<Void> {
   }
 
   @Override public void onError(Throwable t) {
-    throwable.set(t);
+    throwable = t;
     countDown.countDown();
   }
 }

--- a/core/src/main/java/zipkin2/reporter/AwaitableCallback.java
+++ b/core/src/main/java/zipkin2/reporter/AwaitableCallback.java
@@ -30,25 +30,16 @@ public final class AwaitableCallback implements Callback<Void> {
    * {@link Callback#onError(Throwable)} was called.
    */
   public void await() {
-    boolean interrupted = false;
     try {
-      while (true) {
-        try {
-          countDown.await();
-          Throwable result = throwable;
-          if (result == null) return; // void return
-          if (result instanceof Error) throw (Error) result;
-          if (result instanceof RuntimeException) throw (RuntimeException) result;
-          // Don't set interrupted status when the callback received InterruptedException
-          throw new RuntimeException(result);
-        } catch (InterruptedException e) {
-          interrupted = true;
-        }
-      }
-    } finally {
-      if (interrupted) {
-        Thread.currentThread().interrupt();
-      }
+      countDown.await();
+      Throwable result = throwable;
+      if (result == null) return; // void return
+      if (result instanceof Error) throw (Error) result;
+      if (result instanceof RuntimeException) throw (RuntimeException) result;
+      // Don't set interrupted status when the callback received InterruptedException
+      throw new RuntimeException(result);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
@Logic-32 and @anuraaga schooled me that when using Java concurrency
utilities in `java.util.concurrent`, you also inherit the thread
visibility properties ensured with synchronized and volatile symbols.

https://docs.oracle.com/javase/6/docs/api/java/util/concurrent/package-summary.html#MemoryVisibility

Given this, a volatile marker on a field whose state is dependent on
`CountDownLatch` should be redundant. This removes that volatile
qualifier accordingly.

cc other gear-heads @raphw @nicmunroe and @felixbarny for fun and good
measure!

see https://github.com/openzipkin/zipkin/pull/2735#discussion_r310878574