### PR TITLE
Kafka reporter

### DIFF
--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaReporter.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaReporter.java
@@ -2,6 +2,7 @@ package zipkin2.reporter.kafka;
 
 import java.io.Flushable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -239,7 +240,10 @@ public class KafkaReporter extends Component implements Reporter<Span>, Flushabl
     int spanSizeInBytes = encoder.sizeInBytes(span);
     metrics.incrementSpanBytes(spanSizeInBytes);
     ProducerRecord<byte[], byte[]> record =
-      new ProducerRecord<>(topic, span.traceId().getBytes(), encoder.encode(span));
+      new ProducerRecord<>(
+        topic,
+        span.traceId().getBytes(),
+        encoder.encodeList(Collections.singletonList(span)));
     getProducer().send(record, (metadata, exception) -> {
        if (exception != null) {
          metrics.incrementMessagesDropped(exception);

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaReporter.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaReporter.java
@@ -1,0 +1,295 @@
+package zipkin2.reporter.kafka;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import zipkin2.CheckResult;
+import zipkin2.Component;
+import zipkin2.Span;
+import zipkin2.codec.Encoding;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.Reporter;
+import zipkin2.reporter.ReporterMetrics;
+
+public class KafkaReporter extends Component implements Reporter<Span>, Flushable {
+
+  /**
+   * Configuration including defaults needed to send spans to a Kafka topic.
+   */
+  public static final class Builder {
+    ReporterMetrics metrics = ReporterMetrics.NOOP_METRICS;
+    final Properties properties;
+    Encoding encoding = Encoding.JSON;
+    String topic = "zipkin-span";
+    int messageMaxBytes = 500000;
+    int batchSize = 100000;
+    long lingerMs = 5;
+
+    Builder(Properties properties) {
+      this.properties = properties;
+    }
+
+    Builder(KafkaReporter reporter) {
+      properties = new Properties();
+      properties.putAll(reporter.properties);
+      encoding = reporter.encoding;
+      topic = reporter.topic;
+      messageMaxBytes = reporter.messageMaxBytes;
+    }
+
+    /**
+     * Topic zipkin spans will be send to. Defaults to "zipkin-sender"
+     */
+    public KafkaReporter.Builder topic(String topic) {
+      if (topic == null) throw new NullPointerException("topic == null");
+      this.topic = topic;
+      return this;
+    }
+
+    /**
+     * Initial set of kafka servers to connect to, rest of cluster will be discovered (comma
+     * separated). Ex "192.168.99.100:9092" No default
+     *
+     * @see ProducerConfig#BOOTSTRAP_SERVERS_CONFIG
+     */
+    public final KafkaReporter.Builder bootstrapServers(String bootstrapServers) {
+      if (bootstrapServers == null) throw new NullPointerException("bootstrapServers == null");
+      properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+      return this;
+    }
+
+    /**
+     * Maximum size of a message. Must be equal to or less than the server's "message.max.bytes" and
+     * "replica.fetch.max.bytes" to avoid rejected records on the broker side. Default 500000.
+     */
+    public KafkaReporter.Builder messageMaxBytes(int messageMaxBytes) {
+      this.messageMaxBytes = messageMaxBytes;
+      properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, messageMaxBytes);
+      return this;
+    }
+
+    /**
+     * Batch size used by producer to group records before sending them to Kafka. Default 100000.
+     */
+    public KafkaReporter.Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      properties.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize);
+      return this;
+    }
+
+    /**
+     * Milliseconds to wait until batch.size is full, else messages grouped are sent. Default 5
+     */
+    public KafkaReporter.Builder lingerMs(long lingerMs) {
+      this.lingerMs = lingerMs;
+      properties.put(ProducerConfig.LINGER_MS_CONFIG, lingerMs);
+      return this;
+    }
+
+    /**
+     * By default, a producer will be created, targeted to {@link #bootstrapServers(String)} with 0
+     * required {@link ProducerConfig#ACKS_CONFIG acks}. Any properties set here will affect the
+     * producer config.
+     * <p>
+     * Consider not overriding batching properties ("batch.size" and "linger.ms") as those will
+     * duplicate buffering effort that is already handled by Sender.
+     *
+     * <p>For example: Reduce the timeout blocking from one minute to 5 seconds.
+     * <pre>{@code
+     * Map<String, String> overrides = new LinkedHashMap<>();
+     * overrides.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "5000");
+     * builder.overrides(overrides);
+     * }</pre>
+     *
+     * @see ProducerConfig
+     */
+    public final KafkaReporter.Builder overrides(Map<String, ?> overrides) {
+      if (overrides == null) throw new NullPointerException("overrides == null");
+      properties.putAll(overrides);
+      return this;
+    }
+
+    /**
+     * By default, a producer will be created, targeted to {@link #bootstrapServers(String)} with 0
+     * required {@link ProducerConfig#ACKS_CONFIG acks}. Any properties set here will affect the
+     * producer config.
+     * <p>
+     * Consider not overriding batching properties ("batch.size" and "linger.ms") as those will
+     * duplicate buffering effort that is already handled by Sender.
+     *
+     * <p>For example: Reduce the timeout blocking from one minute to 5 seconds.
+     * <pre>{@code
+     * Properties overrides = new Properties();
+     * overrides.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000);
+     * builder.overrides(overrides);
+     * }</pre>
+     *
+     * @see ProducerConfig
+     */
+    public final KafkaReporter.Builder overrides(Properties overrides) {
+      if (overrides == null) throw new NullPointerException("overrides == null");
+      properties.putAll(overrides);
+      return this;
+    }
+
+    /**
+     * Aggregates and reports reporter metrics to a monitoring system. Defaults to no-op.
+     */
+    public KafkaReporter.Builder metrics(ReporterMetrics metrics) {
+      if (metrics == null) throw new NullPointerException("metrics == null");
+      this.metrics = metrics;
+      return this;
+    }
+
+    /**
+     * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
+     *
+     * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
+     */
+    public KafkaReporter.Builder encoding(Encoding encoding) {
+      if (encoding == null) throw new NullPointerException("encoding == null");
+      this.encoding = encoding;
+      return this;
+    }
+
+    public KafkaReporter build() {
+      return new KafkaReporter(this);
+    }
+  }
+
+  final Properties properties;
+  final String topic;
+  final Encoding encoding;
+  final SpanBytesEncoder encoder;
+  final int messageMaxBytes;
+  final ReporterMetrics metrics;
+
+  public static KafkaReporter create(String bootstrapServers) {
+    return newBuilder().bootstrapServers(bootstrapServers).build();
+  }
+
+  public static KafkaReporter.Builder newBuilder() {
+    // Settings below correspond to "Producer Configs"
+    // http://kafka.apache.org/0102/documentation.html#producerconfigs
+    Properties properties = new Properties();
+    properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+    properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+      ByteArraySerializer.class.getName());
+    // disabling batching as duplicates effort covered by sender buffering.
+    properties.put(ProducerConfig.BATCH_SIZE_CONFIG, 0);
+    // 1MB, aligned with default kafka max.message.bytes config.
+    properties.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 1000000);
+    properties.put(ProducerConfig.ACKS_CONFIG, "0");
+    return new KafkaReporter.Builder(properties);
+  }
+
+  KafkaReporter(KafkaReporter.Builder builder) {
+    properties = new Properties();
+    properties.putAll(builder.properties);
+    topic = builder.topic;
+    encoding = builder.encoding;
+    switch (encoding) {
+      case JSON:
+        encoder = SpanBytesEncoder.JSON_V2;
+        break;
+      case PROTO3:
+        encoder = SpanBytesEncoder.PROTO3;
+        break;
+      case THRIFT:
+        encoder = SpanBytesEncoder.THRIFT;
+        break;
+      default:
+        throw new UnsupportedOperationException(encoding.name());
+    }
+    messageMaxBytes = builder.messageMaxBytes;
+    metrics = builder.metrics;
+  }
+
+  public KafkaReporter.Builder toBuilder() {
+    return new KafkaReporter.Builder(this);
+  }
+
+  /**
+   * get and close are typically called from different threads
+   */
+  volatile KafkaProducer<byte[], byte[]> producer;
+  volatile boolean closeCalled;
+  volatile AdminClient adminClient;
+
+  @Override public void report(Span span) {
+    metrics.incrementSpans(1);
+    int spanSizeInBytes = encoder.sizeInBytes(span);
+    metrics.incrementSpanBytes(spanSizeInBytes);
+    ProducerRecord<byte[], byte[]> record =
+      new ProducerRecord<>(topic, span.traceId().getBytes(), encoder.encode(span));
+    getProducer().send(record, (metadata, exception) -> {
+       if (exception != null) {
+         metrics.incrementMessagesDropped(exception);
+         metrics.incrementSpansDropped(1);
+       }
+    });
+  }
+
+  /**
+   * Ensures there are no problems reading metadata about the topic.
+   */
+  @Override public CheckResult check() {
+    try {
+      KafkaFuture<String> maybeClusterId = getAdminClient().describeCluster().clusterId();
+      maybeClusterId.get(1, TimeUnit.SECONDS);
+      return CheckResult.OK;
+    } catch (Exception e) {
+      return CheckResult.failed(e);
+    }
+  }
+
+  KafkaProducer<byte[], byte[]> getProducer() {
+    if (producer == null) {
+      synchronized (this) {
+        if (producer == null) {
+          producer = new KafkaProducer<>(properties);
+        }
+      }
+    }
+    return producer;
+  }
+
+  AdminClient getAdminClient() {
+    if (adminClient == null) {
+      synchronized (this) {
+        if (adminClient == null) {
+          adminClient = AdminClient.create(properties);
+        }
+      }
+    }
+    return adminClient;
+  }
+
+  @Override public void flush() throws IOException {
+    getProducer().flush();
+  }
+
+  @Override public synchronized void close() {
+    if (closeCalled) return;
+    KafkaProducer<byte[], byte[]> producer = this.producer;
+    if (producer != null) producer.close();
+    AdminClient adminClient = this.adminClient;
+    if (adminClient != null) adminClient.close(1, TimeUnit.SECONDS);
+    closeCalled = true;
+  }
+
+  @Override public final String toString() {
+    return "KafkaReporter{"
+      + "bootstrapServers=" + properties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+      + ", topic=" + topic
+      + "}";
+  }
+}

--- a/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaReporter.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaReporter.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2016-2019 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.kafka;
+
+import com.github.charithe.kafka.EphemeralKafkaBroker;
+import com.github.charithe.kafka.KafkaJunitRule;
+import java.lang.management.ManagementFactory;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import javax.management.ObjectName;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import zipkin2.CheckResult;
+import zipkin2.Span;
+import zipkin2.codec.Encoding;
+import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.Sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+
+public class ITKafkaReporter {
+  EphemeralKafkaBroker broker = EphemeralKafkaBroker.create();
+  @Rule public KafkaJunitRule kafka = new KafkaJunitRule(broker).waitForStartup();
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  KafkaReporter reporter;
+
+  @Before public void open() {
+    reporter = KafkaReporter.create(broker.getBrokerList().get());
+  }
+
+  @After public void close() {
+    reporter.close();
+  }
+
+  @Test
+  public void sendsSpans() throws Exception {
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat((readMessage(2)))
+      .extracting(SpanBytesDecoder.JSON_V2::decodeOne)
+      .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test
+  public void sendsSpans_PROTO3() throws Exception {
+    reporter.close();
+    reporter = reporter.toBuilder().encoding(Encoding.PROTO3).build();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat((readMessage(2)))
+      .extracting(SpanBytesDecoder.PROTO3::decodeOne)
+      .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test
+  public void sendsSpans_THRIFT() throws Exception {
+    reporter.close();
+    reporter = reporter.toBuilder().encoding(Encoding.THRIFT).build();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat((readMessage(2)))
+      .extracting(SpanBytesDecoder.THRIFT::decodeOne)
+      .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test
+  public void sendsSpansToCorrectTopic() throws Exception {
+    reporter.close();
+    reporter = reporter.toBuilder().topic("customzipkintopic").build();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    assertThat((readMessage("customzipkintopic", 2)))
+      .extracting(SpanBytesDecoder.JSON_V2::decodeOne)
+      .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test
+  public void checkFalseWhenKafkaIsDown() throws Exception {
+    broker.stop();
+
+    // Make a new tracer that fails faster than 60 seconds
+    reporter.close();
+    Map<String, String> overrides = new LinkedHashMap<>();
+    overrides.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "100");
+    reporter = reporter.toBuilder().overrides(overrides).build();
+
+    CheckResult check = reporter.check();
+    assertThat(check.ok()).isFalse();
+    assertThat(check.error()).isInstanceOf(TimeoutException.class);
+  }
+
+  @Test
+  public void illegalToSendWhenClosed() throws Exception {
+    thrown.expect(IllegalStateException.class);
+    reporter.close();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+  }
+
+  @Test
+  public void shouldCloseKafkaProducerOnClose() throws Exception {
+    send(CLIENT_SPAN, CLIENT_SPAN);
+
+    final ObjectName kafkaProducerMXBeanName = new ObjectName("kafka.producer:*");
+    final Set<ObjectName> withProducers = ManagementFactory.getPlatformMBeanServer().queryNames(
+        kafkaProducerMXBeanName, null);
+    assertThat(withProducers).isNotEmpty();
+
+    reporter.close();
+
+    final Set<ObjectName> withNoProducers = ManagementFactory.getPlatformMBeanServer().queryNames(
+        kafkaProducerMXBeanName, null);
+    assertThat(withNoProducers).isEmpty();
+  }
+
+  @Test
+  public void shouldFailWhenMessageIsBiggerThanMaxSize() throws Exception {
+    thrown.expect(RecordTooLargeException.class);
+    reporter.close();
+    reporter = reporter.toBuilder().messageMaxBytes(1).build();
+
+    send(CLIENT_SPAN, CLIENT_SPAN);
+    reporter.flush();
+  }
+
+  /**
+   * The output of toString() on {@link Sender} implementations appears in thread names created by
+   * {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other monitoring
+   * tools, care should be taken to ensure the toString() output is a reasonable length and does not
+   * contain sensitive information.
+   */
+  @Test
+  public void toStringContainsOnlySummaryInformation() {
+    assertThat(reporter.toString()).isEqualTo(
+        "KafkaReporter{bootstrapServers=" + broker.getBrokerList().get() + ", topic=zipkin-span}"
+    );
+  }
+
+  void send(Span... spans) {
+    for (Span span: spans) reporter.report(span);
+  }
+
+  private List<byte[]> readMessage(String topic, int numMessagesToConsume) throws Exception {
+    KafkaConsumer<byte[], byte[]> consumer = kafka.helper().createByteConsumer();
+    return kafka.helper().consume(topic, consumer, numMessagesToConsume)
+        .get().stream().map(ConsumerRecord::value).collect(Collectors.toList());
+  }
+
+  private List<byte[]> readMessage(int numMessagesToConsume) throws Exception {
+    return readMessage("zipkin-span", numMessagesToConsume);
+  }
+
+  private byte[] readMessage() throws Exception {
+    return readMessage("zipkin-span", 1).get(0);
+  }
+}


### PR DESCRIPTION
Fixes #158 

Adds a KafkaReporter to support: native Kafka batching, partitioning by `traceId`.