### PR TITLE
Use special exception to mark a closed reporter to not conflict with …

### DIFF
--- a/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java
+++ b/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java
@@ -25,6 +25,7 @@ import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 /**
@@ -151,7 +152,7 @@ public final class ActiveMQSender extends Sender {
   }
 
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     byte[] message = encoder.encode(encodedSpans);
     return new ActiveMQCall(message);
   }

--- a/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
+++ b/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
@@ -27,6 +27,7 @@ import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 /**
@@ -212,7 +213,7 @@ public final class RabbitMQSender extends Sender {
 
   /** This sends all of the spans as a single message. */
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     byte[] message = encoder.encode(encodedSpans);
     return new RabbitMQCall(message);
   }

--- a/core/src/main/java/zipkin2/reporter/ClosedSenderException.java
+++ b/core/src/main/java/zipkin2/reporter/ClosedSenderException.java
@@ -1,0 +1,6 @@
+package zipkin2.reporter;
+
+/** An exception thrown when a {@link Sender} is used after it has been closed. */
+public final class ClosedSenderException extends IllegalStateException {
+  static final long serialVersionUID = -4636520624634625689L;
+}

--- a/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
@@ -13,6 +13,9 @@
  */
 package zipkin2.reporter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -25,17 +28,16 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+
 import org.junit.After;
 import org.junit.Test;
+
 import zipkin2.Span;
 import zipkin2.TestObjects;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter.BoundedAsyncReporter;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class AsyncReporterTest {
 
@@ -337,7 +339,7 @@ public class AsyncReporterTest {
     assertThat(metrics.spansDropped()).isEqualTo(1);
     assertThat(metrics.messagesDropped()).isEqualTo(1);
     assertThat(metrics.messagesDroppedByCause().keySet().iterator().next())
-        .isEqualTo(IllegalStateException.class);
+        .isEqualTo(ClosedSenderException.class);
   }
 
   @Test

--- a/core/src/test/java/zipkin2/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeSender.java
@@ -114,7 +114,7 @@ public final class FakeSender extends Sender {
   volatile boolean closeCalled;
 
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     List<Span> decoded = encodedSpans.stream()
         .map(s -> decoder.decodeOne(s))
         .collect(Collectors.toList());

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -33,6 +33,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.AwaitableCallback;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 /**
@@ -245,7 +246,7 @@ public final class KafkaSender extends Sender {
    * <p>NOTE: this blocks until the metadata server is available.
    */
   @Override public zipkin2.Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     byte[] message = encoder.encode(encodedSpans);
     return new KafkaCall(message);
   }

--- a/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
+++ b/kafka08/src/main/java/zipkin2/reporter/kafka08/KafkaSender.java
@@ -27,6 +27,7 @@ import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AwaitableCallback;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 /**
@@ -185,7 +186,7 @@ public final class KafkaSender extends Sender {
    * <p>NOTE: this blocks until the metadata server is available.
    */
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     byte[] message = encoder.encode(encodedSpans);
     return new KafkaCall(message);
   }

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/LibthriftSender.java
@@ -21,6 +21,7 @@ import zipkin2.Call;
 import zipkin2.Callback;
 import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 /**
@@ -127,7 +128,7 @@ public final class LibthriftSender extends Sender {
   }
 
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     return new ScribeCall(encodedSpans);
   }
 

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -13,12 +13,14 @@
  */
 package zipkin2.reporter.okhttp3;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
 import okhttp3.Dispatcher;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
@@ -33,9 +35,8 @@ import okio.Okio;
 import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Reports spans to Zipkin, using its <a href="https://zipkin.io/zipkin-api/#/">POST</a> endpoint.
@@ -261,7 +262,7 @@ public final class OkHttpSender extends Sender {
 
   /** The returned call sends spans as a POST to {@link Builder#endpoint(String)}. */
   @Override public zipkin2.Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("closed");
+    if (closeCalled) throw new ClosedSenderException();
     Request request;
     try {
       request = newRequest(encoder.encode(encodedSpans));

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -26,6 +26,7 @@ import zipkin2.Callback;
 import zipkin2.CheckResult;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.BytesMessageEncoder;
+import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Sender;
 
 /**
@@ -183,7 +184,7 @@ public final class URLConnectionSender extends Sender {
 
   /** The returned call sends spans as a POST to {@link Builder#endpoint}. */
   @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    if (closeCalled) throw new IllegalStateException("close");
+    if (closeCalled) throw new ClosedSenderException();
     return new HttpPostCall(encoder.encode(encodedSpans));
   }
 


### PR DESCRIPTION
…other libraries.

A sender may throw `IllegalStateException` for reasons other than being closed as it's a standard Java exception. So if we want to handle it specially, we should use a specific type for it. As there could be usage of the reporter with senders outside our repos or older versions, a less precise check is still kept as well.

/cc @elefeint

Fixes https://github.com/openzipkin/zipkin-gcp/issues/127