### PR TITLE
issue-169 add adminClientProperties Properties

### DIFF
--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -14,8 +14,7 @@
 package zipkin2.reporter.kafka;
 
 import java.io.IOException;
-
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -225,7 +224,7 @@ public final class KafkaSender extends Sender {
    * See @{@link AdminClientConfig} config properties
    */
   private Map<String, Object> filterPropertiesForAdminClient(Properties properties) {
-    Map<String, Object> adminClientProperties = new HashMap<>();
+    Map<String, Object> adminClientProperties = new LinkedHashMap<>();
     for (Map.Entry property : properties.entrySet()) {
       if (AdminClientConfig.configNames().contains(property.getKey())) {
         adminClientProperties.put(property.getKey().toString(), property.getValue());

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -346,7 +346,7 @@ public final class KafkaSender extends Sender {
     if (adminClient == null) {
       synchronized (this) {
         if (adminClient == null) {
-          adminClient = AdminClient.create(adminClientProperties);
+          adminClient = AdminClient.create(filterPropertiesForAdminClient(properties));
         }
       }
     }

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -223,7 +223,7 @@ public final class KafkaSender extends Sender {
    * <p>
    * See @{@link AdminClientConfig} config properties
    */
-  protected Map<String, Object> filterPropertiesForAdminClient(Properties properties) {
+  Map<String, Object> filterPropertiesForAdminClient(Properties properties) {
     Map<String, Object> adminClientProperties = new LinkedHashMap<>();
     for (Map.Entry property : properties.entrySet()) {
       if (AdminClientConfig.configNames().contains(property.getKey())) {

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -223,7 +223,7 @@ public final class KafkaSender extends Sender {
    * <p>
    * See @{@link AdminClientConfig} config properties
    */
-  private Map<String, Object> filterPropertiesForAdminClient(Properties properties) {
+  protected Map<String, Object> filterPropertiesForAdminClient(Properties properties) {
     Map<String, Object> adminClientProperties = new LinkedHashMap<>();
     for (Map.Entry property : properties.entrySet()) {
       if (AdminClientConfig.configNames().contains(property.getKey())) {

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -14,6 +14,7 @@
 package zipkin2.reporter.kafka;
 
 import java.io.IOException;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public final class KafkaSender extends Sender {
     Properties properties = new Properties();
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-      ByteArraySerializer.class.getName());
+        ByteArraySerializer.class.getName());
     // disabling batching as duplicates effort covered by sender buffering.
     properties.put(ProducerConfig.BATCH_SIZE_CONFIG, 0);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
@@ -314,9 +315,9 @@ public final class KafkaSender extends Sender {
 
   @Override public final String toString() {
     return "KafkaSender{"
-      + "bootstrapServers=" + properties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
-      + ", topic=" + topic
-      + "}";
+        + "bootstrapServers=" + properties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+        + ", topic=" + topic
+        + "}";
   }
 
   class KafkaCall extends Call.Base<Void> { // KafkaFuture is not cancelable
@@ -362,4 +363,3 @@ public final class KafkaSender extends Sender {
     }
   }
 }
-

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -185,7 +185,7 @@ public final class KafkaSender extends Sender {
      */
     public final Builder overridesAdminClient(Map<String, ?> overrides) {
       if (overrides == null) throw new NullPointerException("overrides == null");
-      properties.putAll(overrides);
+      adminClientProperties.putAll(overrides);
       return this;
     }
 
@@ -229,7 +229,7 @@ public final class KafkaSender extends Sender {
      */
     public final Builder overridesAdminClient(Properties overrides) {
       if (overrides == null) throw new NullPointerException("overrides == null");
-      properties.putAll(overrides);
+      adminClientProperties.putAll(overrides);
       return this;
     }
 

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -43,7 +42,7 @@ import zipkin2.reporter.Sender;
  * This sends (usually json v2) encoded spans to a Kafka topic.
  *
  * <h3>Usage</h3>
- * <p>
+ *
  * This type is designed for {@link AsyncReporter.Builder#builder(Sender) the async reporter}.
  *
  * <p>Here's a simple configuration, configured for json:
@@ -74,9 +73,7 @@ import zipkin2.reporter.Sender;
  * work with Kafka 0.10+ brokers
  */
 public final class KafkaSender extends Sender {
-  /**
-   * Creates a sender that sends {@link Encoding#JSON} messages.
-   */
+  /** Creates a sender that sends {@link Encoding#JSON} messages. */
   public static KafkaSender create(String bootstrapServers) {
     return newBuilder().bootstrapServers(bootstrapServers).build();
   }
@@ -94,9 +91,7 @@ public final class KafkaSender extends Sender {
     return new Builder(properties);
   }
 
-  /**
-   * Configuration including defaults needed to send spans to a Kafka topic.
-   */
+  /** Configuration including defaults needed to send spans to a Kafka topic. */
   public static final class Builder {
     final Properties properties;
     Encoding encoding = Encoding.JSON;
@@ -115,9 +110,7 @@ public final class KafkaSender extends Sender {
       messageMaxBytes = sender.messageMaxBytes;
     }
 
-    /**
-     * Topic zipkin spans will be send to. Defaults to "zipkin"
-     */
+    /** Topic zipkin spans will be send to. Defaults to "zipkin" */
     public Builder topic(String topic) {
       if (topic == null) throw new NullPointerException("topic == null");
       this.topic = topic;
@@ -138,7 +131,8 @@ public final class KafkaSender extends Sender {
 
     /**
      * Maximum size of a message. Must be equal to or less than the server's "message.max.bytes" and
-     * "replica.fetch.max.bytes" to avoid rejected records on the broker side. Default 500KB.
+     * "replica.fetch.max.bytes" to avoid rejected records on the broker side.
+     * Default 500KB.
      */
     public Builder messageMaxBytes(int messageMaxBytes) {
       this.messageMaxBytes = messageMaxBytes;
@@ -150,7 +144,7 @@ public final class KafkaSender extends Sender {
      * By default, a producer will be created, targeted to {@link #bootstrapServers(String)} with 0
      * required {@link ProducerConfig#ACKS_CONFIG acks}. Any properties set here will affect the
      * producer config.
-     * <p>
+     *
      * Consider not overriding batching properties ("batch.size" and "linger.ms") as those will
      * duplicate buffering effort that is already handled by Sender.
      *
@@ -173,7 +167,7 @@ public final class KafkaSender extends Sender {
      * By default, a producer will be created, targeted to {@link #bootstrapServers(String)} with 0
      * required {@link ProducerConfig#ACKS_CONFIG acks}. Any properties set here will affect the
      * producer config.
-     * <p>
+     *
      * Consider not overriding batching properties ("batch.size" and "linger.ms") as those will
      * duplicate buffering effort that is already handled by Sender.
      *
@@ -231,7 +225,7 @@ public final class KafkaSender extends Sender {
    */
   private Map<String, Object> filterPropertiesForAdminClient(Properties properties) {
     Map<String, Object> adminClientProperties = new HashMap<>();
-    for (Entry property : properties.entrySet()) {
+    for (Map.Entry property : properties.entrySet()) {
       if (AdminClientConfig.configNames().contains(property.getKey())) {
         adminClientProperties.put(property.getKey().toString(), property.getValue());
       }
@@ -243,9 +237,7 @@ public final class KafkaSender extends Sender {
     return new Builder(this);
   }
 
-  /**
-   * get and close are typically called from different threads
-   */
+  /** get and close are typically called from different threads */
   volatile KafkaProducer<byte[], byte[]> producer;
   volatile boolean closeCalled;
   volatile AdminClient adminClient;
@@ -277,9 +269,7 @@ public final class KafkaSender extends Sender {
     return new KafkaCall(message);
   }
 
-  /**
-   * Ensures there are no problems reading metadata about the topic.
-   */
+  /** Ensures there are no problems reading metadata about the topic. */
   @Override public CheckResult check() {
     try {
       KafkaFuture<String> maybeClusterId = getAdminClient().describeCluster().clusterId();
@@ -301,6 +291,7 @@ public final class KafkaSender extends Sender {
     return producer;
   }
 
+
   AdminClient getAdminClient() {
     if (adminClient == null) {
       synchronized (this) {
@@ -314,7 +305,7 @@ public final class KafkaSender extends Sender {
 
   @Override public synchronized void close() {
     if (closeCalled) return;
-    KafkaProducer<byte[], byte[]> producer = this.producer;
+    KafkaProducer<byte[], byte[]>  producer = this.producer;
     if (producer != null) producer.close();
     AdminClient adminClient = this.adminClient;
     if (adminClient != null) adminClient.close(1, TimeUnit.SECONDS);
@@ -371,3 +362,4 @@ public final class KafkaSender extends Sender {
     }
   }
 }
+

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -14,12 +14,15 @@
 package zipkin2.reporter.kafka;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -80,9 +83,10 @@ public final class KafkaSender extends Sender {
     // Settings below correspond to "Producer Configs"
     // http://kafka.apache.org/0102/documentation.html#producerconfigs
     Properties properties = new Properties();
+    Properties adminClientProperties = new Properties();
     properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
     properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-        ByteArraySerializer.class.getName());
+      ByteArraySerializer.class.getName());
     // disabling batching as duplicates effort covered by sender buffering.
     properties.put(ProducerConfig.BATCH_SIZE_CONFIG, 0);
     properties.put(ProducerConfig.ACKS_CONFIG, "0");
@@ -92,17 +96,20 @@ public final class KafkaSender extends Sender {
   /** Configuration including defaults needed to send spans to a Kafka topic. */
   public static final class Builder {
     final Properties properties;
+    Properties adminClientProperties;
     Encoding encoding = Encoding.JSON;
     String topic = "zipkin";
     int messageMaxBytes = 500_000;
 
     Builder(Properties properties) {
       this.properties = properties;
+      this.adminClientProperties = new Properties();
     }
 
     Builder(KafkaSender sender) {
       properties = new Properties();
       properties.putAll(sender.properties);
+      adminClientProperties = new Properties();
       encoding = sender.encoding;
       topic = sender.topic;
       messageMaxBytes = sender.messageMaxBytes;
@@ -162,6 +169,27 @@ public final class KafkaSender extends Sender {
     }
 
     /**
+     * Any properties set here will affect the admin client config.
+     *
+     * Consider not overriding batching properties ("batch.size" and "linger.ms") as those will
+     * duplicate buffering effort that is already handled by Sender.
+     *
+     * <p>For example: Configure de number of retries to 5.
+     * <pre>{@code
+     * Properties overridesAdminClient = new Properties();
+     * overridesAdminClient.put(AdminClientConfig.RETRIES_CONFIG, 5);
+     * builder.overridesAdminClient(overridesAdminClient);
+     * }</pre>
+     *
+     * @see AdminClientConfig
+     */
+    public final Builder overridesAdminClient(Map<String, ?> overrides) {
+      if (overrides == null) throw new NullPointerException("overrides == null");
+      properties.putAll(overrides);
+      return this;
+    }
+
+    /**
      * By default, a producer will be created, targeted to {@link #bootstrapServers(String)} with 0
      * required {@link ProducerConfig#ACKS_CONFIG acks}. Any properties set here will affect the
      * producer config.
@@ -185,6 +213,27 @@ public final class KafkaSender extends Sender {
     }
 
     /**
+     * Any properties set here will affect the admin client config.
+     *
+     * Consider not overriding batching properties ("batch.size" and "linger.ms") as those will
+     * duplicate buffering effort that is already handled by Sender.
+     *
+     * <p>For example: Configure de number of retries to 5.
+     * <pre>{@code
+     * Properties overridesAdminClient = new Properties();
+     * overridesAdminClient.put(AdminClientConfig.RETRIES_CONFIG, 5);
+     * builder.overridesAdminClient(overridesAdminClient);
+     * }</pre>
+     *
+     * @see AdminClientConfig
+     */
+    public final Builder overridesAdminClient(Properties overrides) {
+      if (overrides == null) throw new NullPointerException("overrides == null");
+      properties.putAll(overrides);
+      return this;
+    }
+
+    /**
      * Use this to change the encoding used in messages. Default is {@linkplain Encoding#JSON}
      *
      * <p>Note: If ultimately sending to Zipkin, version 2.8+ is required to process protobuf.
@@ -201,6 +250,7 @@ public final class KafkaSender extends Sender {
   }
 
   final Properties properties;
+  final Properties adminClientProperties;
   final String topic;
   final Encoding encoding;
   final BytesMessageEncoder encoder;
@@ -208,11 +258,29 @@ public final class KafkaSender extends Sender {
 
   KafkaSender(Builder builder) {
     properties = new Properties();
+    adminClientProperties = new Properties();
     properties.putAll(builder.properties);
+    adminClientProperties.putAll(filterPropertiesForAdminClient(properties));
+    adminClientProperties.putAll(builder.adminClientProperties);
     topic = builder.topic;
     encoding = builder.encoding;
     encoder = BytesMessageEncoder.forEncoding(builder.encoding);
     messageMaxBytes = builder.messageMaxBytes;
+  }
+
+  /**
+   * Filter the properties configured for the producer by removing those not used for the Admin Client.
+   *
+   * See @{@link AdminClientConfig} config properties
+   */
+  private Map<String, Object> filterPropertiesForAdminClient(Properties properties){
+    Map<String, Object> mapResult = new HashMap<>();
+    for (Entry property: properties.entrySet()) {
+      if (AdminClientConfig.configNames().contains(property.getKey())){
+        mapResult.put(property.getKey().toString(),property.getValue());
+      }
+    }
+    return mapResult;
   }
 
   public Builder toBuilder() {
@@ -278,7 +346,7 @@ public final class KafkaSender extends Sender {
     if (adminClient == null) {
       synchronized (this) {
         if (adminClient == null) {
-          adminClient = AdminClient.create(properties);
+          adminClient = AdminClient.create(adminClientProperties);
         }
       }
     }
@@ -296,9 +364,9 @@ public final class KafkaSender extends Sender {
 
   @Override public final String toString() {
     return "KafkaSender{"
-        + "bootstrapServers=" + properties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
-        + ", topic=" + topic
-        + "}";
+      + "bootstrapServers=" + properties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+      + ", topic=" + topic
+      + "}";
   }
 
   class KafkaCall extends Call.Base<Void> { // KafkaFuture is not cancelable

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -274,7 +274,7 @@ public final class KafkaSender extends Sender {
    * See @{@link AdminClientConfig} config properties
    */
   private Map<String, Object> filterPropertiesForAdminClient(Properties properties){
-    Map<String, Object> mapResult = new HashMap<>();
+    Map<String, Object> adminClientProperties = new HashMap<>();
     for (Entry property: properties.entrySet()) {
       if (AdminClientConfig.configNames().contains(property.getKey())){
         mapResult.put(property.getKey().toString(),property.getValue());

--- a/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaSender.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaSender.java
@@ -165,19 +165,21 @@ public class ITKafkaSender {
 
   @Test
   public void checkFilterPropertiesProducerToAdminClient() {
-    Properties overrides = new Properties();
-    overrides.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "100");
-    overrides.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
-    overrides.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+    Properties producerProperties = new Properties();
+    producerProperties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "100");
+    producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
         ByteArraySerializer.class.getName());
-    overrides.put(ProducerConfig.BATCH_SIZE_CONFIG, "0");
-    overrides.put(ProducerConfig.ACKS_CONFIG, "0");
-    overrides.put(ProducerConfig.LINGER_MS_CONFIG, "500");
-    overrides.put(ProducerConfig.BUFFER_MEMORY_CONFIG, "33554432");
-    overrides.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
-    overrides.put(ProducerConfig.SECURITY_PROVIDERS_CONFIG, "sun.security.provider.Sun");
+    producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        ByteArraySerializer.class.getName());
+    producerProperties.put(ProducerConfig.BATCH_SIZE_CONFIG, "0");
+    producerProperties.put(ProducerConfig.ACKS_CONFIG, "0");
+    producerProperties.put(ProducerConfig.LINGER_MS_CONFIG, "500");
+    producerProperties.put(ProducerConfig.BUFFER_MEMORY_CONFIG, "33554432");
+    producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "127.0.0.1:9092");
+    producerProperties.put(ProducerConfig.SECURITY_PROVIDERS_CONFIG, "sun.security.provider.Sun");
 
-    Map<String, Object> filteredProperties = sender.filterPropertiesForAdminClient(overrides);
+    Map<String, Object> filteredProperties =
+        sender.filterPropertiesForAdminClient(producerProperties);
 
     assertThat(filteredProperties.size()).isEqualTo(2);
     assertThat(filteredProperties.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)).isNotNull();


### PR DESCRIPTION
https://github.com/openzipkin/zipkin-reporter-java/issues/169

Would you consider the following pull request?

The goal is not to generate WARN logs for the creation of Kafka's admin client, because now the same properties of the producer are used as for the admin client.

We have added the "adminClientProperties" and "overridesAdminClient" methods, which will be used to optionally set specific properties for kafka's admin client.

In the creation of the "KafkaSender" with the builder, the "adminClientProperties" properties are the result of the filtered producer settings (removing those properties that do not appear in kafka's AdminClientConfig) + the properties added specifically for the admin client (overrridesAdminClient).
