### PR TITLE
Adds Brave integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ the `Reporter<Span>` here to a Brave `FinishedSpanHandler`.
 
 Ex.
 ```java
- tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
+tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
 ```
+
+See [zipkin-reporter-brave](brave/README.md) for more details.
 
 ## Spring Beans
 If you are trying to trace legacy applications, you may be interested in

--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ reporter.report(span);
 
 ## Brave
 Those using the [Brave library](https://github.com/openzipkin/brave) can adapt
-the `Reporter<Span>` here to a Brave
+the `Reporter<Span>` here to a Brave.
 
+Ex.
+```java
+ tracingBuilder.addFinishedSpanHandler(ZipkinFinishedSpanHandler.create(reporter));
+```
 
 ## Spring Beans
 If you are trying to trace legacy applications, you may be interested in

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ reporter.report(span);
 
 ## Brave
 Those using the [Brave library](https://github.com/openzipkin/brave) can adapt
-the `Reporter<Span>` here to a Brave.
+the `Reporter<Span>` here to a Brave `FinishedSpanHandler`.
 
 Ex.
 ```java
- tracingBuilder.addFinishedSpanHandler(ZipkinFinishedSpanHandler.create(reporter));
+ tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
 ```
 
 ## Spring Beans

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ reporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:941
 reporter.report(span);
 ```
 
+## Brave
+Those using the [Brave library](https://github.com/openzipkin/brave) can adapt
+the `Reporter<Span>` here to a Brave
+
+
 ## Spring Beans
 If you are trying to trace legacy applications, you may be interested in
 [Spring XML Configuration](spring-beans/). This allows you to trace legacy
@@ -72,7 +77,7 @@ message.
 
 ## Sender
 The sender component handles the last step of sending a list of encoded spans onto a transport.
-This involves I/O, so you can call `Sender.check()` to check its health on a given frequency. 
+This involves I/O, so you can call `Sender.check()` to check its health on a given frequency.
 
 Sender is used by AsyncReporter, but you can also create your own if you need to.
 ```java

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ reporter.report(span);
 
 ## Brave
 Those using the [Brave library](https://github.com/openzipkin/brave) can adapt
-the `Reporter<Span>` here to a Brave `FinishedSpanHandler`.
+the `Reporter<Span>` here to a Brave `SpanHandler`.
 
 Ex.
 ```java
-tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
+tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(reporter));
 ```
 
 See [zipkin-reporter-brave](brave/README.md) for more details.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -73,6 +73,15 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter-brave</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin-tests</artifactId>
       <scope>compile</scope>
@@ -94,7 +103,7 @@
     <dependency>
       <groupId>com.linecorp.armeria</groupId>
       <artifactId>armeria</artifactId>
-      <version>0.99.1</version>
+      <version>0.99.4</version>
     </dependency>
 
     <dependency>

--- a/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpanBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpanBenchmarks.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Span;
+import brave.handler.MutableSpan;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class MutableSpanBenchmarks {
+
+  @Benchmark public MutableSpan makeServerSpan() {
+    return newServerSpan();
+  }
+
+  public static MutableSpan newServerSpan() {
+    MutableSpan span = new MutableSpan();
+    span.name("get /");
+    span.kind(Span.Kind.SERVER);
+    span.remoteIpAndPort("::1", 63596);
+    span.startTimestamp(1533706251750057L);
+    span.finishTimestamp(1533706251935296L);
+    span.tag("http.method", "GET");
+    span.tag("http.path", "/");
+    span.tag("mvc.controller.class", "Frontend");
+    span.tag("mvc.controller.method", "callBackend");
+    return span;
+  }
+
+  @Benchmark public MutableSpan makeBigClientSpan() {
+    return newBigClientSpan();
+  }
+
+  public static MutableSpan newBigClientSpan() {
+    MutableSpan span = new MutableSpan();
+    span.name("getuserinfobyaccesstoken");
+    span.kind(Span.Kind.CLIENT);
+    span.remoteServiceName("abasdasgad.hsadas.ism");
+    span.remoteIpAndPort("219.235.216.11", 0);
+    span.startTimestamp(1533706251750057L);
+    span.finishTimestamp(1533706251935296L);
+    span.tag("address.local", "/10.1.2.3:59618");
+    span.tag("address.remote", "abasdasgad.hsadas.ism/219.235.216.11:8080");
+    span.tag("http.host", "abasdasgad.hsadas.ism");
+    span.tag("http.method", "POST");
+    span.tag("http.path", "/thrift/shopForTalk");
+    span.tag("http.status_code", "200");
+    span.tag("http.url", "tbinary+h2c://abasdasgad.hsadas.ism/thrift/shopForTalk");
+    span.tag("instanceId", "line-wallet-api");
+    span.tag("phase", "beta");
+    span.tag("siteId", "shop");
+    return span;
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + MutableSpanBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandlerBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandlerBenchmarks.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
+import brave.propagation.TraceContext;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import zipkin2.reporter.Reporter;
+
+import static zipkin2.reporter.brave.MutableSpanBenchmarks.newBigClientSpan;
+import static zipkin2.reporter.brave.MutableSpanBenchmarks.newServerSpan;
+
+@Measurement(iterations = 5, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Fork(3)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+@Threads(1)
+public class ZipkinSpanHandlerBenchmarks {
+  final SpanHandler handler =
+      ZipkinSpanHandler.newBuilder(Reporter.NOOP).alwaysReportSpans().build();
+  final TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+  final MutableSpan serverSpan = newServerSpan();
+  final MutableSpan bigClientSpan = newBigClientSpan();
+
+  @Benchmark public boolean handleServerSpan() {
+    return handler.end(context, serverSpan, SpanHandler.Cause.FINISHED);
+  }
+
+  @Benchmark public boolean handleBigClientSpan() {
+    return handler.end(context, bigClientSpan, SpanHandler.Cause.FINISHED);
+  }
+
+  // Convenience main entry-point
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .addProfiler("gc")
+        .include(".*" + ZipkinSpanHandlerBenchmarks.class.getSimpleName() + ".*")
+        .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/benchmarks/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandlerBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandlerBenchmarks.java
@@ -45,7 +45,7 @@ import static zipkin2.reporter.brave.MutableSpanBenchmarks.newServerSpan;
 @Threads(1)
 public class ZipkinSpanHandlerBenchmarks {
   final SpanHandler handler =
-      ZipkinSpanHandler.newBuilder(Reporter.NOOP).alwaysReportSpans().build();
+      ZipkinSpanHandler.newBuilder(Reporter.NOOP).alwaysReportSpans(true).build();
   final TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
   final MutableSpan serverSpan = newServerSpan();
   final MutableSpan bigClientSpan = newBigClientSpan();

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -143,6 +143,11 @@
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
+        <artifactId>zipkin-reporter-brave</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-reporter-metrics-micrometer</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/brave/README.md
+++ b/brave/README.md
@@ -7,5 +7,14 @@ spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost
 tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
 ```
 
+*Note*: The minimum version of Brave is 5.6. If you are using a version of Brave before 5.12, you
+will also need to set the `spanReporter` to `Reporter.NOOP`. Otherwise, you will see a log
+message for each span.
+
+Ex.
+```java
+tracingBuilder.spanReporter(Reporter.NOOP);
+```
+
 
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,5 +1,5 @@
 # zipkin-reporter-brave
-This allows you to send spans recorded by Brave to a Zipkin reporter.
+This allows you to send spans recorded by Brave 5.6+ to a Zipkin reporter.
 
 Ex.
 ```java

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,13 +1,11 @@
 # zipkin-reporter-brave
-This module contains integration between `zipkin2.reporter.Reporter` and
-Brave's `FinishedSpanHandler`.
+This allows you to send spans recorded by Brave to a Zipkin reporter.
 
 Ex.
 ```java
-tracingBuilder.addFinishedSpanHandler(ZipkinFinishedSpanHandler.create(reporter));
+spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v2/spans"));
+tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
 ```
 
-This decouples Brave from this library and allows users to report to multiple
-Zipkin destinations at the same time.
 
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,0 +1,13 @@
+# zipkin-reporter-brave
+This module contains integration between `zipkin2.reporter.Reporter` and
+Brave's `FinishedSpanHandler`.
+
+Ex.
+```java
+tracingBuilder.addFinishedSpanHandler(ZipkinFinishedSpanHandler.create(reporter));
+```
+
+This decouples Brave from this library and allows users to report to multiple
+Zipkin destinations at the same time.
+
+

--- a/brave/README.md
+++ b/brave/README.md
@@ -15,6 +15,3 @@ Ex.
 ```java
 tracingBuilder.spanReporter(Reporter.NOOP);
 ```
-
-
-

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,17 +1,8 @@
 # zipkin-reporter-brave
-This allows you to send spans recorded by Brave 5.6+ to a Zipkin reporter.
+This allows you to send spans recorded by Brave 5.12+ to a Zipkin reporter.
 
 Ex.
 ```java
 spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v2/spans"));
-tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
-```
-
-*Note*: The minimum version of Brave is 5.6. If you are using a version of Brave before 5.12, you
-will also need to set the `spanReporter` to `Reporter.NOOP`. Otherwise, you will see a log
-message for each span.
-
-Ex.
-```java
-tracingBuilder.spanReporter(Reporter.NOOP);
+tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(reporter));
 ```

--- a/brave/bnd.bnd
+++ b/brave/bnd.bnd
@@ -1,0 +1,4 @@
+Import-Package: \
+  *
+Export-Package: \
+  zipkin2.reporter.brave

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright 2016-2020 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.zipkin.reporter2</groupId>
+    <artifactId>zipkin-reporter-parent</artifactId>
+    <version>2.12.4-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>zipkin-reporter-brave</artifactId>
+  <name>Zipkin Reporter Spring Factory Brave</name>
+  <description>Allows you to configure Zipkin Reporter using XML</description>
+
+  <properties>
+    <!-- Matches Export-Package in bnd.bnd -->
+    <module.name>zipkin2.reporter.brave</module.name>
+
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>5.11.2</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
-      <version>5.11.2</version>
+      <!-- Don't pin Brave -->
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -25,8 +25,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>zipkin-reporter-brave</artifactId>
-  <name>Zipkin Reporter Spring Factory Brave</name>
-  <description>Allows you to configure Zipkin Reporter using XML</description>
+  <name>Zipkin Reporter Brave</name>
+  <description>Adapts a Reporter to a Brave FinishedSpanHandler</description>
 
   <properties>
     <!-- Matches Export-Package in bnd.bnd -->

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -26,7 +26,7 @@
 
   <artifactId>zipkin-reporter-brave</artifactId>
   <name>Zipkin Reporter Brave</name>
-  <description>Adapts a Reporter to a Brave FinishedSpanHandler</description>
+  <description>Adapts a Reporter to a Brave SpanHandler</description>
 
   <properties>
     <!-- Matches Export-Package in bnd.bnd -->

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
@@ -96,8 +96,8 @@ public final class ZipkinSpanHandler extends SpanHandler {
      * @see TraceContext#sampledLocal()
      * @since 2.13
      */
-    public Builder alwaysReportSpans() {
-      this.alwaysReportSpans = true;
+    public Builder alwaysReportSpans(boolean alwaysReportSpans) {
+      this.alwaysReportSpans = alwaysReportSpans;
       return this;
     }
 

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
@@ -31,7 +31,7 @@ import zipkin2.reporter.Reporter;
  * <p>Ex.
  * <pre>{@code
  * spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v2/spans"));
- * tracingBuilder.addFinishedSpanHandler(ZipkinFinishedSpanHandler.create(reporter));
+ * tracingBuilder.addFinishedSpanHandler(ZipkinSpanHandler.create(reporter));
  * }</pre>
  *
  * @see brave.Tracing.Builder#addFinishedSpanHandler(FinishedSpanHandler)

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.ErrorParser;
+import brave.Tags;
+import brave.baggage.BaggageField;
+import brave.handler.FinishedSpanHandler;
+import brave.handler.MutableSpan;
+import brave.handler.MutableSpan.AnnotationConsumer;
+import brave.handler.MutableSpan.TagConsumer;
+import brave.propagation.TraceContext;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+/**
+ * This adapts a {@link Reporter} to a {@link FinishedSpanHandler} used by Brave.
+ *
+ * <p>Ex.
+ * <pre>{@code
+ * tracingBuilder.addFinishedSpanHandler(ZipkinFinishedSpanHandler.create(reporter));
+ * }</pre>
+ *
+ * @since 2.13
+ */
+// TODO: move to SpanHandler after Brave 5.12
+public final class ZipkinSpanHandler extends FinishedSpanHandler {
+
+  /** @since 2.13 */
+  public static FinishedSpanHandler create(Reporter<Span> spanReporter) {
+    return newBuilder(spanReporter).build();
+  }
+
+  /** @since 2.13 */
+  public static Builder newBuilder(Reporter<Span> spanReporter) {
+    return new Builder(spanReporter);
+  }
+
+  public static final class Builder {
+    Reporter<Span> spanReporter;
+    ErrorParser errorParser = new ErrorParser(); // TODO: Brave 5.12 ErrorParser.get()
+    boolean alwaysReportSpans;
+
+    Builder(Reporter<Span> spanReporter) {
+      if (spanReporter == null) throw new NullPointerException("spanReporter == null");
+      this.spanReporter = spanReporter;
+    }
+
+    /**
+     * Sets the "error" tag when absent and {@link MutableSpan#error()} is present.
+     *
+     * <p>Set to the same value as {@link brave.Tracing.Builder#errorParser(ErrorParser)}
+     *
+     * @see Tags#ERROR
+     * @since 2.13
+     */
+    // TODO: Brave 5.12 remove reference to deprecated Tracing.Builder.errorParser which is only
+    // used for Zipkin conversion
+    public Builder errorParser(ErrorParser errorParser) {
+      this.errorParser = errorParser;
+      return this;
+    }
+
+    /**
+     * When true, all spans {@link TraceContext#sampledLocal() sampled locally} are reported to the
+     * span reporter, even if they aren't sampled remotely. Defaults to {@code false}.
+     *
+     * <p>The primary use case is to implement a <a href="https://github.com/openzipkin-contrib/zipkin-secondary-sampling">sampling
+     * overlay</a>, such as boosting the sample rate for a subset of the network depending on the
+     * value of a {@link BaggageField baggage field}. This means that data will report when either
+     * the trace is normally sampled, or secondarily sampled via a custom header.
+     *
+     * <p>This is simpler than a custom {@link FinishedSpanHandler}, because you don't have to
+     * duplicate transport mechanics already implemented in the {@link Reporter span reporter}.
+     * However, this assumes your backend can properly process the partial traces implied when using
+     * conditional sampling. For example, if your sampling condition is not consistent on a call
+     * tree, the resulting data could appear broken.
+     *
+     * @see TraceContext#sampledLocal()
+     * @since 2.13
+     */
+    public Builder alwaysReportSpans() {
+      this.alwaysReportSpans = true;
+      return this;
+    }
+
+    public FinishedSpanHandler build() {
+      return new ZipkinSpanHandler(this);
+    }
+  }
+
+  final Reporter<Span> spanReporter;
+  final ErrorParser errorParser;
+  final boolean alwaysReportSpans;
+
+  ZipkinSpanHandler(Builder builder) {
+    this.spanReporter = builder.spanReporter;
+    this.errorParser = builder.errorParser;
+    this.alwaysReportSpans = builder.alwaysReportSpans;
+  }
+
+  @Override public boolean handle(TraceContext context, MutableSpan span) {
+    if (!alwaysReportSpans && !Boolean.TRUE.equals(context.sampled())) return true;
+    maybeAddErrorTag(span);
+    Span converted = convert(context, span);
+    spanReporter.report(converted);
+    return true;
+  }
+
+  @Override public boolean supportsOrphans() {
+    return true;
+  }
+
+  static Span convert(TraceContext context, MutableSpan span) {
+    // TODO: Brave 5.12: use span, not context for IDs as they could be remapped
+    Span.Builder result = Span.newBuilder()
+      .traceId(context.traceIdString())
+      .parentId(context.parentIdString())
+      .id(context.spanId())
+      .name(span.name());
+
+    long start = span.startTimestamp(), finish = span.finishTimestamp();
+    result.timestamp(start);
+    if (start != 0 && finish != 0L) result.duration(Math.max(finish - start, 1));
+
+    // use ordinal comparison to defend against version skew
+    brave.Span.Kind kind = span.kind();
+    if (kind != null && kind.ordinal() < Span.Kind.values().length) {
+      result.kind(Span.Kind.values()[kind.ordinal()]);
+    }
+
+    String localServiceName = span.localServiceName(), localIp = span.localIp();
+    if (localServiceName != null || localIp != null) {
+      result.localEndpoint(Endpoint.newBuilder()
+        .serviceName(localServiceName)
+        .ip(localIp)
+        .port(span.localPort())
+        .build());
+    }
+
+    String remoteServiceName = span.remoteServiceName(), remoteIp = span.remoteIp();
+    if (remoteServiceName != null || remoteIp != null) {
+      result.remoteEndpoint(Endpoint.newBuilder()
+        .serviceName(remoteServiceName)
+        .ip(remoteIp)
+        .port(span.remotePort())
+        .build());
+    }
+
+    span.forEachTag(Consumer.INSTANCE, result);
+    span.forEachAnnotation(Consumer.INSTANCE, result);
+    if (span.shared()) result.shared(true);
+    // if (span.debug()) result.debug(true); TODO: Brave 5.12
+    if (context.debug()) result.debug(true);
+    return result.build();
+  }
+
+  void maybeAddErrorTag(MutableSpan span) {
+    // span.tag(key) iterates: check if we need to first!
+    if (span.error() == null) return;
+    if (span.tag("error") == null) errorParser.error(span.error(), span);
+  }
+
+  @Override public String toString() {
+    return spanReporter.toString();
+  }
+
+  enum Consumer implements TagConsumer<Span.Builder>, AnnotationConsumer<Span.Builder> {
+    INSTANCE;
+
+    @Override public void accept(Span.Builder target, String key, String value) {
+      target.putTag(key, value);
+    }
+
+    @Override public void accept(Span.Builder target, long timestamp, String value) {
+      target.addAnnotation(timestamp, value);
+    }
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tracing;
+import brave.propagation.B3SingleFormat;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.Span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BasicUsageTest {
+  List<Span> spans = new ArrayList<>();
+  Tracing tracing = Tracing.newBuilder()
+      .localServiceName("Aa")
+      .localIp("1.2.3.4")
+      .localPort(80)
+      .addSpanHandler(ZipkinSpanHandler.create(spans::add))
+      .build();
+
+  @After public void close() {
+    tracing.close();
+  }
+
+  /** This mainly shows endpoints are taken from Brave, and error is back-filled. */
+  @Test public void basicSpan() {
+    TraceContext context = B3SingleFormat.parseB3SingleFormat(
+        "50d980fffa300f29-86154a4ba6e91385-1"
+    ).context();
+
+    tracing.tracer().toSpan(context).name("test")
+        .start(1L)
+        .error(new RuntimeException("this cake is a lie"))
+        .finish(3L);
+
+    assertThat(spans.get(0)).hasToString(
+        "{\"traceId\":\"50d980fffa300f29\","
+            + "\"id\":\"86154a4ba6e91385\","
+            + "\"name\":\"test\","
+            + "\"timestamp\":1,"
+            + "\"duration\":2,"
+            + "\"localEndpoint\":{"
+            + "\"serviceName\":\"aa\","
+            + "\"ipv4\":\"1.2.3.4\","
+            + "\"port\":80},"
+            + "\"tags\":{\"error\":\"this cake is a lie\"}}"
+    );
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -13,15 +13,18 @@
  */
 package zipkin2.reporter.brave;
 
+import brave.handler.FinishedSpanHandler;
 import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.junit.Before;
 import org.junit.Test;
 import zipkin2.Annotation;
 import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.reporter.Reporter;
 
 import static brave.Span.Kind.CLIENT;
 import static brave.Span.Kind.SERVER;
@@ -40,6 +43,25 @@ public class ZipkinSpanHandlerTest {
     defaultSpan.localIp("1.2.3.4");
     defaultSpan.localPort(80);
     handler = (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
+  }
+
+  @Test public void noopIsNoop() {
+    assertThat(ZipkinSpanHandler.create(Reporter.NOOP))
+      .isSameAs(FinishedSpanHandler.NOOP);
+  }
+
+  @Test public void equalsAndHashCode() {
+    assertThat(handler)
+      .hasSameHashCodeAs(ZipkinSpanHandler.create(handler.spanReporter))
+      .isEqualTo(ZipkinSpanHandler.create(handler.spanReporter));
+
+    FinishedSpanHandler otherHandler = ZipkinSpanHandler.create(s -> {
+    });
+
+    assertThat(handler)
+      .isNotEqualTo(otherHandler)
+      .extracting(Objects::hashCode)
+      .isNotEqualTo(otherHandler.hashCode());
   }
 
   @Test public void reportsSampledSpan() {

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -113,7 +113,7 @@ public class ZipkinSpanHandlerTest {
 
   @Test public void alwaysReportSpans_reportsUnsampledSpan() {
     handler = (ZipkinSpanHandler) ZipkinSpanHandler.newBuilder(spans::add)
-        .alwaysReportSpans()
+        .alwaysReportSpans(true)
         .build();
 
     TraceContext context =

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Annotation;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+
+import static brave.Span.Kind.CLIENT;
+import static brave.Span.Kind.SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class ZipkinSpanHandlerTest {
+  List<Span> spans = new ArrayList<>();
+  ZipkinSpanHandler handler;
+  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+  MutableSpan defaultSpan;
+
+  @Before public void init() {
+    defaultSpan = new MutableSpan();
+    defaultSpan.localServiceName("Aa");
+    defaultSpan.localIp("1.2.3.4");
+    defaultSpan.localPort(80);
+    handler = (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
+  }
+
+  @Test public void reportsSampledSpan() {
+    MutableSpan span = new MutableSpan();
+    handler.handle(context, span);
+
+    assertThat(spans.get(0)).isEqualToComparingFieldByField(
+      Span.newBuilder()
+        .traceId("1")
+        .id("2")
+        .build()
+    );
+  }
+
+  @Test public void reportsDebugSpan() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).debug(true).build();
+    MutableSpan span = new MutableSpan();
+    handler.handle(context, span);
+
+    assertThat(spans.get(0)).isEqualToComparingFieldByField(
+      Span.newBuilder()
+        .traceId("1")
+        .id("2")
+        .debug(true)
+        .build()
+    );
+  }
+
+  @Test public void doesntReportUnsampledSpan() {
+    TraceContext context =
+      TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).sampledLocal(true).build();
+    handler.handle(context, new MutableSpan());
+
+    assertThat(spans).isEmpty();
+  }
+
+  @Test public void alwaysReportSpans_reportsUnsampledSpan() {
+    handler = (ZipkinSpanHandler) ZipkinSpanHandler.newBuilder(spans::add)
+      .alwaysReportSpans()
+      .build();
+
+    TraceContext context =
+      TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).sampledLocal(true).build();
+    handler.handle(context, new MutableSpan());
+
+    assertThat(spans).isNotEmpty();
+  }
+
+  @Test public void minimumDurationIsOne() {
+    MutableSpan span = new MutableSpan();
+
+    span.startTimestamp(1L);
+    span.finishTimestamp(1L);
+
+    handler.handle(context, span);
+    assertThat(spans.get(0).duration()).isEqualTo(1L);
+  }
+
+  @Test public void replacesTag() {
+    MutableSpan span = new MutableSpan();
+
+    span.tag("1", "1");
+    span.tag("foo", "bar");
+    span.tag("2", "2");
+    span.tag("foo", "baz");
+    span.tag("3", "3");
+
+    handler.handle(context, span);
+    assertThat(spans.get(0).tags()).containsOnly(
+      entry("1", "1"),
+      entry("foo", "baz"),
+      entry("2", "2"),
+      entry("3", "3")
+    );
+  }
+
+  Throwable ERROR = new RuntimeException();
+
+  @Test public void backfillsErrorTag() {
+    MutableSpan span = new MutableSpan();
+
+    span.error(ERROR);
+
+    handler.handle(context, span);
+
+    assertThat(spans.get(0).tags())
+      .containsOnly(entry("error", "RuntimeException"));
+  }
+
+  @Test public void doesntOverwriteErrorTag() {
+    MutableSpan span = new MutableSpan();
+
+    span.error(ERROR);
+    span.tag("error", "");
+
+    handler.handle(context, span);
+
+    assertThat(spans.get(0).tags())
+      .containsOnly(entry("error", ""));
+  }
+
+  @Test public void addsAnnotations() {
+    MutableSpan span = new MutableSpan();
+
+    span.startTimestamp(1L);
+    span.annotate(2L, "foo");
+    span.finishTimestamp(2L);
+
+    handler.handle(context, span);
+
+    assertThat(spans.get(0).annotations())
+      .containsOnly(Annotation.create(2L, "foo"));
+  }
+
+  @Test public void finished_client() {
+    finish(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
+  }
+
+  @Test public void finished_server() {
+    finish(brave.Span.Kind.SERVER, Span.Kind.SERVER);
+  }
+
+  @Test public void finished_producer() {
+    finish(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
+  }
+
+  @Test public void finished_consumer() {
+    finish(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
+  }
+
+  void finish(brave.Span.Kind braveKind, Span.Kind span2Kind) {
+    MutableSpan span = new MutableSpan();
+    span.kind(braveKind);
+    span.startTimestamp(1L);
+    span.finishTimestamp(2L);
+
+    handler.handle(context, span);
+
+    Span zipkinSpan = spans.get(0);
+    assertThat(zipkinSpan.annotations()).isEmpty();
+    assertThat(zipkinSpan.timestamp()).isEqualTo(1L);
+    assertThat(zipkinSpan.duration()).isEqualTo(1L);
+    assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
+  }
+
+  @Test public void flushed_client() {
+    flush(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
+  }
+
+  @Test public void flushed_server() {
+    flush(brave.Span.Kind.SERVER, Span.Kind.SERVER);
+  }
+
+  @Test public void flushed_producer() {
+    flush(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
+  }
+
+  @Test public void flushed_consumer() {
+    flush(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
+  }
+
+  void flush(brave.Span.Kind braveKind, Span.Kind span2Kind) {
+    MutableSpan span = new MutableSpan();
+    span.kind(braveKind);
+    span.startTimestamp(1L);
+    span.finishTimestamp(0L);
+
+    handler.handle(context, span);
+
+    Span zipkinSpan = spans.get(0);
+    assertThat(zipkinSpan.annotations()).isEmpty();
+    assertThat(zipkinSpan.timestamp()).isEqualTo(1L);
+    assertThat(zipkinSpan.duration()).isNull();
+    assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
+  }
+
+  @Test public void remoteEndpoint() {
+    MutableSpan span = new MutableSpan();
+
+    Endpoint endpoint = Endpoint.newBuilder()
+      .serviceName("fooService")
+      .ip("1.2.3.4")
+      .port(80)
+      .build();
+
+    span.kind(CLIENT);
+    span.remoteServiceName(endpoint.serviceName());
+    span.remoteIpAndPort(endpoint.ipv4(), endpoint.port());
+    span.startTimestamp(1L);
+    span.finishTimestamp(2L);
+
+    handler.handle(context, span);
+
+    assertThat(spans.get(0).remoteEndpoint())
+      .isEqualTo(endpoint);
+  }
+
+  // This prevents the server startTimestamp from overwriting the client one on the collector
+  @Test public void writeTo_sharedStatus() {
+    MutableSpan span = new MutableSpan();
+
+    span.setShared();
+    span.startTimestamp(1L);
+    span.kind(SERVER);
+    span.finishTimestamp(2L);
+
+    handler.handle(context, span);
+
+    assertThat(spans.get(0).shared())
+      .isTrue();
+  }
+
+  @Test public void flushUnstartedNeitherSetsTimestampNorDuration() {
+    MutableSpan flushed = new MutableSpan();
+    flushed.finishTimestamp(0L);
+
+    handler.handle(context, flushed);
+
+    assertThat(spans.get(0)).extracting(Span::timestampAsLong, Span::durationAsLong)
+      .allSatisfy(u -> assertThat(u).isEqualTo(0L));
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -27,6 +27,8 @@ import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
 import static brave.Span.Kind.CLIENT;
+import static brave.Span.Kind.CONSUMER;
+import static brave.Span.Kind.PRODUCER;
 import static brave.Span.Kind.SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -43,6 +45,15 @@ public class ZipkinSpanHandlerTest {
     defaultSpan.localIp("1.2.3.4");
     defaultSpan.localPort(80);
     handler = (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
+  }
+
+  @Test public void generateKindMap() {
+    assertThat(ZipkinSpanHandler.generateKindMap()).containsExactly(
+      entry(CLIENT, Span.Kind.CLIENT),
+      entry(SERVER, Span.Kind.SERVER),
+      entry(PRODUCER, Span.Kind.PRODUCER),
+      entry(CONSUMER, Span.Kind.CONSUMER)
+    );
   }
 
   @Test public void noopIsNoop() {

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,8 @@
     <!-- use the same value in bom/pom.xml -->
     <zipkin.version>2.21.1</zipkin.version>
 
-    <!-- Intentionally old for a while. Ex Allows usage in Sleuth 2.0.4
-         Regardless, do not set this value in bom/pom.xml -->
-    <brave.version>5.6.0</brave.version>
+    <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
+    <brave.version>5.11.3-SNAPSHOT</brave.version>
 
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,10 @@
 
     <!-- use the same value in bom/pom.xml -->
     <zipkin.version>2.21.1</zipkin.version>
+
+    <!-- do not set this value in bom/pom.xml -->
+    <brave.version>5.11.2</brave.version>
+
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
@@ -123,6 +127,11 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-reporter</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.zipkin.brave</groupId>
+        <artifactId>brave</artifactId>
+        <version>${brave.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <zipkin.version>2.21.1</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>5.11.3-SNAPSHOT</brave.version>
+    <brave.version>5.12.0</brave.version>
 
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,9 @@
     <!-- use the same value in bom/pom.xml -->
     <zipkin.version>2.21.1</zipkin.version>
 
-    <!-- do not set this value in bom/pom.xml -->
-    <brave.version>5.11.2</brave.version>
+    <!-- Intentionally old for a while. Ex Allows usage in Sleuth 2.0.4
+         Regardless, do not set this value in bom/pom.xml -->
+    <brave.version>5.6.0</brave.version>
 
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
@@ -132,6 +133,12 @@
         <groupId>io.zipkin.brave</groupId>
         <artifactId>brave</artifactId>
         <version>${brave.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <module>libthrift</module>
     <module>spring-beans</module>
     <module>benchmarks</module>
+    <module>brave</module>
     <module>metrics-micrometer</module>
   </modules>
 

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -38,3 +38,36 @@ Here's an example with Kafka configuration and extended configuration:
     <property name="closeTimeout" value="500"/>
   </bean>
 ```
+
+Here's an example integrating with [Brave](https://github.com/openzipkin/brave/tree/master/spring-beans)
+
+```xml
+<bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
+  <property name="localServiceName" value="${zipkin.service}"/>
+  <property name="finishedSpanHandlers">
+    <bean class="zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean">
+      <property name="spanReporter" ref="spanReporter"/>
+    </bean>
+  </property>
+</bean>
+```
+
+*Note*: The minimum version of Brave is 5.6. If you are using a version of Brave before 5.12, you
+will also need to set the "spanReporter" field to `Reporter.NOOP`. Otherwise, you will see a log
+message for each span.
+
+Ex.
+```xml
+<bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
+  <property name="localServiceName" value="${zipkin.service}"/>
+  <property name="finishedSpanHandlers">
+    <bean class="zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean">
+      <property name="spanReporter" ref="spanReporter"/>
+    </bean>
+  </property>
+  <!-- Suppress the logging reporter -->
+  <property name="spanReporter">
+    <util:constant static-field="zipkin2.reporter.Reporter.NOOP"/>
+  </property>
+</bean>
+```

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -39,35 +39,15 @@ Here's an example with Kafka configuration and extended configuration:
   </bean>
 ```
 
-Here's an example integrating with [Brave](https://github.com/openzipkin/brave/tree/master/spring-beans)
+Here's an example integrating with [Brave 5.12+](https://github.com/openzipkin/brave/tree/master/spring-beans)
 
 ```xml
 <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
   <property name="localServiceName" value="${zipkin.service}"/>
-  <property name="finishedSpanHandlers">
+  <property name="spanHandlers">
     <bean class="zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean">
       <property name="spanReporter" ref="spanReporter"/>
     </bean>
-  </property>
-</bean>
-```
-
-*Note*: The minimum version of Brave is 5.6. If you are using a version of Brave before 5.12, you
-will also need to set the "spanReporter" field to `Reporter.NOOP`. Otherwise, you will see a log
-message for each span.
-
-Ex.
-```xml
-<bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
-  <property name="localServiceName" value="${zipkin.service}"/>
-  <property name="finishedSpanHandlers">
-    <bean class="zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean">
-      <property name="spanReporter" ref="spanReporter"/>
-    </bean>
-  </property>
-  <!-- Suppress the logging reporter -->
-  <property name="spanReporter">
-    <util:constant static-field="zipkin2.reporter.Reporter.NOOP"/>
   </property>
 </bean>
 ```

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -1,6 +1,6 @@
 # zipkin-reporter-spring-beans
 This module contains Spring Factory Beans that allow you to configure
-tracing with only XML. Notably, this requires minimally Spring version 2.5.
+zipkinSpanHandler with only XML. Notably, this requires minimally Spring version 2.5.
 
 ## Configuration
 Bean Factories exist for the following types:
@@ -10,6 +10,7 @@ Bean Factories exist for the following types:
 * KafkaSenderFactoryBean - for [zipkin-sender-kafka](../kafka)
 * RabbitMQSenderFactoryBean - for [zipkin-sender-amqp-client](../amqp-client)
 * URLConnectionSenderFactoryBean - for [zipkin-sender-urlconnection](../urlconnection)
+* ZipkinSpanHandlerFactoryBeanTest - for [brave](https://github.com/openzipkin/brave)
 
 Here's a basic example
 ```xml

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -81,6 +81,16 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter-brave</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
       <version>2.5.6</version>

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
@@ -13,7 +13,7 @@
  */
 package zipkin2.reporter.beans;
 
-import brave.ErrorParser;
+import brave.Tag;
 import brave.handler.SpanHandler;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.Span;
@@ -23,13 +23,13 @@ import zipkin2.reporter.brave.ZipkinSpanHandler;
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
   Reporter<Span> spanReporter;
-  ErrorParser errorParser;
+  Tag<Throwable> errorTag;
   Boolean alwaysReportSpans;
 
   @Override protected SpanHandler createInstance() {
     ZipkinSpanHandler.Builder builder = ZipkinSpanHandler.newBuilder(spanReporter);
-    if (errorParser != null) builder.errorParser(errorParser);
-    if (alwaysReportSpans != null) builder.alwaysReportSpans();
+    if (errorTag != null) builder.errorTag(errorTag);
+    if (alwaysReportSpans != null) builder.alwaysReportSpans(alwaysReportSpans);
     return builder.build();
   }
 
@@ -48,8 +48,8 @@ public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
     this.spanReporter = spanReporter;
   }
 
-  public void setErrorParser(ErrorParser errorParser) {
-    this.errorParser = errorParser;
+  public void setErrorTag(Tag<Throwable> errorTag) {
+    this.errorTag = errorTag;
   }
 
   public void setAlwaysReportSpans(Boolean alwaysReportSpans) {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
@@ -14,7 +14,7 @@
 package zipkin2.reporter.beans;
 
 import brave.ErrorParser;
-import brave.handler.FinishedSpanHandler;
+import brave.handler.SpanHandler;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.Span;
 import zipkin2.reporter.Reporter;
@@ -26,7 +26,7 @@ public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
   ErrorParser errorParser;
   Boolean alwaysReportSpans;
 
-  @Override protected FinishedSpanHandler createInstance() {
+  @Override protected SpanHandler createInstance() {
     ZipkinSpanHandler.Builder builder = ZipkinSpanHandler.newBuilder(spanReporter);
     if (errorParser != null) builder.errorParser(errorParser);
     if (alwaysReportSpans != null) builder.alwaysReportSpans();
@@ -36,8 +36,8 @@ public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
   @Override protected void destroyInstance(Object instance) {
   }
 
-  @Override public Class<? extends FinishedSpanHandler> getObjectType() {
-    return FinishedSpanHandler.class;
+  @Override public Class<? extends SpanHandler> getObjectType() {
+    return SpanHandler.class;
   }
 
   @Override public boolean isSingleton() {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import brave.ErrorParser;
+import brave.handler.FinishedSpanHandler;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
+
+/** Spring XML config does not support chained builders. This converts accordingly */
+public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
+  Reporter<Span> spanReporter;
+  ErrorParser errorParser;
+  Boolean alwaysReportSpans;
+
+  @Override protected FinishedSpanHandler createInstance() {
+    ZipkinSpanHandler.Builder builder = ZipkinSpanHandler.newBuilder(spanReporter);
+    if (errorParser != null) builder.errorParser(errorParser);
+    if (alwaysReportSpans != null) builder.alwaysReportSpans();
+    return builder.build();
+  }
+
+  @Override protected void destroyInstance(Object instance) {
+  }
+
+  @Override public Class<? extends FinishedSpanHandler> getObjectType() {
+    return FinishedSpanHandler.class;
+  }
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setSpanReporter(Reporter<Span> spanReporter) {
+    this.spanReporter = spanReporter;
+  }
+
+  public void setErrorParser(ErrorParser errorParser) {
+    this.errorParser = errorParser;
+  }
+
+  public void setAlwaysReportSpans(Boolean alwaysReportSpans) {
+    this.alwaysReportSpans = alwaysReportSpans;
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
@@ -13,7 +13,8 @@
  */
 package zipkin2.reporter.beans;
 
-import brave.ErrorParser;
+import brave.Tag;
+import brave.propagation.TraceContext;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.reporter.Reporter;
@@ -22,7 +23,11 @@ import zipkin2.reporter.brave.ZipkinSpanHandler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipkinSpanHandlerFactoryBeanTest {
-  public static final ErrorParser ERROR_PARSER = new ErrorParser();
+  public static final Tag<Throwable> ERROR_TAG = new Tag<Throwable>("error") {
+    @Override protected String parseValue(Throwable throwable, TraceContext traceContext) {
+      return null;
+    }
+  };
 
   XmlBeans context;
 
@@ -32,47 +37,47 @@ public class ZipkinSpanHandlerFactoryBeanTest {
 
   @Test public void spanReporter() {
     context = new XmlBeans(""
-      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
-      + "  <property name=\"spanReporter\">\n"
-      + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
-      + "  </property>\n"
-      + "</bean>"
+        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
+        + "  <property name=\"spanReporter\">\n"
+        + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
-      .extracting("spanReporter")
-      .isEqualTo(Reporter.CONSOLE);
+        .extracting("spanReporter")
+        .isEqualTo(Reporter.CONSOLE);
   }
 
-  @Test public void errorParser() {
+  @Test public void errorTag() {
     context = new XmlBeans(""
-      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
-      + "  <property name=\"spanReporter\">\n"
-      + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
-      + "  </property>\n"
-      + "  <property name=\"errorParser\">\n"
-      + "    <util:constant static-field=\"" + getClass().getName() + ".ERROR_PARSER\"/>\n"
-      + "  </property>\n"
-      + "</bean>"
+        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
+        + "  <property name=\"spanReporter\">\n"
+        + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"errorTag\">\n"
+        + "    <util:constant static-field=\"" + getClass().getName() + ".ERROR_TAG\"/>\n"
+        + "  </property>\n"
+        + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
-      .extracting("errorParser")
-      .isSameAs(ERROR_PARSER);
+        .extracting("errorTag")
+        .isSameAs(ERROR_TAG);
   }
 
   @Test public void alwaysReportSpans() {
     context = new XmlBeans(""
-      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
-      + "  <property name=\"spanReporter\">\n"
-      + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
-      + "  </property>\n"
-      + "  <property name=\"alwaysReportSpans\" value=\"true\"/>\n"
-      + "</bean>"
+        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
+        + "  <property name=\"spanReporter\">\n"
+        + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
+        + "  </property>\n"
+        + "  <property name=\"alwaysReportSpans\" value=\"true\"/>\n"
+        + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
-      .extracting("alwaysReportSpans")
-      .isEqualTo(true);
+        .extracting("alwaysReportSpans")
+        .isEqualTo(true);
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import brave.ErrorParser;
+import org.junit.After;
+import org.junit.Test;
+import zipkin2.reporter.Reporter;
+import zipkin2.reporter.brave.ZipkinSpanHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ZipkinSpanHandlerFactoryBeanTest {
+  public static final ErrorParser ERROR_PARSER = new ErrorParser();
+
+  XmlBeans context;
+
+  @After public void close() {
+    if (context != null) context.close();
+  }
+
+  @Test public void spanReporter() {
+    context = new XmlBeans(""
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"spanReporter\">\n"
+      + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
+      .extracting("spanReporter")
+      .isEqualTo(Reporter.CONSOLE);
+  }
+
+  @Test public void errorParser() {
+    context = new XmlBeans(""
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"spanReporter\">\n"
+      + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"errorParser\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".ERROR_PARSER\"/>\n"
+      + "  </property>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
+      .extracting("errorParser")
+      .isSameAs(ERROR_PARSER);
+  }
+
+  @Test public void alwaysReportSpans() {
+    context = new XmlBeans(""
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"spanReporter\">\n"
+      + "    <util:constant static-field=\"zipkin2.reporter.Reporter.CONSOLE\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"alwaysReportSpans\" value=\"true\"/>\n"
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
+      .extracting("alwaysReportSpans")
+      .isEqualTo(true);
+  }
+}


### PR DESCRIPTION
This takes a copy of `ZipkinSpanHandler` in Brave so that we can
eventually decouple Brave from a compile depedency on Zipkin Reporter.

This also allows the commonly requested feature (such as exists in Sleuth)
to allow multiple simultaneous reporters.