### PR TITLE
Adds AsyncZipkinSpanHandler to write Brave's span directly to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ reporter.report(span);
 ```
 
 ## Brave
-Those using the [Brave library](https://github.com/openzipkin/brave) can adapt
-the `Reporter<Span>` here to a Brave `SpanHandler`.
+Those using the [Brave library](https://github.com/openzipkin/brave) can skip
+overhead by using `AsyncZipkinSpanHandler`.
 
 Ex.
 ```java
-tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(reporter));
+sender = URLConnectionSender.create("http://localhost:9411/api/v2/spans");
+zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender); // don't forget to close!
+tracingBuilder.addSpanHandler(zipkinSpanHandler);
 ```
 
 See [zipkin-reporter-brave](brave/README.md) for more details.

--- a/brave/README.md
+++ b/brave/README.md
@@ -1,8 +1,17 @@
 # zipkin-reporter-brave
 This allows you to send spans recorded by Brave 5.12+ to a Zipkin reporter.
 
-Ex.
+If using Zipkin V2 JSON format, construct the span handler so that it writes Brave's data
+directly as JSON:
 ```java
-spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v2/spans"));
+sender = URLConnectionSender.create("http://localhost:9411/api/v2/spans");
+zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender); // don't forget to close!
+tracingBuilder.addSpanHandler(zipkinSpanHandler);
+```
+
+If you need to use a different format, you can pass a constructed reporter instead:
+```java
+reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
+                        .build(SpanBytesEncoder.JSON_V1);
 tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(reporter));
 ```

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
@@ -44,6 +46,19 @@
       <artifactId>brave</artifactId>
       <!-- Don't pin Brave -->
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-junit</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
+import java.io.Closeable;
+import java.io.Flushable;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ReporterMetrics;
+import zipkin2.reporter.Sender;
+
+/**
+ * A {@link brave.handler.SpanHandler} that queues spans on {@link #end} to bundle and send as a
+ * bulk <a href="https://zipkin.io/zipkin-api/#/">Zipkin JSON V2</a> message. When the {@link
+ * Sender} is HTTP, the endpoint is usually "http://zipkinhost:9411/api/v2/spans".
+ *
+ * <p>Example:
+ * <pre>{@code
+ * sender = URLConnectionSender.create("http://localhost:9411/api/v2/spans");
+ * zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender); // don't forget to close!
+ * tracingBuilder.addSpanHandler(zipkinSpanHandler);
+ * }</pre>
+ *
+ * @see ZipkinSpanHandler if you need to use a different format
+ * @see brave.Tracing.Builder#addSpanHandler(SpanHandler)
+ * @since 2.14
+ */
+public final class AsyncZipkinSpanHandler extends ZipkinSpanHandler
+    implements Closeable, Flushable {
+  /** @since 2.14 */
+  public static AsyncZipkinSpanHandler create(Sender sender) {
+    return newBuilder(sender).build();
+  }
+
+  /** @since 2.14 */
+  public static Builder newBuilder(Sender sender) {
+    if (sender == null) throw new NullPointerException("sender == null");
+    return new Builder(sender);
+  }
+
+  /** @since 5.14 */
+  public static final class Builder extends ZipkinSpanHandler.Builder {
+    final AsyncReporter.Builder delegate;
+
+    Builder(Sender sender) {
+      this.delegate = AsyncReporter.builder(sender);
+    }
+
+    /**
+     * @see AsyncReporter.Builder#threadFactory(ThreadFactory)
+     * @since 2.14
+     */
+    public Builder threadFactory(ThreadFactory threadFactory) {
+      delegate.threadFactory(threadFactory);
+      return this;
+    }
+
+    /**
+     * @see AsyncReporter.Builder#metrics(ReporterMetrics)
+     * @since 2.14
+     */
+    public Builder metrics(ReporterMetrics metrics) {
+      delegate.metrics(metrics);
+      return this;
+    }
+
+    /**
+     * @see AsyncReporter.Builder#messageMaxBytes(int)
+     * @since 2.14
+     */
+    public Builder messageMaxBytes(int messageMaxBytes) {
+      delegate.messageMaxBytes(messageMaxBytes);
+      return this;
+    }
+
+    /**
+     * @see AsyncReporter.Builder#messageTimeout(long, TimeUnit)
+     * @since 2.14
+     */
+    public Builder messageTimeout(long timeout, TimeUnit unit) {
+      delegate.messageTimeout(timeout, unit);
+      return this;
+    }
+
+    /**
+     * @see AsyncReporter.Builder#closeTimeout(long, TimeUnit)
+     * @since 2.14
+     */
+    public Builder closeTimeout(long timeout, TimeUnit unit) {
+      delegate.closeTimeout(timeout, unit);
+      return this;
+    }
+
+    /**
+     * @see AsyncReporter.Builder#queuedMaxSpans(int)
+     * @since 2.14
+     */
+    public Builder queuedMaxSpans(int queuedMaxSpans) {
+      delegate.queuedMaxSpans(queuedMaxSpans);
+      return this;
+    }
+
+    /**
+     * @see AsyncReporter.Builder#queuedMaxBytes(int)
+     * @since 2.14
+     */
+    public Builder queuedMaxBytes(int queuedMaxBytes) {
+      delegate.queuedMaxBytes(queuedMaxBytes);
+      return this;
+    }
+
+    @Override public Builder errorTag(Tag<Throwable> errorTag) {
+      return (Builder) super.errorTag(errorTag);
+    }
+
+    @Override public Builder alwaysReportSpans(boolean alwaysReportSpans) {
+      return (Builder) super.alwaysReportSpans(alwaysReportSpans);
+    }
+
+    // AsyncZipkinSpanHandler not SpanHandler, so that Flushable and Closeable are accessible
+    public AsyncZipkinSpanHandler build() {
+      return new AsyncZipkinSpanHandler(delegate.build(new JsonV2Encoder(errorTag)),
+          alwaysReportSpans);
+    }
+  }
+
+  AsyncZipkinSpanHandler(AsyncReporter<MutableSpan> asyncReporter, boolean alwaysReportSpans) {
+    super(asyncReporter, alwaysReportSpans);
+  }
+
+  @Override public void flush() {
+    ((AsyncReporter) spanReporter).flush();
+  }
+
+  @Override public void close() {
+    ((AsyncReporter) spanReporter).close();
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/ConvertingSpanReporter.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ConvertingSpanReporter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Span.Kind;
+import brave.Tag;
+import brave.handler.MutableSpan;
+import brave.handler.MutableSpan.AnnotationConsumer;
+import brave.handler.MutableSpan.TagConsumer;
+import brave.handler.SpanHandler;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+final class ConvertingSpanReporter implements Reporter<MutableSpan> {
+  static final Logger logger = Logger.getLogger(ConvertingSpanReporter.class.getName());
+  static final Map<Kind, Span.Kind> BRAVE_TO_ZIPKIN_KIND = generateKindMap();
+
+  final Reporter<Span> delegate;
+  final Tag<Throwable> errorTag;
+
+  ConvertingSpanReporter(Reporter<Span> delegate, Tag<Throwable> errorTag) {
+    this.delegate = delegate;
+    this.errorTag = errorTag;
+  }
+
+  @Override public void report(MutableSpan span) {
+    maybeAddErrorTag(span);
+    Span converted = convert(span);
+    delegate.report(converted);
+  }
+
+  static Span convert(MutableSpan span) {
+    Span.Builder result = Span.newBuilder()
+        .traceId(span.traceId())
+        .parentId(span.parentId())
+        .id(span.id())
+        .name(span.name());
+
+    long start = span.startTimestamp(), finish = span.finishTimestamp();
+    result.timestamp(start);
+    if (start != 0 && finish != 0L) result.duration(Math.max(finish - start, 1));
+
+    // use ordinal comparison to defend against version skew
+    Kind kind = span.kind();
+    if (kind != null) {
+      result.kind(BRAVE_TO_ZIPKIN_KIND.get(kind));
+    }
+
+    String localServiceName = span.localServiceName(), localIp = span.localIp();
+    if (localServiceName != null || localIp != null) {
+      result.localEndpoint(Endpoint.newBuilder()
+          .serviceName(localServiceName)
+          .ip(localIp)
+          .port(span.localPort())
+          .build());
+    }
+
+    String remoteServiceName = span.remoteServiceName(), remoteIp = span.remoteIp();
+    if (remoteServiceName != null || remoteIp != null) {
+      result.remoteEndpoint(Endpoint.newBuilder()
+          .serviceName(remoteServiceName)
+          .ip(remoteIp)
+          .port(span.remotePort())
+          .build());
+    }
+
+    span.forEachTag(Consumer.INSTANCE, result);
+    span.forEachAnnotation(Consumer.INSTANCE, result);
+    if (span.shared()) result.shared(true);
+    if (span.debug()) result.debug(true);
+    return result.build();
+  }
+
+  void maybeAddErrorTag(MutableSpan span) {
+    // span.tag(key) iterates: check if we need to first!
+    if (span.error() == null) return;
+    if (span.tag("error") == null) errorTag.tag(span.error(), null, span);
+  }
+
+  @Override public String toString() {
+    return delegate.toString();
+  }
+
+  /**
+   * Overridden to avoid duplicates when added via {@link brave.Tracing.Builder#addSpanHandler(SpanHandler)}
+   */
+  @Override public final boolean equals(Object o) {
+    if (o == this) return true;
+    if (!(o instanceof ConvertingSpanReporter)) return false;
+    return delegate.equals(((ConvertingSpanReporter) o).delegate);
+  }
+
+  /**
+   * Overridden to avoid duplicates when added via {@link brave.Tracing.Builder#addSpanHandler(SpanHandler)}
+   */
+  @Override public final int hashCode() {
+    return delegate.hashCode();
+  }
+
+  enum Consumer implements TagConsumer<Span.Builder>, AnnotationConsumer<Span.Builder> {
+    INSTANCE;
+
+    @Override public void accept(Span.Builder target, String key, String value) {
+      target.putTag(key, value);
+    }
+
+    @Override public void accept(Span.Builder target, long timestamp, String value) {
+      target.addAnnotation(timestamp, value);
+    }
+  }
+
+  /**
+   * This keeps the code maintenance free in the rare case there is disparity between Brave and
+   * Zipkin kind values.
+   */
+  static Map<Kind, Span.Kind> generateKindMap() {
+    Map<Kind, Span.Kind> result = new LinkedHashMap<>();
+    // Note: Both Brave and Zipkin treat null kind as a local/in-process span
+    for (Kind kind : Kind.values()) {
+      try {
+        result.put(kind, Span.Kind.valueOf(kind.name()));
+      } catch (RuntimeException e) {
+        logger.warning("Could not map Brave kind " + kind + " to Zipkin");
+      }
+    }
+    return result;
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/JsonV2Encoder.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/JsonV2Encoder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+import brave.handler.MutableSpanBytesEncoder;
+import java.util.List;
+import zipkin2.codec.BytesEncoder;
+import zipkin2.codec.Encoding;
+
+final class JsonV2Encoder implements BytesEncoder<MutableSpan> {
+  final MutableSpanBytesEncoder delegate;
+
+  JsonV2Encoder(Tag<Throwable> errorTag) {
+    this.delegate = MutableSpanBytesEncoder.zipkinJsonV2(errorTag);
+  }
+
+  @Override public Encoding encoding() {
+    return Encoding.JSON;
+  }
+
+  @Override public int sizeInBytes(MutableSpan span) {
+    return delegate.sizeInBytes(span);
+  }
+
+  @Override public byte[] encode(MutableSpan span) {
+    return delegate.encode(span);
+  }
+
+  @Override public byte[] encodeList(List<MutableSpan> spans) {
+    return delegate.encodeList(spans);
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
@@ -13,67 +13,83 @@
  */
 package zipkin2.reporter.brave;
 
-import brave.Span.Kind;
 import brave.Tag;
 import brave.Tags;
 import brave.handler.MutableSpan;
-import brave.handler.MutableSpan.AnnotationConsumer;
-import brave.handler.MutableSpan.TagConsumer;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.logging.Logger;
-import zipkin2.Endpoint;
 import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.Reporter;
 
 /**
- * This allows you to send spans recorded by Brave to a {@linkplain Reporter Zipkin reporter}.
+ * This allows you to send spans recorded by Brave to a pre-configured {@linkplain Reporter Zipkin
+ * reporter}.
  *
- * <p>Ex.
+ * <p>If you can't use {@link AsyncZipkinSpanHandler} because you are using an old format,
+ * construct
+ * the span handler like this:
  * <pre>{@code
- * spanReporter = AsyncReporter.create(URLConnectionSender.create("http://localhost:9411/api/v2/spans"));
+ * reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
+ *                         .build(SpanBytesEncoder.JSON_V1);
  * tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(reporter));
  * }</pre>
  *
+ * <p><em>Note</em>: Use {@link AsyncZipkinSpanHandler} if you are using {@link
+ * SpanBytesEncoder#JSON_V2} format. This handler has to convert {@link MutableSpan} into {@link
+ * Span}, and that conversion happens inline (during production requests) upon {@link
+ * brave.Span#finish()} or {@link brave.Span#flush()}.
+ *
+ * @see AsyncZipkinSpanHandler
  * @see brave.Tracing.Builder#addSpanHandler(SpanHandler)
  * @since 2.13
  */
-public final class ZipkinSpanHandler extends SpanHandler {
-  static final Logger logger = Logger.getLogger(ZipkinSpanHandler.class.getName());
-  static final Map<Kind, Span.Kind> BRAVE_TO_ZIPKIN_KIND = generateKindMap();
-
+public class ZipkinSpanHandler extends SpanHandler {
   /** @since 2.13 */
+  // SpanHandler not ZipkinSpanHandler as it can coerce to NOOP
   public static SpanHandler create(Reporter<Span> spanReporter) {
     return newBuilder(spanReporter).build();
   }
 
   /** @since 2.13 */
   public static Builder newBuilder(Reporter<Span> spanReporter) {
-    return new Builder(spanReporter);
+    if (spanReporter == null) throw new NullPointerException("spanReporter == null");
+    return new ConvertingSpanReporterBuilder(spanReporter);
   }
 
-  public static final class Builder {
-    Reporter<Span> spanReporter;
+  static final class ConvertingSpanReporterBuilder extends Builder {
+    final Reporter<Span> spanReporter;
+
+    ConvertingSpanReporterBuilder(Reporter<Span> spanReporter) {
+      this.spanReporter = spanReporter;
+    }
+
+    // SpanHandler not ZipkinSpanHandler as it can coerce to NOOP
+    @Override public SpanHandler build() {
+      if (spanReporter == Reporter.NOOP) return SpanHandler.NOOP;
+      return new ZipkinSpanHandler(new ConvertingSpanReporter(spanReporter, errorTag),
+          alwaysReportSpans);
+    }
+  }
+
+  public static abstract class Builder {
     Tag<Throwable> errorTag = Tags.ERROR;
     boolean alwaysReportSpans;
 
-    Builder(Reporter<Span> spanReporter) {
-      if (spanReporter == null) throw new NullPointerException("spanReporter == null");
-      this.spanReporter = spanReporter;
+    Builder() { // sealed
     }
 
     /**
      * Sets the "error" tag when absent and {@link MutableSpan#error()} is present.
      *
      * <p><em>Note</em>: Zipkin format uses the {@linkplain Tags#ERROR "error" tag}, but
-     * alternative formats may have a different tag name or a field entirely. Hence, we only create the "error"
-     * tag here, and only if not previously set.
+     * alternative formats may have a different tag name or a field entirely. Hence, we only create
+     * the "error" tag here, and only if not previously set.
      *
      * @since 2.13
      */
     public Builder errorTag(Tag<Throwable> errorTag) {
+      if (errorTag == null) throw new NullPointerException("errorTag == null");
       this.errorTag = errorTag;
       return this;
     }
@@ -101,80 +117,21 @@ public final class ZipkinSpanHandler extends SpanHandler {
       return this;
     }
 
-    public SpanHandler build() {
-      if (spanReporter == Reporter.NOOP) return SpanHandler.NOOP;
-      return new ZipkinSpanHandler(this);
-    }
+    public abstract SpanHandler build();
   }
 
-  final Reporter<Span> spanReporter;
-  final Tag<Throwable> errorTag;
+  final Reporter<MutableSpan> spanReporter;
   final boolean alwaysReportSpans;
 
-  ZipkinSpanHandler(Builder builder) {
-    this.spanReporter = builder.spanReporter;
-    this.errorTag = builder.errorTag;
-    this.alwaysReportSpans = builder.alwaysReportSpans;
+  ZipkinSpanHandler(Reporter<MutableSpan> spanReporter, boolean alwaysReportSpans) {
+    this.spanReporter = spanReporter;
+    this.alwaysReportSpans = alwaysReportSpans;
   }
 
   @Override public boolean end(TraceContext context, MutableSpan span, Cause cause) {
     if (!alwaysReportSpans && !Boolean.TRUE.equals(context.sampled())) return true;
-    maybeAddErrorTag(context, span);
-    Span converted = convert(context, span);
-    spanReporter.report(converted);
+    spanReporter.report(span);
     return true;
-  }
-
-  static Span convert(TraceContext context, MutableSpan span) {
-    Span.Builder result = Span.newBuilder()
-        .traceId(context.traceIdString())
-        .parentId(context.parentIdString())
-        .id(context.spanId())
-        .name(span.name());
-
-    long start = span.startTimestamp(), finish = span.finishTimestamp();
-    result.timestamp(start);
-    if (start != 0 && finish != 0L) result.duration(Math.max(finish - start, 1));
-
-    // use ordinal comparison to defend against version skew
-    Kind kind = span.kind();
-    if (kind != null) {
-      result.kind(BRAVE_TO_ZIPKIN_KIND.get(kind));
-    }
-
-    String localServiceName = span.localServiceName(), localIp = span.localIp();
-    if (localServiceName != null || localIp != null) {
-      result.localEndpoint(Endpoint.newBuilder()
-          .serviceName(localServiceName)
-          .ip(localIp)
-          .port(span.localPort())
-          .build());
-    }
-
-    String remoteServiceName = span.remoteServiceName(), remoteIp = span.remoteIp();
-    if (remoteServiceName != null || remoteIp != null) {
-      result.remoteEndpoint(Endpoint.newBuilder()
-          .serviceName(remoteServiceName)
-          .ip(remoteIp)
-          .port(span.remotePort())
-          .build());
-    }
-
-    span.forEachTag(Consumer.INSTANCE, result);
-    span.forEachAnnotation(Consumer.INSTANCE, result);
-    if (span.shared()) result.shared(true);
-    if (context.debug()) result.debug(true);
-    return result.build();
-  }
-
-  void maybeAddErrorTag(TraceContext context, MutableSpan span) {
-    // span.tag(key) iterates: check if we need to first!
-    if (span.error() == null) return;
-    if (span.tag("error") == null) errorTag.tag(span.error(), context, span);
-  }
-
-  @Override public String toString() {
-    return spanReporter.toString();
   }
 
   /**
@@ -191,34 +148,5 @@ public final class ZipkinSpanHandler extends SpanHandler {
    */
   @Override public final int hashCode() {
     return spanReporter.hashCode();
-  }
-
-  enum Consumer implements TagConsumer<Span.Builder>, AnnotationConsumer<Span.Builder> {
-    INSTANCE;
-
-    @Override public void accept(Span.Builder target, String key, String value) {
-      target.putTag(key, value);
-    }
-
-    @Override public void accept(Span.Builder target, long timestamp, String value) {
-      target.addAnnotation(timestamp, value);
-    }
-  }
-
-  /**
-   * This keeps the code maintenance free in the rare case there is disparity between Brave and
-   * Zipkin kind values.
-   */
-  static Map<Kind, Span.Kind> generateKindMap() {
-    Map<Kind, Span.Kind> result = new LinkedHashMap<>();
-    // Note: Both Brave and Zipkin treat null kind as a local/in-process span
-    for (Kind kind : Kind.values()) {
-      try {
-        result.put(kind, Span.Kind.valueOf(kind.name()));
-      } catch (RuntimeException e) {
-        logger.warning("Could not map Brave kind " + kind + " to Zipkin");
-      }
-    }
-    return result;
   }
 }

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.Rule;
+import zipkin2.Span;
+import zipkin2.junit.ZipkinRule;
+import zipkin2.reporter.okhttp3.OkHttpSender;
+
+public class BasicUsageTest_Async extends BasicUsageTest<AsyncZipkinSpanHandler> {
+  @Rule public ZipkinRule zipkin = new ZipkinRule();
+
+  OkHttpSender sender = OkHttpSender.create(zipkin.httpUrl() + "/api/v2/spans");
+
+  @Override AsyncZipkinSpanHandler zipkinSpanHandler(List<Span> spans) {
+    return AsyncZipkinSpanHandler.newBuilder(sender)
+        .messageTimeout(0, TimeUnit.MILLISECONDS) // don't spawn a thread
+        .build();
+  }
+
+  @Override void triggerReport() {
+    zipkinSpanHandler.flush();
+    for (List<Span> trace : zipkin.getTraces()) {
+      spans.addAll(trace);
+    }
+  }
+
+  @Override public void close() {
+    super.close();
+    zipkinSpanHandler.close();
+    sender.close();
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.handler.SpanHandler;
+import java.util.List;
+import zipkin2.Span;
+
+public class BasicUsageTest_Converting extends BasicUsageTest<SpanHandler> {
+  @Override SpanHandler zipkinSpanHandler(List<Span> spans) {
+    return ZipkinSpanHandler.create(spans::add);
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/ConvertingSpanReporterTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ConvertingSpanReporterTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tags;
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import java.util.ArrayList;
+import java.util.Objects;
+import org.junit.Before;
+import org.junit.Test;
+import zipkin2.Annotation;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+import static brave.Span.Kind.CLIENT;
+import static brave.Span.Kind.CONSUMER;
+import static brave.Span.Kind.PRODUCER;
+import static brave.Span.Kind.SERVER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+public class ConvertingSpanReporterTest {
+  static class ListSpanReporter extends ArrayList<Span> implements Reporter<Span> {
+    @Override public void report(Span span) {
+      add(span);
+    }
+  }
+
+  ListSpanReporter spans = new ListSpanReporter();
+  ConvertingSpanReporter spanReporter;
+  TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+  MutableSpan defaultSpan;
+
+  @Before public void init() {
+    defaultSpan = new MutableSpan(context, null);
+    defaultSpan.localServiceName("Aa");
+    defaultSpan.localIp("1.2.3.4");
+    defaultSpan.localPort(80);
+    spanReporter = new ConvertingSpanReporter(spans, Tags.ERROR);
+  }
+
+  @Test public void generateKindMap() {
+    assertThat(ConvertingSpanReporter.generateKindMap()).containsExactly(
+        entry(CLIENT, Span.Kind.CLIENT),
+        entry(SERVER, Span.Kind.SERVER),
+        entry(PRODUCER, Span.Kind.PRODUCER),
+        entry(CONSUMER, Span.Kind.CONSUMER)
+    );
+  }
+
+  @Test public void equalsAndHashCode() {
+    assertThat(spanReporter)
+        .hasSameHashCodeAs(spans)
+        .isEqualTo(new ConvertingSpanReporter(spans, Tags.ERROR));
+
+    ConvertingSpanReporter otherReporter = new ConvertingSpanReporter(spans::add, Tags.ERROR);
+
+    assertThat(spanReporter)
+        .isNotEqualTo(otherReporter)
+        .extracting(Objects::hashCode)
+        .isNotEqualTo(otherReporter.hashCode());
+  }
+
+  @Test public void convertsSampledSpan() {
+    MutableSpan span = new MutableSpan(context, null);
+    spanReporter.report(span);
+
+    assertThat(spans.get(0)).isEqualToComparingFieldByField(
+        Span.newBuilder()
+            .traceId("1")
+            .id("2")
+            .build()
+    );
+  }
+
+  @Test public void convertsDebugSpan() {
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).debug(true).build();
+    MutableSpan span = new MutableSpan(context, null);
+    spanReporter.report(span);
+
+    assertThat(spans.get(0)).isEqualToComparingFieldByField(
+        Span.newBuilder()
+            .traceId("0000000000000001")
+            .id("0000000000000002")
+            .debug(true)
+            .build()
+    );
+  }
+
+  @Test public void minimumDurationIsOne() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    span.startTimestamp(1L);
+    span.finishTimestamp(1L);
+
+    spanReporter.report(span);
+    assertThat(spans.get(0).duration()).isEqualTo(1L);
+  }
+
+  @Test public void replacesTag() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    span.tag("1", "1");
+    span.tag("foo", "bar");
+    span.tag("2", "2");
+    span.tag("foo", "baz");
+    span.tag("3", "3");
+
+    spanReporter.report(span);
+    assertThat(spans.get(0).tags()).containsOnly(
+        entry("1", "1"),
+        entry("foo", "baz"),
+        entry("2", "2"),
+        entry("3", "3")
+    );
+  }
+
+  Throwable ERROR = new RuntimeException();
+
+  @Test public void backfillsErrorTag() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    span.error(ERROR);
+
+    spanReporter.report(span);
+
+    assertThat(spans.get(0).tags())
+        .containsOnly(entry("error", "RuntimeException"));
+  }
+
+  @Test public void doesntOverwriteErrorTag() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    span.error(ERROR);
+    span.tag("error", "");
+
+    spanReporter.report(span);
+
+    assertThat(spans.get(0).tags())
+        .containsOnly(entry("error", ""));
+  }
+
+  @Test public void addsAnnotations() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    span.startTimestamp(1L);
+    span.annotate(2L, "foo");
+    span.finishTimestamp(2L);
+
+    spanReporter.report(span);
+
+    assertThat(spans.get(0).annotations())
+        .containsOnly(Annotation.create(2L, "foo"));
+  }
+
+  @Test public void finished_client() {
+    finish(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
+  }
+
+  @Test public void finished_server() {
+    finish(brave.Span.Kind.SERVER, Span.Kind.SERVER);
+  }
+
+  @Test public void finished_producer() {
+    finish(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
+  }
+
+  @Test public void finished_consumer() {
+    finish(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
+  }
+
+  void finish(brave.Span.Kind braveKind, Span.Kind span2Kind) {
+    MutableSpan span = new MutableSpan(context, null);
+    span.kind(braveKind);
+    span.startTimestamp(1L);
+    span.finishTimestamp(2L);
+
+    spanReporter.report(span);
+
+    Span zipkinSpan = spans.get(0);
+    assertThat(zipkinSpan.annotations()).isEmpty();
+    assertThat(zipkinSpan.timestamp()).isEqualTo(1L);
+    assertThat(zipkinSpan.duration()).isEqualTo(1L);
+    assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
+  }
+
+  @Test public void flushed_client() {
+    flush(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
+  }
+
+  @Test public void flushed_server() {
+    flush(brave.Span.Kind.SERVER, Span.Kind.SERVER);
+  }
+
+  @Test public void flushed_producer() {
+    flush(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
+  }
+
+  @Test public void flushed_consumer() {
+    flush(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
+  }
+
+  void flush(brave.Span.Kind braveKind, Span.Kind span2Kind) {
+    MutableSpan span = new MutableSpan(context, null);
+    span.kind(braveKind);
+    span.startTimestamp(1L);
+    span.finishTimestamp(0L);
+
+    spanReporter.report(span);
+
+    Span zipkinSpan = spans.get(0);
+    assertThat(zipkinSpan.annotations()).isEmpty();
+    assertThat(zipkinSpan.timestamp()).isEqualTo(1L);
+    assertThat(zipkinSpan.duration()).isNull();
+    assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
+  }
+
+  @Test public void remoteEndpoint() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    Endpoint endpoint = Endpoint.newBuilder()
+        .serviceName("fooService")
+        .ip("1.2.3.4")
+        .port(80)
+        .build();
+
+    span.kind(CLIENT);
+    span.remoteServiceName(endpoint.serviceName());
+    span.remoteIpAndPort(endpoint.ipv4(), endpoint.port());
+    span.startTimestamp(1L);
+    span.finishTimestamp(2L);
+
+    spanReporter.report(span);
+
+    assertThat(spans.get(0).remoteEndpoint())
+        .isEqualTo(endpoint);
+  }
+
+  // This prevents the server startTimestamp from overwriting the client one on the collector
+  @Test public void writeTo_sharedStatus() {
+    MutableSpan span = new MutableSpan(context, null);
+
+    span.setShared();
+    span.startTimestamp(1L);
+    span.kind(SERVER);
+    span.finishTimestamp(2L);
+
+    spanReporter.report(span);
+
+    assertThat(spans.get(0).shared())
+        .isTrue();
+  }
+
+  @Test public void flushUnstartedNeitherSetsTimestampNorDuration() {
+    MutableSpan flushed = new MutableSpan(context, null);
+    flushed.finishTimestamp(0L);
+
+    spanReporter.report(flushed);
+
+    assertThat(spans.get(0)).extracting(Span::timestampAsLong, Span::durationAsLong)
+        .allSatisfy(u -> assertThat(u).isEqualTo(0L));
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -17,26 +17,24 @@ import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import org.junit.Before;
 import org.junit.Test;
-import zipkin2.Annotation;
-import zipkin2.Endpoint;
-import zipkin2.Span;
 import zipkin2.reporter.Reporter;
 
-import static brave.Span.Kind.CLIENT;
-import static brave.Span.Kind.CONSUMER;
-import static brave.Span.Kind.PRODUCER;
-import static brave.Span.Kind.SERVER;
 import static brave.handler.SpanHandler.Cause.FINISHED;
 import static brave.handler.SpanHandler.Cause.FLUSHED;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 public class ZipkinSpanHandlerTest {
-  List<Span> spans = new ArrayList<>();
+  static class ListMutableSpanReporter extends ArrayList<MutableSpan>
+      implements Reporter<MutableSpan> {
+    @Override public void report(MutableSpan span) {
+      add(span);
+    }
+  }
+
+  ListMutableSpanReporter spans = new ListMutableSpanReporter();
   ZipkinSpanHandler handler;
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
   MutableSpan defaultSpan;
@@ -46,16 +44,7 @@ public class ZipkinSpanHandlerTest {
     defaultSpan.localServiceName("Aa");
     defaultSpan.localIp("1.2.3.4");
     defaultSpan.localPort(80);
-    handler = (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
-  }
-
-  @Test public void generateKindMap() {
-    assertThat(ZipkinSpanHandler.generateKindMap()).containsExactly(
-        entry(CLIENT, Span.Kind.CLIENT),
-        entry(SERVER, Span.Kind.SERVER),
-        entry(PRODUCER, Span.Kind.PRODUCER),
-        entry(CONSUMER, Span.Kind.CONSUMER)
-    );
+    handler = new ZipkinSpanHandler(spans, false);
   }
 
   @Test public void noopIsNoop() {
@@ -65,11 +54,10 @@ public class ZipkinSpanHandlerTest {
 
   @Test public void equalsAndHashCode() {
     assertThat(handler)
-        .hasSameHashCodeAs(ZipkinSpanHandler.create(handler.spanReporter))
-        .isEqualTo(ZipkinSpanHandler.create(handler.spanReporter));
+        .hasSameHashCodeAs(spans)
+        .isEqualTo(new ZipkinSpanHandler(spans, false));
 
-    SpanHandler otherHandler = ZipkinSpanHandler.create(s -> {
-    });
+    ZipkinSpanHandler otherHandler = new ZipkinSpanHandler(spans::add, false);
 
     assertThat(handler)
         .isNotEqualTo(otherHandler)
@@ -78,222 +66,51 @@ public class ZipkinSpanHandlerTest {
   }
 
   @Test public void reportsSampledSpan() {
-    MutableSpan span = new MutableSpan();
+    MutableSpan span = new MutableSpan(context, null);
     handler.end(context, span, FINISHED);
 
-    assertThat(spans.get(0)).isEqualToComparingFieldByField(
-        Span.newBuilder()
-            .traceId("1")
-            .id("2")
-            .build()
-    );
+    assertThat(spans.get(0)).isSameAs(span);
   }
 
   @Test public void reportsDebugSpan() {
     TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).debug(true).build();
-    MutableSpan span = new MutableSpan();
+    MutableSpan span = new MutableSpan(context, null);
     handler.end(context, span, FINISHED);
 
-    assertThat(spans.get(0)).isEqualToComparingFieldByField(
-        Span.newBuilder()
-            .traceId("1")
-            .id("2")
-            .debug(true)
-            .build()
-    );
+    assertThat(spans.get(0)).isSameAs(span);
+  }
+
+  @Test public void reportsFlushedSpan() {
+    MutableSpan span = new MutableSpan(context, null);
+    handler.end(context, span, FLUSHED);
+
+    assertThat(spans.get(0)).isSameAs(span);
+  }
+
+  @Test public void doesnNotHandleAbandoned() {
+    assertThat(handler.handlesAbandoned()).isFalse();
   }
 
   @Test public void doesntReportUnsampledSpan() {
     TraceContext context =
         TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).sampledLocal(true).build();
-    handler.end(context, new MutableSpan(), FINISHED);
+    handler.end(context, new MutableSpan(context, null), FINISHED);
 
     assertThat(spans).isEmpty();
   }
 
   @Test public void alwaysReportSpans_reportsUnsampledSpan() {
-    handler = (ZipkinSpanHandler) ZipkinSpanHandler.newBuilder(spans::add)
-        .alwaysReportSpans(true)
-        .build();
+    handler = new ZipkinSpanHandler(spans, true);
 
     TraceContext context =
         TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).sampledLocal(true).build();
-    handler.end(context, new MutableSpan(), FINISHED);
+    handler.end(context, new MutableSpan(context, null), FINISHED);
 
     assertThat(spans).isNotEmpty();
   }
 
-  @Test public void minimumDurationIsOne() {
-    MutableSpan span = new MutableSpan();
-
-    span.startTimestamp(1L);
-    span.finishTimestamp(1L);
-
-    handler.end(context, span, FINISHED);
-    assertThat(spans.get(0).duration()).isEqualTo(1L);
-  }
-
-  @Test public void replacesTag() {
-    MutableSpan span = new MutableSpan();
-
-    span.tag("1", "1");
-    span.tag("foo", "bar");
-    span.tag("2", "2");
-    span.tag("foo", "baz");
-    span.tag("3", "3");
-
-    handler.end(context, span, FINISHED);
-    assertThat(spans.get(0).tags()).containsOnly(
-        entry("1", "1"),
-        entry("foo", "baz"),
-        entry("2", "2"),
-        entry("3", "3")
-    );
-  }
-
-  Throwable ERROR = new RuntimeException();
-
-  @Test public void backfillsErrorTag() {
-    MutableSpan span = new MutableSpan();
-
-    span.error(ERROR);
-
-    handler.end(context, span, FINISHED);
-
-    assertThat(spans.get(0).tags())
-        .containsOnly(entry("error", "RuntimeException"));
-  }
-
-  @Test public void doesntOverwriteErrorTag() {
-    MutableSpan span = new MutableSpan();
-
-    span.error(ERROR);
-    span.tag("error", "");
-
-    handler.end(context, span, FINISHED);
-
-    assertThat(spans.get(0).tags())
-        .containsOnly(entry("error", ""));
-  }
-
-  @Test public void addsAnnotations() {
-    MutableSpan span = new MutableSpan();
-
-    span.startTimestamp(1L);
-    span.annotate(2L, "foo");
-    span.finishTimestamp(2L);
-
-    handler.end(context, span, FINISHED);
-
-    assertThat(spans.get(0).annotations())
-        .containsOnly(Annotation.create(2L, "foo"));
-  }
-
-  @Test public void finished_client() {
-    finish(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
-  }
-
-  @Test public void finished_server() {
-    finish(brave.Span.Kind.SERVER, Span.Kind.SERVER);
-  }
-
-  @Test public void finished_producer() {
-    finish(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
-  }
-
-  @Test public void finished_consumer() {
-    finish(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
-  }
-
-  void finish(brave.Span.Kind braveKind, Span.Kind span2Kind) {
-    MutableSpan span = new MutableSpan();
-    span.kind(braveKind);
-    span.startTimestamp(1L);
-    span.finishTimestamp(2L);
-
-    handler.end(context, span, FINISHED);
-
-    Span zipkinSpan = spans.get(0);
-    assertThat(zipkinSpan.annotations()).isEmpty();
-    assertThat(zipkinSpan.timestamp()).isEqualTo(1L);
-    assertThat(zipkinSpan.duration()).isEqualTo(1L);
-    assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
-  }
-
-  @Test public void flushed_client() {
-    flush(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
-  }
-
-  @Test public void flushed_server() {
-    flush(brave.Span.Kind.SERVER, Span.Kind.SERVER);
-  }
-
-  @Test public void flushed_producer() {
-    flush(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
-  }
-
-  @Test public void flushed_consumer() {
-    flush(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
-  }
-
-  void flush(brave.Span.Kind braveKind, Span.Kind span2Kind) {
-    MutableSpan span = new MutableSpan();
-    span.kind(braveKind);
-    span.startTimestamp(1L);
-    span.finishTimestamp(0L);
-
-    handler.end(context, span, FINISHED);
-
-    Span zipkinSpan = spans.get(0);
-    assertThat(zipkinSpan.annotations()).isEmpty();
-    assertThat(zipkinSpan.timestamp()).isEqualTo(1L);
-    assertThat(zipkinSpan.duration()).isNull();
-    assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
-  }
-
-  @Test public void remoteEndpoint() {
-    MutableSpan span = new MutableSpan();
-
-    Endpoint endpoint = Endpoint.newBuilder()
-        .serviceName("fooService")
-        .ip("1.2.3.4")
-        .port(80)
-        .build();
-
-    span.kind(CLIENT);
-    span.remoteServiceName(endpoint.serviceName());
-    span.remoteIpAndPort(endpoint.ipv4(), endpoint.port());
-    span.startTimestamp(1L);
-    span.finishTimestamp(2L);
-
-    handler.end(context, span, FINISHED);
-
-    assertThat(spans.get(0).remoteEndpoint())
-        .isEqualTo(endpoint);
-  }
-
-  // This prevents the server startTimestamp from overwriting the client one on the collector
-  @Test public void writeTo_sharedStatus() {
-    MutableSpan span = new MutableSpan();
-
-    span.setShared();
-    span.startTimestamp(1L);
-    span.kind(SERVER);
-    span.finishTimestamp(2L);
-
-    handler.end(context, span, FINISHED);
-
-    assertThat(spans.get(0).shared())
-        .isTrue();
-  }
-
-  @Test public void flushUnstartedNeitherSetsTimestampNorDuration() {
-    MutableSpan flushed = new MutableSpan();
-    flushed.finishTimestamp(0L);
-
-    handler.end(context, flushed, FLUSHED);
-
-    assertThat(spans.get(0)).extracting(Span::timestampAsLong, Span::durationAsLong)
-        .allSatisfy(u -> assertThat(u).isEqualTo(0L));
+  @Test public void alwaysReportSpans_doesNotHandleAbandoned() {
+    handler = new ZipkinSpanHandler(spans, true);
+    assertThat(handler.handlesAbandoned()).isFalse();
   }
 }

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -42,12 +42,18 @@ Here's an example with Kafka configuration and extended configuration:
 Here's an example integrating with [Brave 5.12+](https://github.com/openzipkin/brave/tree/master/spring-beans)
 
 ```xml
-<bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
-  <property name="localServiceName" value="${zipkin.service}"/>
-  <property name="spanHandlers">
-    <bean class="zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean">
-      <property name="spanReporter" ref="spanReporter"/>
+  <property name="sender">
+    <bean class="zipkin2.reporter.beans.OkHttpSenderFactoryBean">
+      <property name="endpoint" value="http://localhost:9411/api/v2/spans"/>
     </bean>
   </property>
-</bean>
+
+  <bean id="zipkinSpanHandler" class="zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean">
+    <property name="sender" ref="sender"/>
+  </bean>
+
+  <bean id="tracing" class="brave.spring.beans.TracingFactoryBean">
+    <property name="localServiceName" value="${zipkin.service}"/>
+    <property name="spanHandlers" ref="zipkinSpanHandler" />
+  </bean>
 ```

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,22 +14,12 @@
 package zipkin2.reporter.beans;
 
 import java.util.concurrent.TimeUnit;
-import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.ReporterMetrics;
-import zipkin2.reporter.Sender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class AsyncReporterFactoryBean extends AbstractFactoryBean {
-  Sender sender;
+public class AsyncReporterFactoryBean extends BaseAsyncFactoryBean {
   SpanBytesEncoder encoder;
-  ReporterMetrics metrics;
-  Integer messageMaxBytes;
-  Integer messageTimeout;
-  Integer closeTimeout;
-  Integer queuedMaxSpans;
-  Integer queuedMaxBytes;
 
   @Override public Class<? extends AsyncReporter> getObjectType() {
     return AsyncReporter.class;
@@ -50,39 +40,7 @@ public class AsyncReporterFactoryBean extends AbstractFactoryBean {
     ((AsyncReporter) instance).close();
   }
 
-  @Override public boolean isSingleton() {
-    return true;
-  }
-
-  public void setSender(Sender sender) {
-    this.sender = sender;
-  }
-
   public void setEncoder(SpanBytesEncoder encoder) {
     this.encoder = encoder;
-  }
-
-  public void setMetrics(ReporterMetrics metrics) {
-    this.metrics = metrics;
-  }
-
-  public void setMessageMaxBytes(Integer messageMaxBytes) {
-    this.messageMaxBytes = messageMaxBytes;
-  }
-
-  public void setMessageTimeout(Integer messageTimeout) {
-    this.messageTimeout = messageTimeout;
-  }
-
-  public void setCloseTimeout(Integer closeTimeout) {
-    this.closeTimeout = closeTimeout;
-  }
-
-  public void setQueuedMaxSpans(Integer queuedMaxSpans) {
-    this.queuedMaxSpans = queuedMaxSpans;
-  }
-
-  public void setQueuedMaxBytes(Integer queuedMaxBytes) {
-    this.queuedMaxBytes = queuedMaxBytes;
   }
 }

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBean.java
@@ -14,35 +14,33 @@
 package zipkin2.reporter.beans;
 
 import brave.Tag;
-import brave.handler.SpanHandler;
-import org.springframework.beans.factory.config.AbstractFactoryBean;
-import zipkin2.Span;
-import zipkin2.reporter.Reporter;
-import zipkin2.reporter.brave.ZipkinSpanHandler;
+import java.util.concurrent.TimeUnit;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
-  Reporter<Span> spanReporter;
+public class AsyncZipkinSpanHandlerFactoryBean extends BaseAsyncFactoryBean {
   Tag<Throwable> errorTag;
   Boolean alwaysReportSpans;
 
-  @Override protected SpanHandler createInstance() {
-    ZipkinSpanHandler.Builder builder = ZipkinSpanHandler.newBuilder(spanReporter);
+  @Override public Class<? extends AsyncZipkinSpanHandler> getObjectType() {
+    return AsyncZipkinSpanHandler.class;
+  }
+
+  @Override protected AsyncZipkinSpanHandler createInstance() {
+    AsyncZipkinSpanHandler.Builder builder = AsyncZipkinSpanHandler.newBuilder(sender);
     if (errorTag != null) builder.errorTag(errorTag);
     if (alwaysReportSpans != null) builder.alwaysReportSpans(alwaysReportSpans);
+    if (metrics != null) builder.metrics(metrics);
+    if (messageMaxBytes != null) builder.messageMaxBytes(messageMaxBytes);
+    if (messageTimeout != null) builder.messageTimeout(messageTimeout, TimeUnit.MILLISECONDS);
+    if (closeTimeout != null) builder.closeTimeout(closeTimeout, TimeUnit.MILLISECONDS);
+    if (queuedMaxSpans != null) builder.queuedMaxSpans(queuedMaxSpans);
+    if (queuedMaxBytes != null) builder.queuedMaxBytes(queuedMaxBytes);
     return builder.build();
   }
 
-  @Override public Class<? extends SpanHandler> getObjectType() {
-    return SpanHandler.class;
-  }
-
-  @Override public boolean isSingleton() {
-    return true;
-  }
-
-  public void setSpanReporter(Reporter<Span> spanReporter) {
-    this.spanReporter = spanReporter;
+  @Override protected void destroyInstance(Object instance) {
+    ((AsyncZipkinSpanHandler) instance).close();
   }
 
   public void setErrorTag(Tag<Throwable> errorTag) {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/BaseAsyncFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/BaseAsyncFactoryBean.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.ReporterMetrics;
+import zipkin2.reporter.Sender;
+
+abstract class BaseAsyncFactoryBean extends AbstractFactoryBean {
+  Sender sender;
+  ReporterMetrics metrics;
+  Integer messageMaxBytes;
+  Integer messageTimeout;
+  Integer closeTimeout;
+  Integer queuedMaxSpans;
+  Integer queuedMaxBytes;
+
+  @Override public boolean isSingleton() {
+    return true;
+  }
+
+  public void setSender(Sender sender) {
+    this.sender = sender;
+  }
+
+  public void setMetrics(ReporterMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  public void setMessageMaxBytes(Integer messageMaxBytes) {
+    this.messageMaxBytes = messageMaxBytes;
+  }
+
+  public void setMessageTimeout(Integer messageTimeout) {
+    this.messageTimeout = messageTimeout;
+  }
+
+  public void setCloseTimeout(Integer closeTimeout) {
+    this.closeTimeout = closeTimeout;
+  }
+
+  public void setQueuedMaxSpans(Integer queuedMaxSpans) {
+    this.queuedMaxSpans = queuedMaxSpans;
+  }
+
+  public void setQueuedMaxBytes(Integer queuedMaxBytes) {
+    this.queuedMaxBytes = queuedMaxBytes;
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/FakeSender.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/FakeSender.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import java.util.List;
+import zipkin2.Call;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.Sender;
+
+public class FakeSender extends Sender {
+  @Override public Encoding encoding() {
+    return Encoding.JSON;
+  }
+
+  @Override public int messageMaxBytes() {
+    return 1024;
+  }
+
+  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
+    return 1024;
+  }
+
+  @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+    return Call.create(null);
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
@@ -18,7 +18,9 @@ import brave.propagation.TraceContext;
 import org.junit.After;
 import org.junit.Test;
 import zipkin2.reporter.Reporter;
+import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,7 +47,7 @@ public class ZipkinSpanHandlerFactoryBeanTest {
     );
 
     assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
-        .extracting("spanReporter")
+        .extracting("spanReporter.delegate")
         .isEqualTo(Reporter.CONSOLE);
   }
 
@@ -62,7 +64,7 @@ public class ZipkinSpanHandlerFactoryBeanTest {
     );
 
     assertThat(context.getBean("zipkinSpanHandler", ZipkinSpanHandler.class))
-        .extracting("errorTag")
+        .extracting("spanReporter.errorTag")
         .isSameAs(ERROR_TAG);
   }
 


### PR DESCRIPTION
Formerly, MutableSpan needs to convert first to zipkin2.Span before
sending to Zipkin. Now, provided the format is Zipkin V2, this can be
done directly, with no conversion overhead.

Note: the conversion overhead is inline on the production request, so
the practice here is preferred:

```java
sender = URLConnectionSender.create("http://localhost:9411/api/v2/spans");
zipkinSpanHandler = AsyncZipkinSpanHandler.create(sender); // don't forget to close!
tracingBuilder.addSpanHandler(zipkinSpanHandler);
```

If you have to use a different format, though, you can still use
conversion. Ex.
```java
reporter = AsyncReporter.builder(URLConnectionSender.create("http://localhost:9411/api/v1/spans"))
                        .build(SpanBytesEncoder.JSON_V1);
tracingBuilder.addSpanHandler(ZipkinSpanHandler.create(reporter));
```

Depends on https://github.com/openzipkin/brave/pull/1212