### PR TITLE
Allows ZipkinSpanHandler to be reconfigured for "firehose mode"

### DIFF
--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-reporter-parent</artifactId>
     <groupId>io.zipkin.reporter2</groupId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-amqp-client</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-bom</artifactId>
   <name>Zipkin Reporter BOM</name>
-  <version>2.14.1-SNAPSHOT</version>
+  <version>2.15.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Bill Of Materials POM for all Zipkin reporter artifacts</description>
 

--- a/brave/bnd.bnd
+++ b/brave/bnd.bnd
@@ -1,4 +1,6 @@
+# We use zipkin2.reporter.internal.InternalReporter to reconfigure AsyncReporter
 Import-Package: \
+  !zipkin2.reporter.internal*,\
   *
 Export-Package: \
   zipkin2.reporter.brave

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/brave/src/main/java/zipkin2/reporter/brave/ConvertingZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ConvertingZipkinSpanHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.handler.SpanHandler;
+import zipkin2.Span;
+import zipkin2.reporter.Reporter;
+
+final class ConvertingZipkinSpanHandler extends ZipkinSpanHandler {
+
+  @Override public ZipkinSpanHandler.Builder toBuilder() {
+    return new Builder(((ConvertingSpanReporter) spanReporter).delegate);
+  }
+
+  static final class Builder extends ZipkinSpanHandler.Builder {
+    final Reporter<Span> spanReporter;
+
+    Builder(Reporter<Span> spanReporter) {
+      this.spanReporter = spanReporter;
+    }
+
+    // SpanHandler not ZipkinSpanHandler as it can coerce to NOOP
+    @Override public SpanHandler build() {
+      if (spanReporter == Reporter.NOOP) return SpanHandler.NOOP;
+      return new ConvertingZipkinSpanHandler(this);
+    }
+  }
+
+  ConvertingZipkinSpanHandler(Builder builder) {
+    super(new ConvertingSpanReporter(builder.spanReporter, builder.errorTag),
+        builder.errorTag, builder.alwaysReportSpans);
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
@@ -18,8 +18,10 @@ import brave.Tags;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
+import java.io.Closeable;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Reporter;
 
 /**
@@ -43,7 +45,7 @@ import zipkin2.reporter.Reporter;
  * @see brave.Tracing.Builder#addSpanHandler(SpanHandler)
  * @since 2.13
  */
-public class ZipkinSpanHandler extends SpanHandler {
+public class ZipkinSpanHandler extends SpanHandler implements Closeable {
   /** @since 2.13 */
   // SpanHandler not ZipkinSpanHandler as it can coerce to NOOP
   public static SpanHandler create(Reporter<Span> spanReporter) {
@@ -53,27 +55,39 @@ public class ZipkinSpanHandler extends SpanHandler {
   /** @since 2.13 */
   public static Builder newBuilder(Reporter<Span> spanReporter) {
     if (spanReporter == null) throw new NullPointerException("spanReporter == null");
-    return new ConvertingSpanReporterBuilder(spanReporter);
+    return new ConvertingZipkinSpanHandler.Builder(spanReporter);
   }
 
-  static final class ConvertingSpanReporterBuilder extends Builder {
-    final Reporter<Span> spanReporter;
+  /**
+   * Allows this instance to be reconfigured, for example {@link Builder#alwaysReportSpans(boolean)}.
+   *
+   * <p><em>Note:</em>If the instance  {@link AsyncReporter#close()} if you no longer need this
+   * instance, as otherwise it can leak its reporting thread.
+   *
+   * @since 2.15
+   */
+  public Builder toBuilder() {
+    // For testing, this is easier than making the type abstract: It is package sealed anyway!
+    throw new UnsupportedOperationException();
+  }
 
-    ConvertingSpanReporterBuilder(Reporter<Span> spanReporter) {
-      this.spanReporter = spanReporter;
-    }
-
-    // SpanHandler not ZipkinSpanHandler as it can coerce to NOOP
-    @Override public SpanHandler build() {
-      if (spanReporter == Reporter.NOOP) return SpanHandler.NOOP;
-      return new ZipkinSpanHandler(new ConvertingSpanReporter(spanReporter, errorTag),
-          alwaysReportSpans);
-    }
+  /**
+   * Implementations that throw exceptions on close have bugs. This may result in log warnings,
+   * though.
+   *
+   * @since 2.15
+   */
+  @Override public void close() {
   }
 
   public static abstract class Builder {
     Tag<Throwable> errorTag = Tags.ERROR;
     boolean alwaysReportSpans;
+
+    Builder(ZipkinSpanHandler zipkinSpanHandler) {
+      errorTag = zipkinSpanHandler.errorTag;
+      this.alwaysReportSpans = zipkinSpanHandler.alwaysReportSpans;
+    }
 
     Builder() { // sealed
     }
@@ -120,10 +134,13 @@ public class ZipkinSpanHandler extends SpanHandler {
   }
 
   final Reporter<MutableSpan> spanReporter;
+  final Tag<Throwable> errorTag; // for toBuilder()
   final boolean alwaysReportSpans;
 
-  ZipkinSpanHandler(Reporter<MutableSpan> spanReporter, boolean alwaysReportSpans) {
+  ZipkinSpanHandler(Reporter<MutableSpan> spanReporter, Tag<Throwable> errorTag,
+      boolean alwaysReportSpans) {
     this.spanReporter = spanReporter;
+    this.errorTag = errorTag;
     this.alwaysReportSpans = alwaysReportSpans;
   }
 

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinSpanHandler.java
@@ -21,7 +21,6 @@ import brave.propagation.TraceContext;
 import java.io.Closeable;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
-import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Reporter;
 
 /**
@@ -61,8 +60,8 @@ public class ZipkinSpanHandler extends SpanHandler implements Closeable {
   /**
    * Allows this instance to be reconfigured, for example {@link Builder#alwaysReportSpans(boolean)}.
    *
-   * <p><em>Note:</em>If the instance  {@link AsyncReporter#close()} if you no longer need this
-   * instance, as otherwise it can leak its reporting thread.
+   * <p><em>Note:</em> Call {@link #close()} if you no longer need this instance, as otherwise it
+   * can leak resources.
    *
    * @since 2.15
    */

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
@@ -13,12 +13,11 @@
  */
 package zipkin2.reporter.brave;
 
-import brave.handler.SpanHandler;
 import java.util.List;
 import zipkin2.Span;
 
-public class BasicUsageTest_Converting extends BasicUsageTest<SpanHandler> {
-  @Override SpanHandler zipkinSpanHandler(List<Span> spans) {
-    return ZipkinSpanHandler.create(spans::add);
+public class BasicUsageTest_Converting extends BasicUsageTest<ZipkinSpanHandler> {
+  @Override ZipkinSpanHandler zipkinSpanHandler(List<Span> spans) {
+    return (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
   }
 }

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.reporter.brave;
 
+import brave.Tags;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
@@ -44,7 +45,7 @@ public class ZipkinSpanHandlerTest {
     defaultSpan.localServiceName("Aa");
     defaultSpan.localIp("1.2.3.4");
     defaultSpan.localPort(80);
-    handler = new ZipkinSpanHandler(spans, false);
+    handler = new ZipkinSpanHandler(spans, Tags.ERROR, false);
   }
 
   @Test public void noopIsNoop() {
@@ -55,9 +56,9 @@ public class ZipkinSpanHandlerTest {
   @Test public void equalsAndHashCode() {
     assertThat(handler)
         .hasSameHashCodeAs(spans)
-        .isEqualTo(new ZipkinSpanHandler(spans, false));
+        .isEqualTo(new ZipkinSpanHandler(spans, Tags.ERROR, false));
 
-    ZipkinSpanHandler otherHandler = new ZipkinSpanHandler(spans::add, false);
+    ZipkinSpanHandler otherHandler = new ZipkinSpanHandler(spans::add, Tags.ERROR, false);
 
     assertThat(handler)
         .isNotEqualTo(otherHandler)
@@ -100,7 +101,7 @@ public class ZipkinSpanHandlerTest {
   }
 
   @Test public void alwaysReportSpans_reportsUnsampledSpan() {
-    handler = new ZipkinSpanHandler(spans, true);
+    handler = new ZipkinSpanHandler(spans, Tags.ERROR, true);
 
     TraceContext context =
         TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).sampledLocal(true).build();
@@ -110,7 +111,7 @@ public class ZipkinSpanHandlerTest {
   }
 
   @Test public void alwaysReportSpans_doesNotHandleAbandoned() {
-    handler = new ZipkinSpanHandler(spans, true);
+    handler = new ZipkinSpanHandler(spans, Tags.ERROR, true);
     assertThat(handler.handlesAbandoned()).isFalse();
   }
 }

--- a/core/bnd.bnd
+++ b/core/bnd.bnd
@@ -1,4 +1,5 @@
 Import-Package: \
   *
 Export-Package: \
-  zipkin2.reporter
+  zipkin2.reporter,\
+  brave.internal;braveinternal=true;mandatory:=braveinternal

--- a/core/bnd.bnd
+++ b/core/bnd.bnd
@@ -2,4 +2,4 @@ Import-Package: \
   *
 Export-Package: \
   zipkin2.reporter,\
-  brave.internal;braveinternal=true;mandatory:=braveinternal
+  zipkin2.reporter.internal;zipkinreporterinternal=true;mandatory:=zipkinreporterinternal

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter</artifactId>

--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,10 +13,6 @@
  */
 package zipkin2.reporter;
 
-import static java.lang.String.format;
-import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.WARNING;
-
 import java.io.Flushable;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,13 +23,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import zipkin2.Call;
 import zipkin2.CheckResult;
 import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.SpanBytesEncoder;
+
+import static java.lang.String.format;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
 
 /**
  * As spans are reported, they are encoded and added to a pending queue. The task of sending spans
@@ -89,6 +88,17 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
     long closeTimeoutNanos = TimeUnit.SECONDS.toNanos(1);
     int queuedMaxSpans = 10000;
     int queuedMaxBytes = onePercentOfMemory();
+
+    Builder(BoundedAsyncReporter<?> asyncReporter) {
+      this.sender = asyncReporter.sender;
+      this.threadFactory = asyncReporter.threadFactory;
+      this.metrics = asyncReporter.metrics;
+      this.messageMaxBytes = asyncReporter.messageMaxBytes;
+      this.messageTimeoutNanos = asyncReporter.messageTimeoutNanos;
+      this.closeTimeoutNanos = asyncReporter.closeTimeoutNanos;
+      this.queuedMaxSpans = asyncReporter.pending.maxSize;
+      this.queuedMaxBytes = asyncReporter.pending.maxBytes;
+    }
 
     static int onePercentOfMemory() {
       long result = (long) (Runtime.getRuntime().totalMemory() * 0.01);
@@ -191,31 +201,21 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
             "Encoder doesn't match Sender: %s %s", encoder.encoding(), sender.encoding()));
       }
 
-      final BoundedAsyncReporter<S> result = new BoundedAsyncReporter<>(this, encoder);
-
-      if (messageTimeoutNanos > 0) { // Start a thread that flushes the queue in a loop.
-        final BufferNextMessage<S> consumer =
-            BufferNextMessage.create(encoder.encoding(), messageMaxBytes, messageTimeoutNanos);
-        Thread flushThread = threadFactory.newThread(new Flusher<>(result, consumer));
-        flushThread.setName("AsyncReporter{" + sender + "}");
-        flushThread.setDaemon(true);
-        flushThread.start();
-      }
-      return result;
+      return new BoundedAsyncReporter<>(this, encoder);
     }
   }
 
   static final class BoundedAsyncReporter<S> extends AsyncReporter<S> {
     static final Logger logger = Logger.getLogger(BoundedAsyncReporter.class.getName());
-    final AtomicBoolean closed;
+    final AtomicBoolean started, closed;
     final BytesEncoder<S> encoder;
     final ByteBoundedQueue<S> pending;
     final Sender sender;
     final int messageMaxBytes;
-    final long messageTimeoutNanos;
-    final long closeTimeoutNanos;
+    final long messageTimeoutNanos, closeTimeoutNanos;
     final CountDownLatch close;
     final ReporterMetrics metrics;
+    final ThreadFactory threadFactory;
 
     /** Tracks if we should log the first instance of an exception in flush(). */
     private boolean shouldWarnException = true;
@@ -227,13 +227,27 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
       this.messageTimeoutNanos = builder.messageTimeoutNanos;
       this.closeTimeoutNanos = builder.closeTimeoutNanos;
       this.closed = new AtomicBoolean(false);
+      // pretend we already started when config implies no thread that flushes the queue in a loop.
+      this.started = new AtomicBoolean(builder.messageTimeoutNanos == 0);
       this.close = new CountDownLatch(builder.messageTimeoutNanos > 0 ? 1 : 0);
       this.metrics = builder.metrics;
+      this.threadFactory = builder.threadFactory;
       this.encoder = encoder;
+    }
+
+    void startFlusherThread() {
+      BufferNextMessage<S> consumer =
+          BufferNextMessage.create(encoder.encoding(), messageMaxBytes, messageTimeoutNanos);
+      Thread flushThread = threadFactory.newThread(new Flusher<>(this, consumer));
+      flushThread.setName("AsyncReporter{" + sender + "}");
+      flushThread.setDaemon(true);
+      flushThread.start();
     }
 
     @Override public void report(S next) {
       if (next == null) throw new NullPointerException("span == null");
+      // Lazy start so that reporters never used don't spawn threads
+      if (started.compareAndSet(false, true)) startFlusherThread();
       metrics.incrementSpans(1);
       int nextSizeInBytes = encoder.sizeInBytes(next);
       int messageSizeOfNextSpan = sender.messageSizeInBytes(nextSizeInBytes);
@@ -320,6 +334,7 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
 
     @Override public void close() {
       if (!closed.compareAndSet(false, true)) return; // already closed
+      started.set(true); // prevent anything from starting the thread after close!
       try {
         // wait for in-flight spans to send
         if (!close.await(closeTimeoutNanos, TimeUnit.NANOSECONDS)) {
@@ -334,6 +349,10 @@ public abstract class AsyncReporter<S> extends Component implements Reporter<S>,
         metrics.incrementSpansDropped(count);
         logger.warning("Dropped " + count + " spans due to AsyncReporter.close()");
       }
+    }
+
+    Builder toBuilder() {
+      return new Builder(this);
     }
 
     @Override public String toString() {

--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -13,6 +13,10 @@
  */
 package zipkin2.reporter;
 
+import static java.lang.String.format;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.WARNING;
+
 import java.io.Flushable;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,16 +27,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import zipkin2.Call;
 import zipkin2.CheckResult;
 import zipkin2.Component;
 import zipkin2.Span;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.SpanBytesEncoder;
-
-import static java.lang.String.format;
-import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.WARNING;
 
 /**
  * As spans are reported, they are encoded and added to a pending queue. The task of sending spans

--- a/core/src/main/java/zipkin2/reporter/Sender.java
+++ b/core/src/main/java/zipkin2/reporter/Sender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import zipkin2.Call;
 import zipkin2.Component;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.Encoding;
+import zipkin2.reporter.internal.InternalReporter;
 
 /**
  * Sends a list of encoded spans to a transport such as http or Kafka. Usually, this involves
@@ -89,4 +90,12 @@ public abstract class Sender extends Component {
    * @throws IllegalStateException if {@link #close() close} was called.
    */
   public abstract Call<Void> sendSpans(List<byte[]> encodedSpans);
+
+  static {
+    InternalReporter.instance = new InternalReporter() {
+      @Override public AsyncReporter.Builder toBuilder(AsyncReporter<?> asyncReporter) {
+        return ((AsyncReporter.BoundedAsyncReporter) asyncReporter).toBuilder();
+      }
+    };
+  }
 }

--- a/core/src/main/java/zipkin2/reporter/internal/InternalReporter.java
+++ b/core/src/main/java/zipkin2/reporter/internal/InternalReporter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.internal;
+
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.Sender;
+
+/**
+ * Escalate internal APIs in {@code zipkin2.reporter} so they can be used from outside packages. The
+ * only implementation is in {@link Sender}.
+ *
+ * <p>Inspired by {@code okhttp3.internal.Internal}.
+ */
+public abstract class InternalReporter {
+  public static InternalReporter instance;
+
+  /**
+   * Internal utility that allows a reporter to be reconfigured.
+   *
+   * <p><em>Note:</em>Call {@link AsyncReporter#close()} if you no longer need this instance, as
+   * otherwise it can leak its reporting thread.
+   *
+   * @since 2.15
+   */
+  public abstract AsyncReporter.Builder toBuilder(AsyncReporter<?> asyncReporter);
+}

--- a/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -275,11 +275,16 @@ public class AsyncReporterTest {
   }
 
   @Test
-  public void close_close_stopsSender() throws InterruptedException {
+  public void close_close_stopsFlushThread() throws InterruptedException {
     reporter = AsyncReporter.builder(FakeSender.create())
         .metrics(metrics)
         .messageTimeout(2, TimeUnit.MILLISECONDS)
         .build();
+
+    // Reporter thread is lazy
+    assertThat(reporter).extracting("started.get").isEqualTo(false);
+    reporter.report(span);
+    assertThat(reporter).extracting("started.get").isEqualTo(true);
 
     reporter.close();
 
@@ -450,9 +455,13 @@ public class AsyncReporterTest {
 
   @Test public void build_threadFactory() {
     Thread thread = new Thread();
-    AsyncReporter.builder(FakeSender.create())
+    reporter = AsyncReporter.builder(FakeSender.create())
       .threadFactory(r -> thread)
       .build();
+
+    // Reporter thread is lazy
+    assertThat(thread.isAlive()).isFalse();
+    reporter.report(span);
 
     assertThat(thread.getName()).isEqualTo("AsyncReporter{FakeSender}");
     assertThat(thread.toString()).contains("AsyncReporter{FakeSender}");

--- a/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/AsyncReporterTest.java
@@ -380,9 +380,9 @@ public class AsyncReporterTest {
         .messageTimeout(30, TimeUnit.SECONDS)
         .build();
 
+    reporter.report(span);
     Thread.sleep(500); // wait for the thread to start
 
-    reporter.report(span);
     reporter.close(); // close while there's a pending span
 
     assertThat(metrics.spans()).isEqualTo(1);

--- a/core/src/test/java/zipkin2/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,7 +26,7 @@ import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.codec.SpanBytesEncoder;
 
 public final class FakeSender extends Sender {
-  static FakeSender create() {
+  public static FakeSender create() {
     return new FakeSender(
         Encoding.JSON,
         Integer.MAX_VALUE,

--- a/core/src/test/java/zipkin2/reporter/internal/InternalReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/internal/InternalReporterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.internal;
+
+import java.util.List;
+import org.junit.Test;
+import zipkin2.codec.BytesEncoder;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.FakeSender;
+import zipkin2.reporter.Sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InternalReporterTest {
+  Sender sender = FakeSender.create();
+  BytesEncoder<String> bytesEncoder = new BytesEncoder<String>() {
+    @Override public Encoding encoding() {
+      return Encoding.JSON;
+    }
+
+    @Override public int sizeInBytes(String s) {
+      return s.length();
+    }
+
+    @Override public byte[] encode(String s) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public byte[] encodeList(List<String> list) {
+      throw new UnsupportedOperationException();
+    }
+  };
+
+  /**
+   * Shows usage for {@code AsyncZipkinSpanHandler} which internally builds an async reporter with a
+   * custom bytes encoder. This allows {@code AsyncZipkinSpanHandler.toBuilder()} to be safely
+   * created as the there is no ambiguity on whether {@link AsyncReporter.Builder#build()} or {@link
+   * AsyncReporter.Builder#build(BytesEncoder)} was called.
+   */
+  @Test public void toBuilder() {
+    AsyncReporter<String> input = AsyncReporter.builder(sender).build(bytesEncoder);
+    assertThat(InternalReporter.instance.toBuilder(input).build(bytesEncoder))
+        .usingRecursiveComparison()
+        .isEqualTo(input);
+  }
+}

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka</artifactId>

--- a/kafka08/pom.xml
+++ b/kafka08/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka08</artifactId>

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-libthrift</artifactId>

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-okhttp3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-parent</artifactId>
-  <version>2.14.1-SNAPSHOT</version>
+  <version>2.15.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.14.1-SNAPSHOT</version>
+    <version>2.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-urlconnection</artifactId>


### PR DESCRIPTION
The routine configuration of secondary sampling is to set
`alwaysReportSpans` so that the same zipkin reporter configured will now
be used also for secondary reporting.

We deprecated `Tracing.Builder.alwaysReportSpans()`, but before this
change, there was no viable alternative, as the sampling component
doesn't control the span reporting one.

This solves the problem by adding `ZipkinSpanHandler.toBuilder()`, which
can be called after the zipkin handler is added to `Tracing.Builder`.

To reduce burden, this also makes `AsyncReporter` lazy start its flusher
which is something it probably should have always done.

See https://github.com/openzipkin-contrib/zipkin-secondary-sampling/pull/33