### PR TITLE
Actually run RabbitMQ integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache:
   directories:
     - $HOME/.m2
 
+services:
+  - docker
+
 language: java
 
 jdk: openjdk13

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -45,5 +45,11 @@
       <artifactId>amqp-client</artifactId>
       <version>${amqp-client.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/ITRabbitMQSender.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/ITRabbitMQSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,68 +17,44 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import zipkin2.Call;
-import zipkin2.CheckResult;
 import zipkin2.Span;
 import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.codec.SpanBytesEncoder;
-import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 
-/** This works against a running RabbitMQ server on localhost */
+/** This works against a docker container or throws an {@link AssumptionViolatedException}. */
 public class ITRabbitMQSender {
-  @Rule public ExpectedException thrown = ExpectedException.none();
+  @ClassRule public static RabbitMQSenderRule rabbit = new RabbitMQSenderRule();
+  RabbitMQSender sender = rabbit.tryToInitializeSender(rabbit.newSenderBuilder());
 
-  RabbitMQSender sender;
-
-  @Before public void open() throws Exception {
-    sender = RabbitMQSender.newBuilder()
-        .queue("zipkin-test1")
-        .addresses("localhost:5672").build();
-
-    CheckResult check = sender.check();
-    if (!check.ok()) {
-      throw new AssumptionViolatedException(check.error().getMessage(), check.error());
-    }
-
-    declareQueue(sender.queue);
-  }
-
-  @After public void close() throws IOException {
+  @After public void after() throws Exception {
     sender.close();
   }
 
-  @Test
-  public void sendsSpans() throws Exception {
+  @Test public void sendsSpans() throws Exception {
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
     assertThat(SpanBytesDecoder.JSON_V2.decodeList(readMessage()))
         .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void sendsSpans_PROTO3() throws Exception {
+  @Test public void sendsSpans_PROTO3() throws Exception {
     sender.close();
-    Thread.sleep(100);
-
-    sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
-    declareQueue(sender.queue);
+    sender = rabbit.tryToInitializeSender(rabbit.newSenderBuilder().encoding(Encoding.PROTO3));
 
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
@@ -86,13 +62,12 @@ public class ITRabbitMQSender {
         .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void sendsSpansToCorrectQueue() throws Exception {
-    sender.close();
-    Thread.sleep(100);
+  @Test public void sendsSpansToCorrectQueue() throws Exception {
+    String differentQueue = "zipkin-test2";
 
-    sender = sender.toBuilder().queue("zipkin-test2").build();
-    declareQueue(sender.queue);
+    rabbit.declareQueue(differentQueue);
+    sender.close();
+    sender = rabbit.tryToInitializeSender(rabbit.newSenderBuilder().queue(differentQueue));
 
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
@@ -100,82 +75,44 @@ public class ITRabbitMQSender {
         .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void checkFalseWhenRabbitMQIsDown() throws Exception {
-    sender.close();
-    sender = sender.toBuilder().connectionTimeout(100).addresses("1.2.3.4:1213").build();
-
-    CheckResult check = sender.check();
-    assertThat(check.ok()).isFalse();
-    assertThat(check.error())
-        .isInstanceOf(RuntimeException.class);
-  }
-
-  @Test
-  public void illegalToSendWhenClosed() throws Exception {
-    thrown.expect(IllegalStateException.class);
-    sender.close();
-
-    send(CLIENT_SPAN, CLIENT_SPAN).execute();
-  }
-
-  @Test
-  public void shouldCloseRabbitMQProducerOnClose() throws Exception {
+  @Test public void shouldCloseRabbitMQConnectionOnClose() throws Exception {
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
     sender.close();
-    assertThat(sender.get().isOpen())
+    assertThat(sender.connection.isOpen())
         .isFalse();
   }
 
-  /**
-   * The output of toString() on {@link Sender} implementations appears in thread names created by
-   * {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other monitoring
-   * tools, care should be taken to ensure the toString() output is a reasonable length and does not
-   * contain sensitive information.
-   */
-  @Test
-  public void toStringContainsOnlySummaryInformation() throws Exception {
-    assertThat(sender.toString()).isEqualTo(
-        "RabbitMQSender{addresses=" + sender.addresses + ", queue=zipkin-test1}"
-    );
+  Call<Void> send(Span... spans) {
+    return send(sender, spans);
   }
 
   /** Blocks until the callback completes to allow read-your-writes consistency during tests. */
-  Call<Void> send(Span... spans) {
+  static Call<Void> send(Sender sender, Span... spans) {
     SpanBytesEncoder bytesEncoder = sender.encoding() == Encoding.JSON
         ? SpanBytesEncoder.JSON_V2 : SpanBytesEncoder.PROTO3;
     return sender.sendSpans(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
   }
 
-  private void declareQueue(String queue) throws Exception {
-    Channel channel = sender.get().createChannel();
-    try {
-      channel.queueDelete(queue);
-      channel.queueDeclare(queue, false, true, true, null);
-    } finally {
-      channel.close();
-    }
-    Thread.sleep(500L);
-  }
-
-  private byte[] readMessage() throws Exception {
+  byte[] readMessage() throws Exception {
     final CountDownLatch countDown = new CountDownLatch(1);
     final AtomicReference<byte[]> result = new AtomicReference<>();
 
-    Channel channel = sender.get().createChannel();
-    try {
-      channel.basicConsume(sender.queue, true, new DefaultConsumer(channel) {
-        @Override public void handleDelivery(String consumerTag, Envelope envelope,
-            AMQP.BasicProperties properties, byte[] body) throws IOException {
-          result.set(body);
-          countDown.countDown();
-        }
-      });
-      countDown.await(5, TimeUnit.SECONDS);
-    } finally {
-      channel.close();
-    }
+    // Don't close this as it invalidates the sender's connection!
+    Channel channel = sender.localChannel();
+    channel.basicConsume(sender.queue, true, new DefaultConsumer(channel) {
+      @Override public void handleDelivery(String consumerTag, Envelope envelope,
+          AMQP.BasicProperties properties, byte[] body) {
+        result.set(body);
+        countDown.countDown();
+      }
+    });
+    assertThat(countDown.await(10, TimeUnit.SECONDS))
+        .withFailMessage("Timed out waiting to read message")
+        .isTrue();
+    assertThat(result)
+        .withFailMessage("handleDelivery set null body")
+        .isNotNull();
     return result.get();
   }
 }

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderRule.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderRule.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.amqp;
+
+import java.time.Duration;
+import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container.ExecResult;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import zipkin2.CheckResult;
+
+import static zipkin2.Call.propagateIfFatal;
+
+/** This should be used as a {@link ClassRule} as it takes a very long time to start-up. */
+class RabbitMQSenderRule extends ExternalResource {
+  static final Logger LOGGER = LoggerFactory.getLogger(RabbitMQSenderRule.class);
+  static final String IMAGE = "rabbitmq:3.7-management-alpine";
+  static final String QUEUE = "zipkin-test1";
+  static final int RABBIT_PORT = 5672;
+
+  static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
+    RabbitMQContainer(String image) {
+      super(image);
+      addExposedPorts(RABBIT_PORT);
+      this.waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1)
+          .withStartupTimeout(Duration.ofSeconds(60));
+    }
+  }
+
+  RabbitMQContainer container;
+
+  @Override protected void before() {
+    if ("true".equals(System.getProperty("docker.skip"))) {
+      throw new AssumptionViolatedException("Skipping startup of docker " + IMAGE);
+    }
+
+    try {
+      LOGGER.info("Starting docker image " + IMAGE);
+      container = new RabbitMQContainer(IMAGE);
+      container.start();
+    } catch (Throwable e) {
+      throw new AssumptionViolatedException(
+          "Couldn't start docker image " + IMAGE + ": " + e.getMessage(), e);
+    }
+
+    declareQueue(QUEUE);
+
+    tryToInitializeSender(newSenderBuilder());
+  }
+
+  RabbitMQSender tryToInitializeSender(RabbitMQSender.Builder senderBuilder) {
+    RabbitMQSender result = senderBuilder.build();
+
+    CheckResult check;
+    try {
+      check = result.check();
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      throw new AssertionError("sender.check shouldn't propagate errors", e);
+    }
+
+    if (!check.ok()) {
+      throw new AssumptionViolatedException(
+          "Couldn't connect to docker container " + container + ": " +
+              check.error().getMessage(), check.error());
+    }
+
+    return result;
+  }
+
+  RabbitMQSender.Builder newSenderBuilder() {
+    return RabbitMQSender.newBuilder().queue(QUEUE)
+        .addresses(container.getContainerIpAddress() + ":" + container.getMappedPort(RABBIT_PORT));
+  }
+
+  void declareQueue(String queue) {
+    ExecResult result;
+    try {
+      result = container.execInContainer("rabbitmqadmin", "declare", "queue", "name=" + queue);
+    } catch (Throwable e) {
+      propagateIfFatal(e);
+      throw new AssumptionViolatedException(
+          "Couldn't declare queue " + queue + ": " + e.getMessage(), e);
+    }
+    if (result.getExitCode() != 0) {
+      throw new AssumptionViolatedException("Couldn't declare queue " + queue + ": " + result);
+    }
+  }
+
+  @Override protected void after() {
+    if (container != null) {
+      LOGGER.info("Stopping docker container " + container);
+      container.stop();
+    }
+  }
+}

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderRule.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderRule.java
@@ -59,8 +59,6 @@ class RabbitMQSenderRule extends ExternalResource {
     }
 
     declareQueue(QUEUE);
-
-    tryToInitializeSender(newSenderBuilder());
   }
 
   RabbitMQSender tryToInitializeSender(RabbitMQSender.Builder senderBuilder) {

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.amqp;
+
+import org.junit.Test;
+import zipkin2.CheckResult;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.Sender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+import static zipkin2.reporter.amqp.ITRabbitMQSender.send;
+
+/** This works against a running RabbitMQ server on localhost */
+public class RabbitMQSenderTest {
+  RabbitMQSender sender = RabbitMQSender.newBuilder()
+      .connectionTimeout(100).addresses("1.2.3.4:1213").build();
+
+  @Test public void checkFalseWhenRabbitMQIsDown() {
+    CheckResult check = sender.check();
+    assertThat(check.ok()).isFalse();
+    assertThat(check.error())
+        .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test public void illegalToSendWhenClosed() throws Exception {
+    sender.close();
+
+    assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN))
+        .isInstanceOf(ClosedSenderException.class);
+  }
+
+  /**
+   * The output of toString() on {@link Sender} implementations appears in thread names created by
+   * {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other monitoring
+   * tools, care should be taken to ensure the toString() output is a reasonable length and does not
+   * contain sensitive information.
+   */
+  @Test public void toStringContainsOnlySummaryInformation() {
+    assertThat(sender).hasToString(
+        "RabbitMQSender{addresses=[1.2.3.4:1213], queue=zipkin}"
+    );
+  }
+}

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.reporter.amqp.ITRabbitMQSender.send;
 
-/** This works against a running RabbitMQ server on localhost */
 public class RabbitMQSenderTest {
+  // We can be pretty certain RabbitMQ isn't running on localhost port 80
   RabbitMQSender sender = RabbitMQSender.newBuilder()
-      .connectionTimeout(100).addresses("1.2.3.4:1213").build();
+      .connectionTimeout(100).addresses("localhost:80").build();
 
   @Test public void checkFalseWhenRabbitMQIsDown() {
     CheckResult check = sender.check();
@@ -51,7 +51,7 @@ public class RabbitMQSenderTest {
    */
   @Test public void toStringContainsOnlySummaryInformation() {
     assertThat(sender).hasToString(
-        "RabbitMQSender{addresses=[1.2.3.4:1213], queue=zipkin}"
+        "RabbitMQSender{addresses=[localhost:80], queue=zipkin}"
     );
   }
 }

--- a/benchmarks/src/main/java/zipkin2/reporter/amqp/RabbitMQSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/amqp/RabbitMQSenderBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,7 +38,7 @@ public class RabbitMQSenderBenchmarks extends SenderBenchmarks {
       throw new AssumptionViolatedException(check.error().getMessage(), check.error());
     }
 
-    channel = result.get().createChannel();
+    channel = result.localChannel();
     channel.queueDelete(result.queue);
     channel.queueDeclare(result.queue, false, true, true, null);
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <zipkin.version>2.21.1</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>5.12.0</brave.version>
+    <brave.version>5.12.3</brave.version>
 
     <license-maven-plugin.version>3.0</license-maven-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
@@ -148,6 +148,11 @@
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>mockwebserver</artifactId>
         <version>3.14.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>1.14.2</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Before, these only ran locally. This makes them use Docker and never
local setup. The fallback is not that helpful, and makes interpreting
failures complex.

Similar to https://github.com/openzipkin/zipkin/issues/1748