### PR TITLE
Adds b3:0 header to avoid trace amplification when using proxies

### DIFF
--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -317,6 +317,9 @@ public final class OkHttpSender extends Sender {
 
   Request newRequest(RequestBody body) throws IOException {
     Request.Builder request = new Request.Builder().url(endpoint);
+    // Amplification can occur when the Zipkin endpoint is proxied, and the proxy is instrumented.
+    // This prevents that in proxies, such as Envoy, that understand B3 single format,
+    request.addHeader("b3", "0");
     if (compressionEnabled) {
       request.addHeader("Content-Encoding", "gzip");
       Buffer gzipped = new Buffer();

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,7 +53,7 @@ public class OkHttpSenderTest {
   OkHttpSender sender =
       OkHttpSender.newBuilder().endpoint(endpoint).compressionEnabled(false).build();
 
-  @Test public void badUrlIsAnIllegalArgument() throws Exception {
+  @Test public void badUrlIsAnIllegalArgument() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("invalid post url: ");
 
@@ -136,6 +136,15 @@ public class OkHttpSenderTest {
     // we expect the first compressed request to be smaller than the uncompressed one.
     assertThat(requests.get(0).getBodySize())
         .isLessThan(requests.get(1).getBodySize());
+  }
+
+  @Test public void ensuresProxiesDontTrace() throws Exception {
+    server.enqueue(new MockResponse());
+
+    send(CLIENT_SPAN, CLIENT_SPAN).execute();
+
+    // If the Zipkin endpoint is proxied and instrumented, it will know "0" means don't trace.
+    assertThat(server.takeRequest().getHeader("b3")).isEqualTo("0");
   }
 
   @Test public void mediaTypeBasedOnSpanEncoding() throws Exception {
@@ -254,7 +263,7 @@ public class OkHttpSenderTest {
     }
   }
 
-  @Test public void noExceptionWhenServerErrors() throws Exception {
+  @Test public void noExceptionWhenServerErrors() {
     server.enqueue(new MockResponse().setResponseCode(500));
 
     send().enqueue(new Callback<Void>() {
@@ -266,14 +275,14 @@ public class OkHttpSenderTest {
     });
   }
 
-  @Test public void outOfBandCancel() throws Exception {
+  @Test public void outOfBandCancel() {
     HttpCall call = (HttpCall) send(CLIENT_SPAN, CLIENT_SPAN);
     call.cancel();
 
     assertThat(call.isCanceled()).isTrue();
   }
 
-  @Test public void check_ok() throws Exception {
+  @Test public void check_ok() {
     server.enqueue(new MockResponse());
 
     assertThat(sender.check().ok()).isTrue();
@@ -281,7 +290,7 @@ public class OkHttpSenderTest {
     assertThat(server.getRequestCount()).isEqualTo(1);
   }
 
-  @Test public void check_fail() throws Exception {
+  @Test public void check_fail() {
     server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
     assertThat(sender.check().ok()).isFalse();
@@ -300,11 +309,11 @@ public class OkHttpSenderTest {
    * tools, care should be taken to ensure the toString() output is a reasonable length and does not
    * contain sensitive information.
    */
-  @Test public void toStringContainsOnlySenderTypeAndEndpoint() throws Exception {
+  @Test public void toStringContainsOnlySenderTypeAndEndpoint() {
     assertThat(sender.toString()).isEqualTo("OkHttpSender{" + endpoint + "}");
   }
 
-  @Test public void bugGuardCache() throws Exception {
+  @Test public void bugGuardCache() {
     assertThat(sender.client.cache())
         .withFailMessage("senders should not open a disk cache")
         .isNull();

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2020 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -209,6 +209,9 @@ public final class URLConnectionSender extends Sender {
     connection.setConnectTimeout(connectTimeout);
     connection.setReadTimeout(readTimeout);
     connection.setRequestMethod("POST");
+    // Amplification can occur when the Zipkin endpoint is proxied, and the proxy is instrumented.
+    // This prevents that in proxies, such as Envoy, that understand B3 single format,
+    connection.addRequestProperty("b3", "0");
     connection.addRequestProperty("Content-Type", mediaType);
     if (compressionEnabled) {
       connection.addRequestProperty("Content-Encoding", "gzip");


### PR DESCRIPTION
Same as https://github.com/openzipkin/zipkin-go/pull/176