### PR TITLE
Removes root dependency management

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -75,8 +75,9 @@ VERSION=xx-version-to-release-xx
 # once this works, deploy and synchronize to maven central
 git checkout $VERSION
 
+# -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central
+./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy -DskipBenchmarks -pl -:zipkin-reporter-bom
 # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
-./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy -pl -:zipkin-reporter-bom
 ./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy -f bom/pom.xml
 
 # if all the above worked, clean up stuff and push the local changes.

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -49,6 +50,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -79,11 +79,19 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
+      <version>${brave.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin-tests</artifactId>
+      <version>${zipkin.version}</version>
       <scope>compile</scope>
     </dependency>
 
@@ -122,6 +130,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
     </dependency>
   </dependencies>
 
@@ -137,28 +146,10 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <configuration>
-          <skipStaging>true</skipStaging>
-        </configuration>
-      </plugin>
 
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,8 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.22.1</zipkin.version>
+    <zipkin.version>2.22.2</zipkin.version>
+    <zipkin-proto3.version>0.2.2</zipkin-proto3.version>
 
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
   </properties>
@@ -88,15 +89,9 @@
         <version>${zipkin.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin-tests</artifactId>
-        <version>${zipkin.version}</version>
-      </dependency>
-      <!-- Also set version of the JUnit rule that tests reporters -->
-      <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin-junit</artifactId>
-        <version>${zipkin.version}</version>
+        <groupId>io.zipkin.proto3</groupId>
+        <artifactId>zipkin-proto3</artifactId>
+        <version>${zipkin-proto3.version}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
@@ -171,6 +166,11 @@
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
+          </plugin>
+
+          <plugin>
+            <artifactId>maven-deploy-plugin</artifactId>
+            <version>3.0.0-M1</version>
           </plugin>
 
           <plugin>

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -42,6 +42,13 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
+      <version>${brave.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <!-- Don't pin Brave -->
       <scope>provided</scope>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,4 +32,12 @@
 
     <main.basedir>${project.basedir}/..</main.basedir>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>${zipkin.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -40,6 +40,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/kafka08/pom.xml
+++ b/kafka08/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -37,6 +37,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -48,16 +48,19 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>io.zipkin.reporter2</groupId>
@@ -33,7 +35,6 @@
     <module>okhttp3</module>
     <module>libthrift</module>
     <module>spring-beans</module>
-    <module>benchmarks</module>
     <module>brave</module>
     <module>metrics-micrometer</module>
   </modules>
@@ -54,14 +55,19 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- override to set exclusions per-project -->
-    <errorprone.args />
+    <errorprone.args/>
     <errorprone.version>2.4.0</errorprone.version>
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.22.1</zipkin.version>
+    <zipkin.version>2.22.2</zipkin.version>
+    <zipkin-proto3.version>0.2.2</zipkin-proto3.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>5.12.7</brave.version>
+    <brave.version>5.13.0</brave.version>
+
+    <okhttp.version>3.14.9</okhttp.version>
+    <logback.version>1.2.3</logback.version>
+    <testcontainers.version>1.15.0-rc2</testcontainers.version>
 
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.0.rc2</license-maven-plugin.version>
@@ -126,52 +132,18 @@
   </issueManagement>
 
   <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>${project.groupId}</groupId>
-        <artifactId>zipkin-reporter</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave</artifactId>
-        <version>${brave.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>3.14.9</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>mockwebserver</artifactId>
-        <version>3.14.9</version>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers</artifactId>
-        <version>1.15.0-rc2</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>1.2.3</version>
-      </dependency>
-    </dependencies>
+    <!-- Be careful here, especially to not import BOMs as io.zipkin.reporter2:zipkin-reporter and
+         zipkin-reporter-brave have this parent.
+
+         For example, if you imported Netty's BOM here, using Brave would also download that BOM as
+         it depends indirectly on io.zipkin.reporter2:zipkin-reporter-brave. As Brave itself is
+         indirectly used, this can be extremely confusing when people are troubleshooting library
+         version assignments. -->
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin</artifactId>
-      <version>${zipkin.version}</version>
-    </dependency>
+    <!-- Do not add compile dependencies here. This can cause problems for libraries that depend on
+         io.zipkin.reporter2:zipkin-reporter or zipkin-reporter-brave difficult to unravel. -->
 
     <dependency>
       <groupId>junit</groupId>
@@ -194,6 +166,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -476,6 +449,18 @@
         </plugins>
       </build>
     </profile>
+    <!-- -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central -->
+    <profile>
+      <id>include-benchmarks</id>
+      <activation>
+        <property>
+          <name>!skipBenchmarks</name>
+        </property>
+      </activation>
+      <modules>
+        <module>benchmarks</module>
+      </modules>
+    </profile>
     <profile>
       <id>release</id>
       <build>
@@ -487,6 +472,9 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <!-- Double the normal timeout even though we haven't had a problem in this project.
+                   The only outcome of timing out client side is trying again. -->
+              <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -49,6 +49,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -88,6 +89,13 @@
     <dependency>
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
+      <version>${brave.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/travis/publish.sh
+++ b/travis/publish.sh
@@ -133,8 +133,9 @@ elif is_travis_branch_master; then
   # -Prelease ensures the core jar ends up JRE 1.6 compatible
   DEPLOY="./mvnw --batch-mode -s ./.settings.xml -Prelease -nsu -DskipTests deploy"
 
+  # -DskipBenchmarks ensures benchmarks don't end up in javadocs or in Maven Central
+  $DEPLOY -DskipBenchmarks -pl -:zipkin-reporter-bom
   # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
-  $DEPLOY -pl -:zipkin-reporter-bom
   $DEPLOY -f bom/pom.xml
 
   if is_release_version; then

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -37,11 +37,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This removes root dependency management for same rationale as
https://github.com/openzipkin/zipkin/pull/3284

Notably, to prevent interference or confusion in downstream projects,
notably Brave.

This also forcibly prevents benchmarks from the deploy phase as the
prior config resulted in orphaned staging repos. See
https://github.com/openzipkin/zipkin/pull/3286