### PR TITLE
Changes testcontainers to not pull docker.io and switches to Arm64 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
+# We use LXD containers where possible as they boot much faster than full VMs
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
 arch: arm64           # LXD container based build for OSS only
 os: linux             # required for arch different than amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Run `travis lint` when changing this file to avoid breaking the build.
 
-# We need a full VM so that testcontainers can use Docker
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
 arch: arm64           # LXD container based build for OSS only
 os: linux             # required for arch different than amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 # We need a full VM so that testcontainers can use Docker
 # See https://docs.travis-ci.com/user/reference/overview/#for-a-particular-travisyml-configuration
-arch: amd64           # arm64 is LXD containers which we can't use because we run Docker tests
+arch: arm64           # LXD container based build for OSS only
 os: linux             # required for arch different than amd64
 dist: focal           # newest available distribution
 
@@ -20,20 +20,19 @@ cache:
 services:
   - docker
 
+# Re-use JDK 11 from focal release instead of delaying build with installation
 before_install:
-  - |
-    # Intentionally don't use "jdk" Travis apt key as it is coupled to jdk.java.net availability.
-    # Use JDK 11, so we can release Java 6 bytecode
-    OPENJDK_VERSION=11
-    sudo apt-get -y install openjdk-${OPENJDK_VERSION}-jdk
-    export JAVA_HOME=/usr/lib/jvm/java-${OPENJDK_VERSION}-openjdk-${TRAVIS_CPU_ARCH}/
-    ./mvnw -version
   - |
     # Cache as help:evaluate is not quick
     export POM_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout)
-
-    # Disable testcontainers checks
+  - |
+    # Don't pull Docker Hub Registry images as it can result in a build outage:
+    # https://www.testcontainers.org/supported_docker_environment/image_registry_rate_limiting/
+    #  * alpine - used to check whether images can be pulled at startup
     echo checks.disable=true > ~/.testcontainers.properties
+    #  * testcontainers/ryuk - performs fail-safe cleanup of containers
+    #    * doesn't work on arm64 anyway: https://github.com/testcontainers/moby-ryuk/issues/15
+    export TESTCONTAINERS_RYUK_DISABLED=true
   - |
     # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
     # controlled by branch (typically only master). Check to see if a well-known env is available

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,11 @@ before_install:
     # Don't pull Docker Hub Registry images as it can result in a build outage:
     # https://www.testcontainers.org/supported_docker_environment/image_registry_rate_limiting/
     #  * alpine - used to check whether images can be pulled at startup
-    echo checks.disable=true > ~/.testcontainers.properties
+    #    * disabling this saves time and another docker.io pull
+    echo checks.disable=true >> ~/.testcontainers.properties
     #  * testcontainers/ryuk - performs fail-safe cleanup of containers
-    #    * doesn't work on arm64 anyway: https://github.com/testcontainers/moby-ryuk/issues/15
-    export TESTCONTAINERS_RYUK_DISABLED=true
+    #    * Temporary until: https://github.com/testcontainers/moby-ryuk/issues/15 and 16
+    echo ryuk.container.image=ghcr.io/openzipkin/testcontainers-ryuk:latest >> ~/.testcontainers.properties
   - |
     # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access
     # controlled by branch (typically only master). Check to see if a well-known env is available

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,20 @@ before_install:
     # Cache as help:evaluate is not quick
     export POM_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout)
   - |
-    # Don't pull Docker Hub Registry images as it can result in a build outage:
-    # https://www.testcontainers.org/supported_docker_environment/image_registry_rate_limiting/
-    #  * alpine - used to check whether images can be pulled at startup
-    #    * disabling this saves time and another docker.io pull
+    # Defend against build outages caused by Docker Hub (docker.io) pull rate limits
+
+    # We don't use any docker.io images, but add a Google's mirror in case something implicitly does
+    # * See https://cloud.google.com/container-registry/docs/pulling-cached-images
+    echo '{ "registry-mirrors": ["https://mirror.gcr.io"] }' | sudo tee /etc/docker/daemon.json
+    sudo service docker restart
+    # * Ensure buildx and related features are disabled
+    mkdir -p ${HOME}/.docker && echo '{"experimental":"disabled"}' > ${HOME}/.docker/config.json
+
+    # Change testcontainers configuration so that it doesn't pull from docker.io
+    # * See https://www.testcontainers.org/supported_docker_environment/image_registry_rate_limiting/
+    # * checks.disable=true - saves time and a docker.io pull of alpine
     echo checks.disable=true >> ~/.testcontainers.properties
-    #  * testcontainers/ryuk - performs fail-safe cleanup of containers
-    #    * Temporary until: https://github.com/testcontainers/moby-ryuk/issues/15 and 16
+    # * change ryuk to ghcr.io until: https://github.com/testcontainers/moby-ryuk/issues/15 and 16
     echo ryuk.container.image=ghcr.io/openzipkin/testcontainers-ryuk:latest >> ~/.testcontainers.properties
   - |
     # Credentials entered into https://travis-ci.org/github/openzipkin/${REPO}/settings are access

--- a/pom.xml
+++ b/pom.xml
@@ -172,13 +172,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <!-- mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -->
-        <plugin>
-          <groupId>de.qaware.maven</groupId>
-          <artifactId>go-offline-maven-plugin</artifactId>
-          <version>1.2.7</version>
-        </plugin>
-
         <!-- mvn -N io.takari:maven:wrapper generates the ./mvnw script -->
         <plugin>
           <groupId>io.takari</groupId>
@@ -187,6 +180,13 @@
           <configuration>
             <maven>3.6.3</maven>
           </configuration>
+        </plugin>
+
+        <!-- mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -->
+        <plugin>
+          <groupId>de.qaware.maven</groupId>
+          <artifactId>go-offline-maven-plugin</artifactId>
+          <version>1.2.7</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This follows advice from testcontainers to opt-out of incidental images
used until they are republished on a non rate-limited registry.

https://www.testcontainers.org/supported_docker_environment/image_registry_rate_limiting/

This also moves the build to the much faster arm64 config