### PR TITLE
More accurate OkHttp3 / Okio version management for OSGi deployments

### DIFF
--- a/okhttp3/bnd.bnd
+++ b/okhttp3/bnd.bnd
@@ -1,4 +1,6 @@
 Import-Package: \
+  okhttp3;version="[3.11, 5)",\
+  okio;version="[1.15,3)",\
   *
 Export-Package: \
   zipkin2.reporter.okhttp3


### PR DESCRIPTION
At the moment, the OkHttp3 and Okio versions are unspecified in OSGI manifests.

```
Import-Package: okhttp3,okio,zipkin2;version="[2.23,3)",zipkin2.codec;version="[2.23,3)",zipkin2.reporter;version="[2.16,3)"
```

Since Zipkin OkHttp3 Sender is going to support OkHttp3 `3.x` and `4.x`, more accurate version management would be helpful. 

```
Import-Package: okhttp3;version="[3.11,5)",okio;version="[1.15,3)",zipkin2;version="[2.23,3)",zipkin2.codec;version="[2.23,3)",zipkin2.reporter;version="[2.15,3)"
```

Relates to https://github.com/openzipkin/zipkin-reporter-java/pull/195
CC @adriancole 