### PR TITLE
WIP upgrade to Kafka 2.7 and off kafka-junit

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -14,7 +14,9 @@
     the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -48,22 +50,14 @@
       <artifactId>kafka-clients</artifactId>
       <!-- recent clients can talk to old 0.10 brokers -->
       <!-- when changing this, a change to the version of kafka-junit is likely needed, too -->
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
 
     <dependency>
-      <groupId>com.github.charithe</groupId>
-      <artifactId>kafka-junit</artifactId>
-      <!-- This version is tightly coupled to the version of kafka-clients being used.
-       https://github.com/charithe/kafka-junit -->
-      <version>4.1.10</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaSender.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaSender.java
@@ -13,9 +13,9 @@
  */
 package zipkin2.reporter.kafka;
 
-import com.github.charithe.kafka.EphemeralKafkaBroker;
-import com.github.charithe.kafka.KafkaJunitRule;
 import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -23,15 +23,17 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 import javax.management.ObjectName;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import zipkin2.Call;
 import zipkin2.CheckResult;
 import zipkin2.Span;
@@ -42,34 +44,35 @@ import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 
-public class ITKafkaSender {
-  EphemeralKafkaBroker broker = EphemeralKafkaBroker.create();
-  @Rule public KafkaJunitRule kafka = new KafkaJunitRule(broker).waitForStartup();
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ITKafkaSender {
+  @RegisterExtension KafkaExtension kafka = new KafkaExtension();
 
   KafkaSender sender;
 
-  @Before public void open() {
-    sender = KafkaSender.create(broker.getBrokerList().get());
+  @BeforeEach public void open() {
+    sender = KafkaSender.create(kafka.bootstrapServer());
+    kafka.prepareTopics(sender.topic, 1);
   }
 
-  @After public void close() {
+  @AfterEach public void close() {
     sender.close();
   }
 
-  @Test
-  public void sendsSpans() throws Exception {
+  @Test void sendsSpans() throws Exception {
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
     assertThat(SpanBytesDecoder.JSON_V2.decodeList(readMessage()))
       .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void sendsSpans_PROTO3() throws Exception {
+  @Test void sendsSpans_PROTO3() throws Exception {
     sender.close();
     sender = sender.toBuilder().encoding(Encoding.PROTO3).build();
 
@@ -79,8 +82,7 @@ public class ITKafkaSender {
       .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void sendsSpans_THRIFT() throws Exception {
+  @Test void sendsSpans_THRIFT() throws Exception {
     sender.close();
     sender = sender.toBuilder().encoding(Encoding.THRIFT).build();
 
@@ -90,9 +92,9 @@ public class ITKafkaSender {
       .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void sendsSpansToCorrectTopic() throws Exception {
+  @Test void sendsSpansToCorrectTopic() throws Exception {
     sender.close();
+    kafka.prepareTopics("customzipkintopic", 1);
     sender = sender.toBuilder().topic("customzipkintopic").build();
 
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
@@ -101,9 +103,8 @@ public class ITKafkaSender {
       .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test
-  public void checkFalseWhenKafkaIsDown() throws Exception {
-    broker.stop();
+  @Test void checkFalseWhenKafkaIsDown() {
+    kafka.container.stop();
 
     // Make a new tracer that fails faster than 60 seconds
     sender.close();
@@ -116,16 +117,14 @@ public class ITKafkaSender {
     assertThat(check.error()).isInstanceOf(TimeoutException.class);
   }
 
-  @Test
-  public void illegalToSendWhenClosed() {
+  @Test void illegalToSendWhenClosed() {
     sender.close();
 
     assertThatThrownBy(() -> send(CLIENT_SPAN, CLIENT_SPAN).execute())
       .isInstanceOf(IllegalStateException.class);
   }
 
-  @Test
-  public void shouldCloseKafkaProducerOnClose() throws Exception {
+  @Test void shouldCloseKafkaProducerOnClose() throws Exception {
     send(CLIENT_SPAN, CLIENT_SPAN).execute();
 
     final ObjectName kafkaProducerMXBeanName = new ObjectName("kafka.producer:*");
@@ -140,8 +139,7 @@ public class ITKafkaSender {
     assertThat(withNoProducers).isEmpty();
   }
 
-  @Test
-  public void shouldFailWhenMessageIsBiggerThanMaxSize() {
+  @Test void shouldFailWhenMessageIsBiggerThanMaxSize() {
     sender.close();
     sender = sender.toBuilder().messageMaxBytes(1).build();
 
@@ -155,15 +153,13 @@ public class ITKafkaSender {
    * tools, care should be taken to ensure the toString() output is a reasonable length and does not
    * contain sensitive information.
    */
-  @Test
-  public void toStringContainsOnlySummaryInformation() {
+  @Test void toStringContainsOnlySummaryInformation() {
     assertThat(sender.toString()).isEqualTo(
-      "KafkaSender{bootstrapServers=" + broker.getBrokerList().get() + ", topic=zipkin}"
+      "KafkaSender{bootstrapServers=" + kafka.bootstrapServer() + ", topic=zipkin}"
     );
   }
 
-  @Test
-  public void checkFilterPropertiesProducerToAdminClient() {
+  @Test void checkFilterPropertiesProducerToAdminClient() {
     Properties producerProperties = new Properties();
     producerProperties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "100");
     producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
@@ -203,13 +199,22 @@ public class ITKafkaSender {
     return sender.sendSpans(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
   }
 
-  private byte[] readMessage(String topic) throws Exception {
-    KafkaConsumer<byte[], byte[]> consumer = kafka.helper().createByteConsumer();
-    return kafka.helper().consume(topic, consumer, 1)
-      .get().stream().map(ConsumerRecord::value).findFirst().get();
+  byte[] readMessage(String topic) {
+    Properties properties = new Properties();
+    properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.bootstrapServer());
+    properties.put(GROUP_ID_CONFIG, "zipkin");
+    properties.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    ByteArrayDeserializer keyDeserializer = new ByteArrayDeserializer();
+    ByteArrayDeserializer valueDeserializer = new ByteArrayDeserializer();
+    try (Consumer<byte[], byte[]> consumer =
+           new KafkaConsumer<>(properties, keyDeserializer, valueDeserializer)) {
+      consumer.subscribe(Collections.singletonList(topic));
+      return consumer.poll(Duration.ofSeconds(1)).iterator().next().value();
+    }
   }
 
-  private byte[] readMessage() throws Exception {
+  private byte[] readMessage() {
     return readMessage("zipkin");
   }
 }

--- a/kafka/src/test/java/zipkin2/reporter/kafka/KafkaExtension.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/KafkaExtension.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016-2020 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.kafka;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opentest4j.TestAbortedException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.InternetProtocol;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.testcontainers.utility.DockerImageName.parse;
+
+class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
+  static final Logger LOGGER = LoggerFactory.getLogger(KafkaExtension.class);
+  static final int KAFKA_PORT = 19092;
+
+  final KafkaContainer container = new KafkaContainer();
+
+  @Override public void beforeAll(ExtensionContext context) {
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
+    }
+
+    container.start();
+    LOGGER.info("Using bootstrapServer " + bootstrapServer());
+  }
+
+  void prepareTopics(String topics, int partitions) {
+    Properties config = new Properties();
+    config.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServer());
+
+    List<NewTopic> newTopics = new ArrayList<>();
+    for (String topic : topics.split(",")) {
+      if ("".equals(topic)) continue;
+      newTopics.add(new NewTopic(topic, partitions, (short) 1));
+    }
+
+    try (AdminClient adminClient = AdminClient.create(config)) {
+      adminClient.createTopics(newTopics).all().get();
+    } catch (InterruptedException | ExecutionException e) {
+      if (e.getCause() != null && e.getCause() instanceof TopicExistsException) return;
+      throw new TestAbortedException(
+        "Topics could not be created " + newTopics + ": " + e.getMessage(), e);
+    }
+  }
+
+  String bootstrapServer() {
+    return container.getHost() + ":" + container.getMappedPort(KAFKA_PORT);
+  }
+
+  @Override public void afterAll(ExtensionContext context) {
+    if (context.getRequiredTestClass().getEnclosingClass() != null) {
+      // Only run once in outermost scope.
+      return;
+    }
+    container.stop();
+  }
+
+  // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
+  static final class KafkaContainer extends GenericContainer<KafkaContainer> {
+    KafkaContainer() {
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.23.2"));
+      if ("true".equals(System.getProperty("docker.skip"))) {
+        throw new TestAbortedException("${docker.skip} == true");
+      }
+      waitStrategy = Wait.forHealthcheck();
+      // 19092 is for connections from the Docker host and needs to be used as a fixed port.
+      // TODO: someone who knows Kafka well, make ^^ comment better!
+      addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);
+      withLogConsumer(new Slf4jLogConsumer(LOGGER));
+    }
+  }
+}


### PR DESCRIPTION
This moves to testcontainers, but has a glitch maybe @jeqo can help solve.

Once done, we also need to sort out benchmarks as that also uses kafka-junit.