### PR TITLE
Upgrade okhttp3 3.14.9 => 4.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenZipkin Authors
+    Copyright 2016-2022 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <junit.version>4.13.1</junit.version>
     <junit-jupiter.version>5.7.0</junit-jupiter.version>
-    <okhttp.version>3.14.9</okhttp.version>
+    <okhttp.version>4.9.3</okhttp.version>
     <logback.version>1.2.3</logback.version>
     <testcontainers.version>1.15.1</testcontainers.version>
 


### PR DESCRIPTION
As title says, this upgrades the underlying `okhttp3` library from `3.14.9` to `4.9.3`.