### PR TITLE
spring-beans 2.5.6 -> 3.0.0.RELEASE; fix @Bean AutoConfiguration mult…

### DIFF
--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>2.5.6</version>
+      <version>3.0.0.RELEASE</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/ActiveMQSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/ActiveMQSenderFactoryBean.java
@@ -19,7 +19,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.activemq.ActiveMQSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class ActiveMQSenderFactoryBean extends AbstractFactoryBean {
+public class ActiveMQSenderFactoryBean extends AbstractFactoryBean<ActiveMQSender> {
 
   String url, queue, username, password;
   String clientIdPrefix = "zipkin", connectionIdPrefix = "zipkin";

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
@@ -18,7 +18,7 @@ import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class AsyncReporterFactoryBean extends BaseAsyncFactoryBean {
+public class AsyncReporterFactoryBean extends BaseAsyncFactoryBean<AsyncReporter> {
   SpanBytesEncoder encoder;
 
   @Override public Class<? extends AsyncReporter> getObjectType() {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBean.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class AsyncZipkinSpanHandlerFactoryBean extends BaseAsyncFactoryBean {
+public class AsyncZipkinSpanHandlerFactoryBean extends BaseAsyncFactoryBean<AsyncZipkinSpanHandler> {
   Tag<Throwable> errorTag;
   Boolean alwaysReportSpans;
 

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/BaseAsyncFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/BaseAsyncFactoryBean.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
 
-abstract class BaseAsyncFactoryBean extends AbstractFactoryBean {
+abstract class BaseAsyncFactoryBean<T> extends AbstractFactoryBean<T> {
   Sender sender;
   ReporterMetrics metrics;
   Integer messageMaxBytes;

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/KafkaSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/KafkaSenderFactoryBean.java
@@ -18,7 +18,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.kafka.KafkaSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class KafkaSenderFactoryBean extends AbstractFactoryBean {
+public class KafkaSenderFactoryBean extends AbstractFactoryBean<KafkaSender> {
 
   String bootstrapServers, topic;
   Encoding encoding;

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/LibthriftSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/LibthriftSenderFactoryBean.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.reporter.libthrift.LibthriftSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class LibthriftSenderFactoryBean extends AbstractFactoryBean {
+public class LibthriftSenderFactoryBean extends AbstractFactoryBean<LibthriftSender> {
 
   String host;
   Integer connectTimeout, socketTimeout;

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
@@ -18,7 +18,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
+public class OkHttpSenderFactoryBean extends AbstractFactoryBean<OkHttpSender> {
 
   String endpoint;
   Encoding encoding;

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBean.java
@@ -19,7 +19,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.amqp.RabbitMQSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class RabbitMQSenderFactoryBean extends AbstractFactoryBean {
+public class RabbitMQSenderFactoryBean extends AbstractFactoryBean<RabbitMQSender> {
 
   String addresses, queue;
   Encoding encoding;

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
@@ -18,7 +18,7 @@ import zipkin2.codec.Encoding;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
+public class URLConnectionSenderFactoryBean extends AbstractFactoryBean<URLConnectionSender> {
 
   String endpoint;
   Encoding encoding;

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBean.java
@@ -21,7 +21,7 @@ import zipkin2.reporter.Reporter;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
-public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean {
+public class ZipkinSpanHandlerFactoryBean extends AbstractFactoryBean<SpanHandler> {
   Reporter<Span> spanReporter;
   Tag<Throwable> errorTag;
   Boolean alwaysReportSpans;


### PR DESCRIPTION
After Springbean version 3.0, FactoryBeans automatically configured through @ bean encountered a not found bean error

The reason is that no specific generic type was specified。

In order to reduce the impact, I only upgraded to the minimum version number that supports AbstractFactoryBean<T>

The following is a code example。

erro：not fund   AsyncReporter  Sender 。。。


``` java

    @Bean
    public  OkHttpSenderFactoryBean sender() {
        OkHttpSenderFactoryBean okHttpSenderFactoryBean = new OkHttpSenderFactoryBean();
        okHttpSenderFactoryBean.setEndpoint("http://localhost:9412/api/v2/spans");
        return okHttpSenderFactoryBean;
    }

    @Bean
    public  AsyncReporterFactoryBean reporter(Sender sender) throws Exception {
        AsyncReporterFactoryBean asyncReporterFactoryBean = new AsyncReporterFactoryBean();
        asyncReporterFactoryBean.setSender(sender);
        asyncReporterFactoryBean.setCloseTimeout(500);
        return asyncReporterFactoryBean;
    }

    @Bean
    public ZipkinSpanHandlerFactoryBean spanHandler(AsyncReporter reporter) {
        ZipkinSpanHandlerFactoryBean factoryBean = new ZipkinSpanHandlerFactoryBean();
        factoryBean.setSpanReporter(reporter);
        return factoryBean;
    }

```
