### PR TITLE
deps: updates to latest libthrift

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,11 +54,19 @@ the following:
 
 Before you do the first release of the year, move the SNAPSHOT version back and forth from whatever the current is.
 In-between, re-apply the licenses.
+
+Note: the command below is more complex than a normal project because this
+project has a bom.
 ```bash
-$ ./mvnw versions:set -DnewVersion=1.3.3-SNAPSHOT -DgenerateBackupPoms=false
-$ ./mvnw com.mycila:license-maven-plugin:format
-$ ./mvnw versions:set -DnewVersion=1.3.2-SNAPSHOT -DgenerateBackupPoms=false
-$ git commit -am"Adjusts copyright headers for this year"
+$ mvn=$PWD/mvnw
+$ for p in ./bom .; do
+ (cd $p
+ $mvn versions:set -DnewVersion=2.17.1-SNAPSHOT -DgenerateBackupPoms=false
+ $mvn -o clean install -DskipTests
+ $mvn com.mycila:license-maven-plugin:format
+ $mvn versions:set -DnewVersion=2.17.0-SNAPSHOT -DgenerateBackupPoms=false)
+ done
+$ git commit -asm"Adjusts copyright headers for this year"
 ```
 
 ## Manually releasing

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-reporter-parent</artifactId>
     <groupId>io.zipkin.reporter2</groupId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-amqp-client</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-bom</artifactId>
   <name>Zipkin Reporter BOM</name>
-  <version>2.16.6-SNAPSHOT</version>
+  <version>2.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Bill Of Materials POM for all Zipkin reporter artifacts</description>
 

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter</artifactId>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka</artifactId>

--- a/kafka08/pom.xml
+++ b/kafka08/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka08</artifactId>

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-libthrift</artifactId>
@@ -43,8 +43,12 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-      <!-- versions after this break compatability -->
-      <version>0.13.0</version>
+      <!-- Always update this to the highest value that doesn't break signature
+           compatability on patch release. Signature compatability breaks are
+           common in libthrift and lead to rev-lock. As scribe is a deprecated
+           transport in Zipkin, it is ok to update this to a signature breaking
+           version on minor, but increment to the next minor in the PR. -->
+      <version>0.19.0</version>
     </dependency>
 
     <dependency>

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/ScribeClient.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/ScribeClient.java
@@ -60,7 +60,7 @@ final class ScribeClient implements Closeable {
   boolean log(List<byte[]> encodedSpans) throws TException {
     try {
       // Starting in version 0.14, TSocket opens a socket inside its
-      // constructor, which we defer vs having to throw exceptions in ours.
+      // constructor, which we defer so that the server can be initially down.
       if (socket == null) {
         synchronized (this) {
           if (socket == null) {

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/ScribeClient.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/ScribeClient.java
@@ -36,6 +36,10 @@ final class ScribeClient implements Closeable {
   volatile TSocket socket;
   volatile TBinaryProtocol prot;
 
+  /**
+   * This defers opening a socket until the first call to {@link #log}, to
+   * accommodate a server that's down when the client initializes.
+   */
   ScribeClient(String host, int port, int socketTimeout, int connectTimeout) {
     this.host = host;
     this.port = port;
@@ -55,6 +59,8 @@ final class ScribeClient implements Closeable {
 
   boolean log(List<byte[]> encodedSpans) throws TException {
     try {
+      // Starting in version 0.14, TSocket opens a socket inside its
+      // constructor, which we defer vs having to throw exceptions in ours.
       if (socket == null) {
         synchronized (this) {
           if (socket == null) {

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter-metrics-micrometer</artifactId>

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-okhttp3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-parent</artifactId>
-  <version>2.16.6-SNAPSHOT</version>
+  <version>2.17.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>2.16.6-SNAPSHOT</version>
+    <version>2.17.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-urlconnection</artifactId>


### PR DESCRIPTION
This updates to the most recent libthrift while bumping to the next minor. This is a compromised decision that takes into account that libthrift can cause revlocks in code that uses it, due in part to being perpetually <1.0 versions.

Fixes #201