### PR TITLE
deps: removes accidental dependency management of zipkin-proto

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,7 +28,6 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- use the same value in ../pom.xml -->
     <zipkin.version>2.24.4</zipkin.version>
-    <zipkin-proto3.version>1.0.0</zipkin-proto3.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>
@@ -85,11 +84,6 @@
         <groupId>io.zipkin.zipkin2</groupId>
         <artifactId>zipkin</artifactId>
         <version>${zipkin.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zipkin.proto3</groupId>
-        <artifactId>zipkin-proto3</artifactId>
-        <version>${zipkin-proto3.version}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
 
     <!-- use the same value in bom/pom.xml -->
     <zipkin.version>2.24.4</zipkin.version>
-    <zipkin-proto3.version>1.0.0</zipkin-proto3.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
     <brave.version>5.16.0</brave.version>


### PR DESCRIPTION
This was accidentally copy/pasted in #189 and not consumed here or in brave.