### PR TITLE
refactor: migrates from JUnit 4 to JUnit 5 (Jupiter)

### DIFF
--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ITActiveMQSender.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ITActiveMQSender.java
@@ -38,7 +38,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(60)
-public class ITActiveMQSender {
+class ITActiveMQSender {
   @RegisterExtension ActiveMQExtension activemq = new ActiveMQExtension();
 
   @Test void checkPasses() {

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package zipkin2.reporter.amqp;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zipkin2.CheckResult;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.ClosedSenderException;
@@ -24,19 +24,19 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.reporter.amqp.ITRabbitMQSender.send;
 
-public class RabbitMQSenderTest {
+class RabbitMQSenderTest {
   // We can be pretty certain RabbitMQ isn't running on localhost port 80
   RabbitMQSender sender = RabbitMQSender.newBuilder()
       .connectionTimeout(100).addresses("localhost:80").build();
 
-  @Test public void checkFalseWhenRabbitMQIsDown() {
+  @Test void checkFalseWhenRabbitMQIsDown() {
     CheckResult check = sender.check();
     assertThat(check.ok()).isFalse();
     assertThat(check.error())
         .isInstanceOf(RuntimeException.class);
   }
 
-  @Test public void illegalToSendWhenClosed() throws Exception {
+  @Test void illegalToSendWhenClosed() throws Exception {
     sender.close();
 
     assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN))
@@ -49,7 +49,7 @@ public class RabbitMQSenderTest {
    * tools, care should be taken to ensure the toString() output is a reasonable length and does not
    * contain sensitive information.
    */
-  @Test public void toStringContainsOnlySummaryInformation() {
+  @Test void toStringContainsOnlySummaryInformation() {
     assertThat(sender).hasToString(
         "RabbitMQSender{addresses=[localhost:80], queue=zipkin}"
     );

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -121,11 +121,6 @@
       <version>4.2.10</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
@@ -15,13 +15,12 @@ package zipkin2.reporter.brave;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.junit.Rule;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import zipkin2.Span;
 import zipkin2.junit5.ZipkinExtension;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
-public class BasicUsageTest_Async extends BasicUsageTest<AsyncZipkinSpanHandler> {
+class BasicUsageTest_Async extends BasicUsageTest<AsyncZipkinSpanHandler> {
   @RegisterExtension public ZipkinExtension zipkin = new ZipkinExtension();
 
   OkHttpSender sender = OkHttpSender.create(zipkin.httpUrl() + "/api/v2/spans");

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,7 +16,7 @@ package zipkin2.reporter.brave;
 import java.util.List;
 import zipkin2.Span;
 
-public class BasicUsageTest_Converting extends BasicUsageTest<ZipkinSpanHandler> {
+class BasicUsageTest_Converting extends BasicUsageTest<ZipkinSpanHandler> {
   @Override ZipkinSpanHandler zipkinSpanHandler(List<Span> spans) {
     return (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
   }

--- a/brave/src/test/java/zipkin2/reporter/brave/ConvertingSpanReporterTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ConvertingSpanReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,8 +18,8 @@ import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.Objects;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.Annotation;
 import zipkin2.Endpoint;
 import zipkin2.Span;
@@ -32,7 +32,7 @@ import static brave.Span.Kind.SERVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-public class ConvertingSpanReporterTest {
+class ConvertingSpanReporterTest {
   static class ListSpanReporter extends ArrayList<Span> implements Reporter<Span> {
     @Override public void report(Span span) {
       add(span);
@@ -44,7 +44,7 @@ public class ConvertingSpanReporterTest {
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
   MutableSpan defaultSpan;
 
-  @Before public void init() {
+  @BeforeEach void init() {
     defaultSpan = new MutableSpan(context, null);
     defaultSpan.localServiceName("Aa");
     defaultSpan.localIp("1.2.3.4");
@@ -52,7 +52,7 @@ public class ConvertingSpanReporterTest {
     spanReporter = new ConvertingSpanReporter(spans, Tags.ERROR);
   }
 
-  @Test public void generateKindMap() {
+  @Test void generateKindMap() {
     assertThat(ConvertingSpanReporter.generateKindMap()).containsExactly(
         entry(CLIENT, Span.Kind.CLIENT),
         entry(SERVER, Span.Kind.SERVER),
@@ -61,7 +61,7 @@ public class ConvertingSpanReporterTest {
     );
   }
 
-  @Test public void equalsAndHashCode() {
+  @Test void equalsAndHashCode() {
     assertThat(spanReporter)
         .hasSameHashCodeAs(spans)
         .isEqualTo(new ConvertingSpanReporter(spans, Tags.ERROR));
@@ -74,7 +74,7 @@ public class ConvertingSpanReporterTest {
         .isNotEqualTo(otherReporter.hashCode());
   }
 
-  @Test public void convertsSampledSpan() {
+  @Test void convertsSampledSpan() {
     MutableSpan span = new MutableSpan(context, null);
     spanReporter.report(span);
 
@@ -86,7 +86,7 @@ public class ConvertingSpanReporterTest {
     );
   }
 
-  @Test public void convertsDebugSpan() {
+  @Test void convertsDebugSpan() {
     TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).debug(true).build();
     MutableSpan span = new MutableSpan(context, null);
     spanReporter.report(span);
@@ -100,7 +100,7 @@ public class ConvertingSpanReporterTest {
     );
   }
 
-  @Test public void minimumDurationIsOne() {
+  @Test void minimumDurationIsOne() {
     MutableSpan span = new MutableSpan(context, null);
 
     span.startTimestamp(1L);
@@ -110,7 +110,7 @@ public class ConvertingSpanReporterTest {
     assertThat(spans.get(0).duration()).isEqualTo(1L);
   }
 
-  @Test public void replacesTag() {
+  @Test void replacesTag() {
     MutableSpan span = new MutableSpan(context, null);
 
     span.tag("1", "1");
@@ -130,7 +130,7 @@ public class ConvertingSpanReporterTest {
 
   Throwable ERROR = new RuntimeException();
 
-  @Test public void backfillsErrorTag() {
+  @Test void backfillsErrorTag() {
     MutableSpan span = new MutableSpan(context, null);
 
     span.error(ERROR);
@@ -141,7 +141,7 @@ public class ConvertingSpanReporterTest {
         .containsOnly(entry("error", "RuntimeException"));
   }
 
-  @Test public void doesntOverwriteErrorTag() {
+  @Test void doesntOverwriteErrorTag() {
     MutableSpan span = new MutableSpan(context, null);
 
     span.error(ERROR);
@@ -153,7 +153,7 @@ public class ConvertingSpanReporterTest {
         .containsOnly(entry("error", ""));
   }
 
-  @Test public void addsAnnotations() {
+  @Test void addsAnnotations() {
     MutableSpan span = new MutableSpan(context, null);
 
     span.startTimestamp(1L);
@@ -166,19 +166,19 @@ public class ConvertingSpanReporterTest {
         .containsOnly(Annotation.create(2L, "foo"));
   }
 
-  @Test public void finished_client() {
+  @Test void finished_client() {
     finish(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
   }
 
-  @Test public void finished_server() {
+  @Test void finished_server() {
     finish(brave.Span.Kind.SERVER, Span.Kind.SERVER);
   }
 
-  @Test public void finished_producer() {
+  @Test void finished_producer() {
     finish(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
   }
 
-  @Test public void finished_consumer() {
+  @Test void finished_consumer() {
     finish(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
   }
 
@@ -197,19 +197,19 @@ public class ConvertingSpanReporterTest {
     assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
   }
 
-  @Test public void flushed_client() {
+  @Test void flushed_client() {
     flush(brave.Span.Kind.CLIENT, Span.Kind.CLIENT);
   }
 
-  @Test public void flushed_server() {
+  @Test void flushed_server() {
     flush(brave.Span.Kind.SERVER, Span.Kind.SERVER);
   }
 
-  @Test public void flushed_producer() {
+  @Test void flushed_producer() {
     flush(brave.Span.Kind.PRODUCER, Span.Kind.PRODUCER);
   }
 
-  @Test public void flushed_consumer() {
+  @Test void flushed_consumer() {
     flush(brave.Span.Kind.CONSUMER, Span.Kind.CONSUMER);
   }
 
@@ -228,7 +228,7 @@ public class ConvertingSpanReporterTest {
     assertThat(zipkinSpan.kind()).isEqualTo(span2Kind);
   }
 
-  @Test public void remoteEndpoint() {
+  @Test void remoteEndpoint() {
     MutableSpan span = new MutableSpan(context, null);
 
     Endpoint endpoint = Endpoint.newBuilder()
@@ -250,7 +250,7 @@ public class ConvertingSpanReporterTest {
   }
 
   // This prevents the server startTimestamp from overwriting the client one on the collector
-  @Test public void writeTo_sharedStatus() {
+  @Test void writeTo_sharedStatus() {
     MutableSpan span = new MutableSpan(context, null);
 
     span.setShared();
@@ -264,7 +264,7 @@ public class ConvertingSpanReporterTest {
         .isTrue();
   }
 
-  @Test public void flushUnstartedNeitherSetsTimestampNorDuration() {
+  @Test void flushUnstartedNeitherSetsTimestampNorDuration() {
     MutableSpan flushed = new MutableSpan(context, null);
     flushed.finishTimestamp(0L);
 

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,15 +19,15 @@ import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
 import java.util.ArrayList;
 import java.util.Objects;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.reporter.Reporter;
 
 import static brave.handler.SpanHandler.Cause.FINISHED;
 import static brave.handler.SpanHandler.Cause.FLUSHED;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZipkinSpanHandlerTest {
+class ZipkinSpanHandlerTest {
   static class ListMutableSpanReporter extends ArrayList<MutableSpan>
       implements Reporter<MutableSpan> {
     @Override public void report(MutableSpan span) {
@@ -40,7 +40,7 @@ public class ZipkinSpanHandlerTest {
   TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
   MutableSpan defaultSpan;
 
-  @Before public void init() {
+  @BeforeEach void init() {
     defaultSpan = new MutableSpan();
     defaultSpan.localServiceName("Aa");
     defaultSpan.localIp("1.2.3.4");
@@ -48,12 +48,12 @@ public class ZipkinSpanHandlerTest {
     handler = new ZipkinSpanHandler(spans, Tags.ERROR, false);
   }
 
-  @Test public void noopIsNoop() {
+  @Test void noopIsNoop() {
     assertThat(ZipkinSpanHandler.create(Reporter.NOOP))
         .isSameAs(SpanHandler.NOOP);
   }
 
-  @Test public void equalsAndHashCode() {
+  @Test void equalsAndHashCode() {
     assertThat(handler)
         .hasSameHashCodeAs(spans)
         .isEqualTo(new ZipkinSpanHandler(spans, Tags.ERROR, false));
@@ -66,14 +66,14 @@ public class ZipkinSpanHandlerTest {
         .isNotEqualTo(otherHandler.hashCode());
   }
 
-  @Test public void reportsSampledSpan() {
+  @Test void reportsSampledSpan() {
     MutableSpan span = new MutableSpan(context, null);
     handler.end(context, span, FINISHED);
 
     assertThat(spans.get(0)).isSameAs(span);
   }
 
-  @Test public void reportsDebugSpan() {
+  @Test void reportsDebugSpan() {
     TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).debug(true).build();
     MutableSpan span = new MutableSpan(context, null);
     handler.end(context, span, FINISHED);
@@ -81,18 +81,18 @@ public class ZipkinSpanHandlerTest {
     assertThat(spans.get(0)).isSameAs(span);
   }
 
-  @Test public void reportsFlushedSpan() {
+  @Test void reportsFlushedSpan() {
     MutableSpan span = new MutableSpan(context, null);
     handler.end(context, span, FLUSHED);
 
     assertThat(spans.get(0)).isSameAs(span);
   }
 
-  @Test public void doesnNotHandleAbandoned() {
+  @Test void doesnNotHandleAbandoned() {
     assertThat(handler.handlesAbandoned()).isFalse();
   }
 
-  @Test public void doesntReportUnsampledSpan() {
+  @Test void doesntReportUnsampledSpan() {
     TraceContext context =
         TraceContext.newBuilder().traceId(1).spanId(2).sampled(false).sampledLocal(true).build();
     handler.end(context, new MutableSpan(context, null), FINISHED);
@@ -100,7 +100,7 @@ public class ZipkinSpanHandlerTest {
     assertThat(spans).isEmpty();
   }
 
-  @Test public void alwaysReportSpans_reportsUnsampledSpan() {
+  @Test void alwaysReportSpans_reportsUnsampledSpan() {
     handler = new ZipkinSpanHandler(spans, Tags.ERROR, true);
 
     TraceContext context =
@@ -110,7 +110,7 @@ public class ZipkinSpanHandlerTest {
     assertThat(spans).isNotEmpty();
   }
 
-  @Test public void alwaysReportSpans_doesNotHandleAbandoned() {
+  @Test void alwaysReportSpans_doesNotHandleAbandoned() {
     handler = new ZipkinSpanHandler(spans, Tags.ERROR, true);
     assertThat(handler.handlesAbandoned()).isFalse();
   }

--- a/core/src/test/java/zipkin2/reporter/AwaitableCallbackTest.java
+++ b/core/src/test/java/zipkin2/reporter/AwaitableCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,15 +15,14 @@ package zipkin2.reporter;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
-public class AwaitableCallbackTest {
-
-  @Test public void awaitIsUninterruptable() {
+class AwaitableCallbackTest {
+  @Test void awaitIsUninterruptable() {
     AtomicBoolean returned = new AtomicBoolean();
     AwaitableCallback captor = new AwaitableCallback();
     Thread thread = new Thread(() -> {
@@ -39,14 +38,14 @@ public class AwaitableCallbackTest {
     assertThat(returned.get()).isFalse();
   }
 
-  @Test public void onSuccessReturns() {
+  @Test void onSuccessReturns() {
     AwaitableCallback captor = new AwaitableCallback();
     captor.onSuccess(null);
 
     captor.await();
   }
 
-  @Test public void onError_propagatesRuntimeException() {
+  @Test void onError_propagatesRuntimeException() {
     AwaitableCallback captor = new AwaitableCallback();
     captor.onError(new IllegalStateException());
 
@@ -54,7 +53,7 @@ public class AwaitableCallbackTest {
       .isInstanceOf(IllegalStateException.class);
   }
 
-  @Test public void onError_propagatesError() {
+  @Test void onError_propagatesError() {
     AwaitableCallback captor = new AwaitableCallback();
     captor.onError(new LinkageError());
 
@@ -62,7 +61,7 @@ public class AwaitableCallbackTest {
       .isInstanceOf(LinkageError.class);
   }
 
-  @Test public void onError_doesntSetInterrupted() {
+  @Test void onError_doesntSetInterrupted() {
     AwaitableCallback captor = new AwaitableCallback();
     captor.onError(new InterruptedException());
 
@@ -75,7 +74,7 @@ public class AwaitableCallbackTest {
     }
   }
 
-  @Test public void onError_wrapsCheckedExceptions() {
+  @Test void onError_wrapsCheckedExceptions() {
     AwaitableCallback captor = new AwaitableCallback();
     captor.onError(new IOException());
 
@@ -84,7 +83,7 @@ public class AwaitableCallbackTest {
       .hasCauseInstanceOf(IOException.class);
   }
 
-  @Test public void onError_wrapsCustomThrowable() {
+  @Test void onError_wrapsCustomThrowable() {
     AwaitableCallback captor = new AwaitableCallback();
     class MyThrowable extends Throwable {
     }

--- a/core/src/test/java/zipkin2/reporter/BufferNextMessageTest.java
+++ b/core/src/test/java/zipkin2/reporter/BufferNextMessageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +13,13 @@
  */
 package zipkin2.reporter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BufferNextMessageTest {
-
-  @Test public void empty_json() {
+class BufferNextMessageTest {
+  @Test void empty_json() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
 
     assertThat(pending.bufferFull)
@@ -29,7 +28,7 @@ public class BufferNextMessageTest {
         .isEqualTo(2 /* [] */);
   }
 
-  @Test public void offer_json() {
+  @Test void offer_json() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
     pending.offer(1, 1);
 
@@ -46,7 +45,7 @@ public class BufferNextMessageTest {
         .isEqualTo(5 /* [1,2] */);
   }
 
-  @Test public void offerWhenFull_json() {
+  @Test void offerWhenFull_json() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
     for (int i = 0; i < 4; i++) {
       assertThat(pending.offer(i, 1))
@@ -66,7 +65,7 @@ public class BufferNextMessageTest {
     assertThat(pending.bufferFull).isTrue();
   }
 
-  @Test public void drain_json() {
+  @Test void drain_json() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
     for (int i = 0; i < 4; i++) {
       pending.offer(i, 1);
@@ -81,7 +80,7 @@ public class BufferNextMessageTest {
     );
   }
 
-  @Test public void drain_incrementally_json() {
+  @Test void drain_incrementally_json() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.JSON, 10, 0L);
     for (int i = 0; i < 4; i++) {
       pending.offer(i, 1);
@@ -104,7 +103,7 @@ public class BufferNextMessageTest {
         .isEqualTo(3 /* [3] */);
   }
 
-  @Test public void empty_proto3() {
+  @Test void empty_proto3() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
 
     assertThat(pending.bufferFull)
@@ -113,7 +112,7 @@ public class BufferNextMessageTest {
         .isZero();
   }
 
-  @Test public void offer_proto3() {
+  @Test void offer_proto3() {
     BufferNextMessage<Character> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
     pending.offer('a', 1);
 
@@ -130,7 +129,7 @@ public class BufferNextMessageTest {
         .isEqualTo(2 /* ab */);
   }
 
-  @Test public void offerWhenFull_proto3() {
+  @Test void offerWhenFull_proto3() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
     for (int i = 0; i < 3; i++) {
       assertThat(pending.offer(i, 3))
@@ -150,7 +149,7 @@ public class BufferNextMessageTest {
     assertThat(pending.bufferFull).isTrue();
   }
 
-  @Test public void drain_proto3() {
+  @Test void drain_proto3() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
     for (int i = 0; i < 4; i++) {
       pending.offer(i, 1);
@@ -165,7 +164,7 @@ public class BufferNextMessageTest {
     );
   }
 
-  @Test public void drain_incrementally_proto3() {
+  @Test void drain_incrementally_proto3() {
     BufferNextMessage<Integer> pending = BufferNextMessage.create(Encoding.PROTO3, 10, 0L);
     for (int i = 0; i < 4; i++) {
       pending.offer(i, 1);

--- a/core/src/test/java/zipkin2/reporter/ByteBoundedQueueTest.java
+++ b/core/src/test/java/zipkin2/reporter/ByteBoundedQueueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,45 +15,40 @@ package zipkin2.reporter;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ByteBoundedQueueTest {
+class ByteBoundedQueueTest {
   ByteBoundedQueue<byte[]> queue = new ByteBoundedQueue<>(10, 10);
 
-  @Test
-  public void offer_failsWhenFull_size() {
+  @Test void offer_failsWhenFull_size() {
     for (int i = 0; i < queue.maxSize; i++) {
       assertThat(queue.offer(new byte[1], 1)).isTrue();
     }
     assertThat(queue.offer(new byte[1], 1)).isFalse();
   }
 
-  @Test
-  public void offer_failsWhenFull_sizeInBytes() {
+  @Test void offer_failsWhenFull_sizeInBytes() {
     assertThat(queue.offer(new byte[10], 10)).isTrue();
     assertThat(queue.offer(new byte[1], 1)).isFalse();
   }
 
-  @Test
-  public void offer_updatesCount() {
+  @Test void offer_updatesCount() {
     for (int i = 0; i < queue.maxSize; i++) {
       queue.offer(new byte[1], 1);
     }
     assertThat(queue.count).isEqualTo(10);
   }
 
-  @Test
-  public void offer_sizeInBytes() {
+  @Test void offer_sizeInBytes() {
     for (int i = 0; i < queue.maxSize; i++) {
       queue.offer(new byte[1], 1);
     }
     assertThat(queue.sizeInBytes).isEqualTo(queue.maxSize);
   }
 
-  @Test
-  public void circular() {
+  @Test void circular() {
     ByteBoundedQueue<Integer> queue = new ByteBoundedQueue<>(10, 10);
 
     List<Integer> polled = new ArrayList<>();

--- a/core/src/test/java/zipkin2/reporter/BytesMessageEncoderTest.java
+++ b/core/src/test/java/zipkin2/reporter/BytesMessageEncoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,26 +15,25 @@ package zipkin2.reporter;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BytesMessageEncoderTest {
-
-  @Test public void emptyList_json() {
+class BytesMessageEncoderTest {
+  @Test void emptyList_json() {
     List<byte[]> encoded = Arrays.asList();
     assertThat(BytesMessageEncoder.JSON.encode(encoded))
         .containsExactly('[', ']');
   }
 
-  @Test public void singletonList_json() {
+  @Test void singletonList_json() {
     List<byte[]> encoded = Arrays.asList(new byte[] {'{', '}'});
 
     assertThat(BytesMessageEncoder.JSON.encode(encoded))
         .containsExactly('[', '{', '}', ']');
   }
 
-  @Test public void multiItemList_json() {
+  @Test void multiItemList_json() {
     List<byte[]> encoded = Arrays.asList(
         "{\"k\":\"1\"}".getBytes(),
         "{\"k\":\"2\"}".getBytes(),
@@ -44,20 +43,20 @@ public class BytesMessageEncoderTest {
         .isEqualTo("[{\"k\":\"1\"},{\"k\":\"2\"},{\"k\":\"3\"}]");
   }
 
-  @Test public void emptyList_proto3() {
+  @Test void emptyList_proto3() {
     List<byte[]> encoded = Arrays.asList();
     assertThat(BytesMessageEncoder.PROTO3.encode(encoded))
         .isEmpty();
   }
 
-  @Test public void singletonList_proto3() {
+  @Test void singletonList_proto3() {
     List<byte[]> encoded = Arrays.asList(new byte[] {1, 1, 'a'});
 
     assertThat(BytesMessageEncoder.PROTO3.encode(encoded))
         .containsExactly(1, 1, 'a');
   }
 
-  @Test public void multiItemList_proto3() {
+  @Test void multiItemList_proto3() {
     List<byte[]> encoded = Arrays.asList(
         new byte[] {1, 1, 'a'},
         new byte[] {1, 1, 'b'},

--- a/core/src/test/java/zipkin2/reporter/InMemoryReporterMetricsTest.java
+++ b/core/src/test/java/zipkin2/reporter/InMemoryReporterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,13 +13,12 @@
  */
 package zipkin2.reporter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InMemoryReporterMetricsTest {
-  @Test
-  public void incrementMessagesDropped_sameExceptionTypeIsNotCountedMoreThanOnce() {
+class InMemoryReporterMetricsTest {
+  @Test void incrementMessagesDropped_sameExceptionTypeIsNotCountedMoreThanOnce() {
     InMemoryReporterMetrics inMemoryReporterMetrics = new InMemoryReporterMetrics();
 
     inMemoryReporterMetrics.incrementMessagesDropped(new RuntimeException());
@@ -31,8 +30,7 @@ public class InMemoryReporterMetricsTest {
     assertThat(inMemoryReporterMetrics.messagesDroppedByCause().size()).isEqualTo(2);
   }
 
-  @Test
-  public void incrementMessagesDropped_multipleOccurrencesOfSameExceptionTypeAreCounted() {
+  @Test void incrementMessagesDropped_multipleOccurrencesOfSameExceptionTypeAreCounted() {
     InMemoryReporterMetrics inMemoryReporterMetrics = new InMemoryReporterMetrics();
 
     inMemoryReporterMetrics.incrementMessagesDropped(new RuntimeException());

--- a/core/src/test/java/zipkin2/reporter/internal/InternalReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/internal/InternalReporterTest.java
@@ -14,7 +14,7 @@
 package zipkin2.reporter.internal;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.BytesEncoder;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.AsyncReporter;
@@ -23,7 +23,7 @@ import zipkin2.reporter.Sender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InternalReporterTest {
+class InternalReporterTest {
   Sender sender = FakeSender.create();
   BytesEncoder<String> bytesEncoder = new BytesEncoder<String>() {
     @Override public Encoding encoding() {
@@ -49,7 +49,7 @@ public class InternalReporterTest {
    * created as the there is no ambiguity on whether {@link AsyncReporter.Builder#build()} or {@link
    * AsyncReporter.Builder#build(BytesEncoder)} was called.
    */
-  @Test public void toBuilder() {
+  @Test void toBuilder() {
     AsyncReporter<String> input = AsyncReporter.builder(sender).build(bytesEncoder);
     assertThat(InternalReporter.instance.toBuilder(input).build(bytesEncoder))
         .usingRecursiveComparison()

--- a/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaSender.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/ITKafkaSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -56,12 +56,12 @@ class ITKafkaSender {
 
   KafkaSender sender;
 
-  @BeforeEach public void open() {
+  @BeforeEach void open() {
     sender = KafkaSender.create(kafka.bootstrapServer());
     kafka.prepareTopics(sender.topic, 1);
   }
 
-  @AfterEach public void close() {
+  @AfterEach void close() {
     sender.close();
   }
 

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/InternalScribeCodecTest.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/InternalScribeCodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,7 +19,7 @@ import java.util.Base64;
 import java.util.List;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TIOStreamTransport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import zipkin2.Endpoint;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
@@ -30,10 +30,8 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.TestObjects.TODAY;
 import static zipkin2.TestObjects.UTF_8;
 
-public class InternalScribeCodecTest {
-
-  @Test
-  public void base64_matches() {
+class InternalScribeCodecTest {
+  @Test void base64_matches() {
     // testing every padding value
     for (String input : Arrays.asList("abc", "abcd", "abcd", "abcde")) {
       byte[] base64 = Base64.getEncoder().encode(input.getBytes(UTF_8));
@@ -42,8 +40,7 @@ public class InternalScribeCodecTest {
     }
   }
 
-  @Test
-  public void sendsSpansExpectedMetrics() throws Exception {
+  @Test void sendsSpansExpectedMetrics() throws Exception {
     byte[] thrift = SpanBytesEncoder.THRIFT.encode(CLIENT_SPAN);
     List<byte[]> encodedSpans = asList(thrift, thrift);
 
@@ -56,8 +53,7 @@ public class InternalScribeCodecTest {
         .isEqualTo(out.size());
   }
 
-  @Test
-  public void sendsSpanExpectedMetrics() throws Exception {
+  @Test void sendsSpanExpectedMetrics() throws Exception {
     byte[] thrift = SpanBytesEncoder.THRIFT.encode(CLIENT_SPAN);
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     TBinaryProtocol prot = new TBinaryProtocol(new TIOStreamTransport(out));
@@ -71,8 +67,7 @@ public class InternalScribeCodecTest {
         .isEqualTo(out.size());
   }
 
-  @Test
-  public void base64SizeInBytes() {
+  @Test void base64SizeInBytes() {
     Endpoint web = Endpoint.newBuilder().serviceName("web").ip("127.0.0.1").build();
 
     Span span1 =

--- a/metrics-micrometer/src/test/java/zipkin2/reporter/metrics/micrometer/MicrometerReporterMetricsTest.java
+++ b/metrics-micrometer/src/test/java/zipkin2/reporter/metrics/micrometer/MicrometerReporterMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,16 +17,15 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MicrometerReporterMetricsTest {
+class MicrometerReporterMetricsTest {
   MeterRegistry meterRegistry = new SimpleMeterRegistry();
   MicrometerReporterMetrics reporterMetrics = MicrometerReporterMetrics.create(meterRegistry);
 
-  @Test
-  public void expectedMetricsRegistered() {
+  @Test void expectedMetricsRegistered() {
     assertThat(meterRegistry.getMeters())
       .extracting(Meter::getId).extracting(Meter.Id::getName)
       .containsExactlyInAnyOrder(
@@ -40,8 +39,7 @@ public class MicrometerReporterMetricsTest {
       );
   }
 
-  @Test
-  public void incrementMessagesDropped_sameExceptionTypeIsNotTaggedMoreThanOnce() {
+  @Test void incrementMessagesDropped_sameExceptionTypeIsNotTaggedMoreThanOnce() {
     reporterMetrics.incrementMessagesDropped(new RuntimeException("boo"));
     reporterMetrics.incrementMessagesDropped(new RuntimeException("shh"));
     reporterMetrics.incrementMessagesDropped(new IllegalStateException());
@@ -54,8 +52,7 @@ public class MicrometerReporterMetricsTest {
     assertThat(messagesDroppedTotal).isEqualTo(3); // 3 total messages dropped
   }
 
-  @Test
-  public void gaugesSurviveGc() {
+  @Test void gaugesSurviveGc() {
     reporterMetrics.updateQueuedBytes(53);
     reporterMetrics.updateQueuedSpans(2);
 

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/HttpCallTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/HttpCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,13 +21,12 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.Okio;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class HttpCallTest {
-
-  @Test public void parseResponse_closesBody() throws Exception {
+class HttpCallTest {
+  @Test void parseResponse_closesBody() throws Exception {
 
     // It is difficult to prove close was called, this approach looks at an underlying stream
     AtomicBoolean closed = new AtomicBoolean();

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
     <brave.version>5.16.0</brave.version>
 
-    <junit.version>4.13.2</junit.version>
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <!-- use pre-kotlin version -->
     <okhttp.version>3.14.9</okhttp.version>
@@ -160,39 +159,8 @@
          io.zipkin.reporter2:zipkin-reporter or zipkin-reporter-brave difficult to unravel. -->
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${junit-jupiter.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit-jupiter.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <!-- Current versions of JUnit5 provide the above junit-jupiter artifact for convenience, but we
-         may still have transitive dependencies on these older artifacts and have to make sure
-         they're all using the same version. -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit-jupiter.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/ActiveMQSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/ActiveMQSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,21 +14,22 @@
 package zipkin2.reporter.beans;
 
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.activemq.ActiveMQSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ActiveMQSenderFactoryBeanTest {
+class ActiveMQSenderFactoryBeanTest {
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void url() {
+  @Test void url() {
     String brokerUrl = "ssl://abcd.mq.ap-southeast-1.amazonaws.com:61617";
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
@@ -41,7 +42,7 @@ public class ActiveMQSenderFactoryBeanTest {
       .isEqualTo(brokerUrl);
   }
 
-  @Test public void connectionIdPrefix() {
+  @Test void connectionIdPrefix() {
     String connectionIdPrefix = "zipkin-reporter2";
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
@@ -55,7 +56,7 @@ public class ActiveMQSenderFactoryBeanTest {
       .isEqualTo(connectionIdPrefix);
   }
 
-  @Test public void clientIdPrefix() {
+  @Test void clientIdPrefix() {
     String clientIdPrefix = "zipkin-reporter2";
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
@@ -69,7 +70,7 @@ public class ActiveMQSenderFactoryBeanTest {
       .isEqualTo(clientIdPrefix);
   }
 
-  @Test public void queue() {
+  @Test void queue() {
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
       + "  <property name=\"url\" value=\"tcp://localhost:61616\"/>\n"
@@ -82,7 +83,7 @@ public class ActiveMQSenderFactoryBeanTest {
       .isEqualTo("zipkin2");
   }
 
-  @Test public void usernamePassword() {
+  @Test void usernamePassword() {
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
       + "  <property name=\"url\" value=\"tcp://localhost:61616\"/>\n"
@@ -96,7 +97,7 @@ public class ActiveMQSenderFactoryBeanTest {
       .containsExactly("foo", "bar");
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
       + "  <property name=\"url\" value=\"tcp://localhost:61616\"/>\n"
@@ -109,7 +110,7 @@ public class ActiveMQSenderFactoryBeanTest {
       .isEqualTo(1024);
   }
 
-  @Test public void encoding() {
+  @Test void encoding() {
     context = new XmlBeans(""
       + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
       + "  <property name=\"url\" value=\"tcp://localhost:61616\"/>\n"
@@ -122,16 +123,18 @@ public class ActiveMQSenderFactoryBeanTest {
       .isEqualTo(Encoding.PROTO3);
   }
 
-  @Test(expected = IllegalStateException.class) public void close_closesSender() {
-    context = new XmlBeans(""
-      + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
-      + "  <property name=\"url\" value=\"tcp://localhost:61616\"/>\n"
-      + "</bean>"
-    );
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context = new XmlBeans(""
+          + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.ActiveMQSenderFactoryBean\">\n"
+          + "  <property name=\"url\" value=\"tcp://localhost:61616\"/>\n"
+          + "</bean>"
+      );
 
-    ActiveMQSender sender = context.getBean("sender", ActiveMQSender.class);
-    context.close();
+      ActiveMQSender sender = context.getBean("sender", ActiveMQSender.class);
+      context.close();
 
-    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+    });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncReporterFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncReporterFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,8 +14,8 @@
 package zipkin2.reporter.beans;
 
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.codec.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
@@ -24,8 +24,7 @@ import zipkin2.reporter.Sender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AsyncReporterFactoryBeanTest {
-
+class AsyncReporterFactoryBeanTest {
   public static Sender SENDER = new FakeSender();
   public static Sender PROTO3_SENDER = new FakeSender(){
     @Override public Encoding encoding() {
@@ -36,11 +35,11 @@ public class AsyncReporterFactoryBeanTest {
 
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void sender() {
+  @Test void sender() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -55,7 +54,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(SENDER);
   }
 
-  @Test public void metrics() {
+  @Test void metrics() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -73,7 +72,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(METRICS);
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -89,7 +88,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(512);
   }
 
-  @Test public void messageTimeout() {
+  @Test void messageTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -104,7 +103,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
   }
 
-  @Test public void closeTimeout() {
+  @Test void closeTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -120,7 +119,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
   }
 
-  @Test public void queuedMaxSpans() {
+  @Test void queuedMaxSpans() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -136,7 +135,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(10);
   }
 
-  @Test public void queuedMaxBytes() {
+  @Test void queuedMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -152,7 +151,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(512);
   }
 
-  @Test public void sender_proto3() {
+  @Test void sender_proto3() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -167,7 +166,7 @@ public class AsyncReporterFactoryBeanTest {
         .isEqualTo(SpanBytesEncoder.PROTO3);
   }
 
-  @Test public void encoder() {
+  @Test void encoder() {
     context = new XmlBeans(""
         + "<bean id=\"asyncReporter\" class=\"zipkin2.reporter.beans.AsyncReporterFactoryBean\">\n"
         + "  <property name=\"sender\">\n"

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,8 +16,8 @@ package zipkin2.reporter.beans;
 import brave.Tag;
 import brave.propagation.TraceContext;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
@@ -25,7 +25,7 @@ import zipkin2.reporter.brave.ZipkinSpanHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class AsyncZipkinSpanHandlerFactoryBeanTest {
+class AsyncZipkinSpanHandlerFactoryBeanTest {
   public static final Tag<Throwable> ERROR_TAG = new Tag<Throwable>("error") {
     @Override protected String parseValue(Throwable throwable, TraceContext traceContext) {
       return null;
@@ -36,11 +36,11 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
 
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void errorTag() {
+  @Test void errorTag() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -58,7 +58,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isSameAs(ERROR_TAG);
   }
 
-  @Test public void alwaysReportSpans() {
+  @Test void alwaysReportSpans() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -75,7 +75,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
   }
 
   // below copied from AsyncReporterFactoryBean
-  @Test public void sender() {
+  @Test void sender() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -90,7 +90,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(SENDER);
   }
 
-  @Test public void metrics() {
+  @Test void metrics() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -108,7 +108,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(METRICS);
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -124,7 +124,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(512);
   }
 
-  @Test public void messageTimeout() {
+  @Test void messageTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -139,7 +139,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
   }
 
-  @Test public void closeTimeout() {
+  @Test void closeTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -155,7 +155,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
   }
 
-  @Test public void queuedMaxSpans() {
+  @Test void queuedMaxSpans() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"
@@ -171,7 +171,7 @@ public class AsyncZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(10);
   }
 
-  @Test public void queuedMaxBytes() {
+  @Test void queuedMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"sender\">\n"

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/FakeSender.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/FakeSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,7 +18,7 @@ import zipkin2.Call;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.Sender;
 
-public class FakeSender extends Sender {
+class FakeSender extends Sender {
   @Override public Encoding encoding() {
     return Encoding.JSON;
   }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,21 +14,22 @@
 package zipkin2.reporter.beans;
 
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.kafka.KafkaSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class KafkaSenderFactoryBeanTest {
+class KafkaSenderFactoryBeanTest {
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void bootstrapServers() {
+  @Test void bootstrapServers() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
         + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
@@ -42,7 +43,7 @@ public class KafkaSenderFactoryBeanTest {
             .build());
   }
 
-  @Test public void topic() {
+  @Test void topic() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
         + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
@@ -57,7 +58,7 @@ public class KafkaSenderFactoryBeanTest {
             .topic("zipkin2").build());
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
         + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
@@ -70,7 +71,7 @@ public class KafkaSenderFactoryBeanTest {
         .isEqualTo(1024);
   }
 
-  @Test public void encoding() {
+  @Test void encoding() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
         + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
@@ -83,16 +84,18 @@ public class KafkaSenderFactoryBeanTest {
         .isEqualTo(Encoding.PROTO3);
   }
 
-  @Test(expected = IllegalStateException.class) public void close_closesSender() {
-    context = new XmlBeans(""
-        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
-        + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
-        + "</bean>"
-    );
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context = new XmlBeans(""
+          + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.KafkaSenderFactoryBean\">\n"
+          + "  <property name=\"bootstrapServers\" value=\"localhost:9092\"/>\n"
+          + "</bean>"
+      );
 
-    KafkaSender sender = context.getBean("sender", KafkaSender.class);
-    context.close();
+      KafkaSender sender = context.getBean("sender", KafkaSender.class);
+      context.close();
 
-    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+    });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/LibthriftSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/LibthriftSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,22 +15,21 @@ package zipkin2.reporter.beans;
 
 import java.net.MalformedURLException;
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.reporter.libthrift.LibthriftSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LibthriftSenderFactoryBeanTest {
+class LibthriftSenderFactoryBeanTest {
   XmlBeans context;
 
-  @After
-  public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test
-  public void host() throws MalformedURLException {
+  @Test void host() throws MalformedURLException {
     context =
         new XmlBeans(
             ""
@@ -43,8 +42,7 @@ public class LibthriftSenderFactoryBeanTest {
         .isEqualTo("myhost");
   }
 
-  @Test
-  public void connectTimeout() {
+  @Test void connectTimeout() {
     context =
         new XmlBeans(
             ""
@@ -58,8 +56,7 @@ public class LibthriftSenderFactoryBeanTest {
         .isEqualTo(LibthriftSender.newBuilder().host("myhost").connectTimeout(0).build());
   }
 
-  @Test
-  public void socketTimeout() {
+  @Test void socketTimeout() {
     context =
         new XmlBeans(
             ""
@@ -73,8 +70,7 @@ public class LibthriftSenderFactoryBeanTest {
         .isEqualTo(LibthriftSender.newBuilder().host("myhost").socketTimeout(0).build());
   }
 
-  @Test
-  public void port() {
+  @Test void port() {
     context =
         new XmlBeans(
             ""
@@ -88,8 +84,7 @@ public class LibthriftSenderFactoryBeanTest {
         .isEqualTo(1000);
   }
 
-  @Test
-  public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context =
         new XmlBeans(
             ""
@@ -103,18 +98,19 @@ public class LibthriftSenderFactoryBeanTest {
         .isEqualTo(1024);
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void close_closesSender() {
-    context =
-        new XmlBeans(
-            ""
-                + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
-                + "  <property name=\"host\" value=\"myhost\"/>\n"
-                + "</bean>");
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context =
+          new XmlBeans(
+              ""
+                  + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.LibthriftSenderFactoryBean\">\n"
+                  + "  <property name=\"host\" value=\"myhost\"/>\n"
+                  + "</bean>");
 
-    LibthriftSender sender = context.getBean("sender", LibthriftSender.class);
-    context.close();
+      LibthriftSender sender = context.getBean("sender", LibthriftSender.class);
+      context.close();
 
-    sender.sendSpans(Arrays.asList(new byte[0]));
+      sender.sendSpans(Arrays.asList(new byte[0]));
+    });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,21 +15,22 @@ package zipkin2.reporter.beans;
 
 import java.util.Arrays;
 import okhttp3.HttpUrl;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class OkHttpSenderFactoryBeanTest {
+class OkHttpSenderFactoryBeanTest {
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void endpoint() {
+  @Test void endpoint() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -41,7 +42,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(HttpUrl.parse("http://localhost:9411/api/v2/spans"));
   }
 
-  @Test public void connectTimeout() {
+  @Test void connectTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -54,7 +55,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(1000);
   }
 
-  @Test public void writeTimeout() {
+  @Test void writeTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -67,7 +68,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(1000);
   }
 
-  @Test public void readTimeout() {
+  @Test void readTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -80,7 +81,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(1000);
   }
 
-  @Test public void maxRequests() {
+  @Test void maxRequests() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -93,7 +94,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(4);
   }
 
-  @Test public void compressionEnabled() {
+  @Test void compressionEnabled() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -106,7 +107,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(false);
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -119,7 +120,7 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(1024);
   }
 
-  @Test public void encoding() {
+  @Test void encoding() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -132,16 +133,18 @@ public class OkHttpSenderFactoryBeanTest {
         .isEqualTo(Encoding.PROTO3);
   }
 
-  @Test(expected = IllegalStateException.class) public void close_closesSender() {
-    context = new XmlBeans(""
-        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
-        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
-        + "</bean>"
-    );
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context = new XmlBeans(""
+          + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.OkHttpSenderFactoryBean\">\n"
+          + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+          + "</bean>"
+      );
 
-    OkHttpSender sender = context.getBean("sender", OkHttpSender.class);
-    context.close();
+      OkHttpSender sender = context.getBean("sender", OkHttpSender.class);
+      context.close();
 
-    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+    });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,22 +15,23 @@ package zipkin2.reporter.beans;
 
 import com.rabbitmq.client.Address;
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.amqp.RabbitMQSender;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class RabbitMQSenderFactoryBeanTest {
+class RabbitMQSenderFactoryBeanTest {
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void addresses() {
+  @Test void addresses() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -42,7 +43,7 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo(asList(new Address("localhost")));
   }
 
-  @Test public void queue() {
+  @Test void queue() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -55,7 +56,7 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo("zipkin2");
   }
 
-  @Test public void connectionTimeout() {
+  @Test void connectionTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -68,7 +69,7 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo(0);
   }
 
-  @Test public void virtualHost() {
+  @Test void virtualHost() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -81,7 +82,7 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo("zipkin3");
   }
 
-  @Test public void usernamePassword() {
+  @Test void usernamePassword() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -95,7 +96,7 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo(asList("foo", "bar"));
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -108,7 +109,7 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo(1024);
   }
 
-  @Test public void encoding() {
+  @Test void encoding() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
         + "  <property name=\"addresses\" value=\"localhost\"/>\n"
@@ -121,16 +122,18 @@ public class RabbitMQSenderFactoryBeanTest {
         .isEqualTo(Encoding.PROTO3);
   }
 
-  @Test(expected = IllegalStateException.class) public void close_closesSender() {
-    context = new XmlBeans(""
-        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
-        + "  <property name=\"addresses\" value=\"localhost\"/>\n"
-        + "</bean>"
-    );
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context = new XmlBeans(""
+          + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.RabbitMQSenderFactoryBean\">\n"
+          + "  <property name=\"addresses\" value=\"localhost\"/>\n"
+          + "</bean>"
+      );
 
-    RabbitMQSender sender = context.getBean("sender", RabbitMQSender.class);
-    context.close();
+      RabbitMQSender sender = context.getBean("sender", RabbitMQSender.class);
+      context.close();
 
-    sender.sendSpans(asList(new byte[] {'{', '}'}));
+      sender.sendSpans(asList(new byte[]{'{', '}'}));
+    });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,21 +16,22 @@ package zipkin2.reporter.beans;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Arrays;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.codec.Encoding;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class URLConnectionSenderFactoryBeanTest {
+class URLConnectionSenderFactoryBeanTest {
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void endpoint() throws MalformedURLException {
+  @Test void endpoint() throws MalformedURLException {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -42,7 +43,7 @@ public class URLConnectionSenderFactoryBeanTest {
         .isEqualTo(URI.create("http://localhost:9411/api/v2/spans").toURL());
   }
 
-  @Test public void connectTimeout() {
+  @Test void connectTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -58,7 +59,7 @@ public class URLConnectionSenderFactoryBeanTest {
             .build()));
   }
 
-  @Test public void readTimeout() {
+  @Test void readTimeout() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -73,7 +74,7 @@ public class URLConnectionSenderFactoryBeanTest {
             .readTimeout(0).build()));
   }
 
-  @Test public void compressionEnabled() {
+  @Test void compressionEnabled() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -86,7 +87,7 @@ public class URLConnectionSenderFactoryBeanTest {
         .isEqualTo(false);
   }
 
-  @Test public void messageMaxBytes() {
+  @Test void messageMaxBytes() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -99,7 +100,7 @@ public class URLConnectionSenderFactoryBeanTest {
         .isEqualTo(1024);
   }
 
-  @Test public void encoding() {
+  @Test void encoding() {
     context = new XmlBeans(""
         + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
         + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
@@ -112,16 +113,18 @@ public class URLConnectionSenderFactoryBeanTest {
         .isEqualTo(Encoding.PROTO3);
   }
 
-  @Test(expected = IllegalStateException.class) public void close_closesSender() {
-    context = new XmlBeans(""
-        + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
-        + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
-        + "</bean>"
-    );
+  @Test void close_closesSender() {
+    assertThrows(IllegalStateException.class, () -> {
+      context = new XmlBeans(""
+          + "<bean id=\"sender\" class=\"zipkin2.reporter.beans.URLConnectionSenderFactoryBean\">\n"
+          + "  <property name=\"endpoint\" value=\"http://localhost:9411/api/v2/spans\"/>\n"
+          + "</bean>"
+      );
 
-    URLConnectionSender sender = context.getBean("sender", URLConnectionSender.class);
-    context.close();
+      URLConnectionSender sender = context.getBean("sender", URLConnectionSender.class);
+      context.close();
 
-    sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+    });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/ZipkinSpanHandlerFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,8 +15,8 @@ package zipkin2.reporter.beans;
 
 import brave.Tag;
 import brave.propagation.TraceContext;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.ZipkinSpanHandler;
@@ -24,7 +24,7 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ZipkinSpanHandlerFactoryBeanTest {
+class ZipkinSpanHandlerFactoryBeanTest {
   public static final Tag<Throwable> ERROR_TAG = new Tag<Throwable>("error") {
     @Override protected String parseValue(Throwable throwable, TraceContext traceContext) {
       return null;
@@ -33,11 +33,11 @@ public class ZipkinSpanHandlerFactoryBeanTest {
 
   XmlBeans context;
 
-  @After public void close() {
+  @AfterEach void close() {
     if (context != null) context.close();
   }
 
-  @Test public void spanReporter() {
+  @Test void spanReporter() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"spanReporter\">\n"
@@ -51,7 +51,7 @@ public class ZipkinSpanHandlerFactoryBeanTest {
         .isEqualTo(Reporter.CONSOLE);
   }
 
-  @Test public void errorTag() {
+  @Test void errorTag() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"spanReporter\">\n"
@@ -68,7 +68,7 @@ public class ZipkinSpanHandlerFactoryBeanTest {
         .isSameAs(ERROR_TAG);
   }
 
-  @Test public void alwaysReportSpans() {
+  @Test void alwaysReportSpans() {
     context = new XmlBeans(""
         + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.ZipkinSpanHandlerFactoryBean\">\n"
         + "  <property name=\"spanReporter\">\n"


### PR DESCRIPTION
This migrates from JUnit 4 to JUnit 5 (Jupiter) beginning with the following OpenRewrite command:

```bash
$ ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:LATEST \
  -Drewrite.activeRecipes=org.openrewrite.java.testing.junit5.JUnit4to5Migration
```

After this, we had to do some work, notably as Brave needs to support non-alpha versions of OkHttp and alpha 5 creates a classpath conflict on Okio. Notably, I had to revert changes for the okhttp and urlconnection senders, which formerly used normal mockwebserver 3 and were automatically migrated to v5 alpha.

Next, I had to polish formatting as it undid some of that, and also fixed some cases where we were inconsistent. Then, I reviewed our base pom and removed some special cases that were no longer needed. Finally, I swept through and reduced visibility modifiers where possible.

Note: Both testcontainers and mockwebserver v3 have an implicit dep on junit 4. This is ok and the same as zipkin. The main thing here is we aren't explicitly using it anymore.