### PR TITLE
amqp-client: moves to latest version and tests prior

### DIFF
--- a/amqp-client/README.md
+++ b/amqp-client/README.md
@@ -1,0 +1,12 @@
+# zipkin-sender-amqp-client
+This module contains a span sender for [RabbitMQ](https://github.com/rabbitmq/rabbitmq-java-client).
+
+Please view [RabbitMQSender](src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java)
+for usage details.
+
+## Compatability
+
+In order to keep new users current, this assigns the most recent major version
+of amqp-client 5.x. This reduces distraction around CVEs. That said, this
+module is tested to be runtime compatible with 4.x, for users who need to
+support Java 6 or 7 use cases.

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -31,7 +31,9 @@
     <module.name>zipkin2.reporter.amqp</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-    <amqp-client.version>4.12.0</amqp-client.version>
+    <amqp-client.version>5.20.0</amqp-client.version>
+    <!-- Last pre-1.8 version -->
+    <old-amqp-client.version>4.12.0</old-amqp-client.version>
   </properties>
 
   <dependencies>
@@ -54,6 +56,38 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>de.qaware.maven</groupId>
+        <artifactId>go-offline-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>resolve-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- Add dependencies specific to invoker tests so that they cache on go-offline -->
+          <dynamicDependencies>
+            <DynamicDependency>
+              <groupId>com.rabbitmq</groupId>
+              <artifactId>amqp-client</artifactId>
+              <version>${old-amqp-client.version}</version>
+              <repositoryType>MAIN</repositoryType>
+              <type>jar</type>
+            </DynamicDependency>
+          </dynamicDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/amqp-client/src/it/amqp_v4/README.md
+++ b/amqp-client/src/it/amqp_v4/README.md
@@ -1,0 +1,2 @@
+# amqp_v4
+This tests that RabbitMQSender can be used with amqp-client 4.x

--- a/amqp-client/src/it/amqp_v4/pom.xml
+++ b/amqp-client/src/it/amqp_v4/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2023 The OpenZipkin Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>amqp_v4</artifactId>
+  <version>@project.version@</version>
+  <name>amqp_v4</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>zipkin-sender-amqp-client</artifactId>
+      <version>@project.version@</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.rabbitmq</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.rabbitmq</groupId>
+      <artifactId>amqp-client</artifactId>
+      <version>@old-amqp-client.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>@junit-jupiter.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-tests</artifactId>
+      <version>@zipkin.version@</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>@testcontainers.version@</version>
+    </dependency>
+
+    <!-- Main code uses jul and tests log with log4j -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4j.version@</version>
+    </dependency>
+    <!-- route jul over log4j2 during integration tests -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>@log4j.version@</version>
+    </dependency>
+    <!-- route slf4j over log4j2 during integration tests -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>@log4j.version@</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>@project.build.testSourceDirectory@</sourceDirectory>
+    <testResources>
+      <testResource>
+        <directory>@project.basedir@/src/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+        <configuration>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-surefire-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+          <!-- Try to prevent flakes in CI -->
+          <reuseForks>false</reuseForks>
+          <!-- workaround to SUREFIRE-1831 -->
+          <useModulePath>false</useModulePath>
+          <systemPropertyVariables>
+            <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/amqp-client/src/it/amqp_v4/src/test/java/zipkin2/reporter/amqp_v4/ITRabbitMQSender.java
+++ b/amqp-client/src/it/amqp_v4/src/test/java/zipkin2/reporter/amqp_v4/ITRabbitMQSender.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2016-2023 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.amqp_v4;
+
+public class ITRabbitMQSender extends zipkin2.reporter.amqp.ITRabbitMQSender {
+}

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/ITRabbitMQSender.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/ITRabbitMQSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2023 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,7 +38,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Timeout(60)
-class ITRabbitMQSender {
+public class ITRabbitMQSender { // public for use in src/it
   @RegisterExtension RabbitMQExtension rabbit = new RabbitMQExtension();
 
   @Test void sendsSpans() throws Exception {


### PR DESCRIPTION
This follows the same pattern as OkHttp by testing RabbitMQ's prior version instead of pinning an old version with CVEs as a strict dependency. This removes the amount of CVE distractions and still keeps things compatible.