### PR TITLE
deps: updates to zipkin 2.25.2

### DIFF
--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQExtension.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQExtension.java
@@ -64,7 +64,7 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-activemq:2.25.1"));
+      super(parse("ghcr.io/openzipkin/zipkin-activemq:2.25.2"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQExtension.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQExtension.java
@@ -82,7 +82,7 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.25.1"));
+      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.25.2"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
@@ -41,7 +41,7 @@ public class KafkaSenderBenchmarks extends SenderBenchmarks {
 
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.1"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.2"));
       waitStrategy = Wait.forHealthcheck();
       // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
       addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.25.1</zipkin.version>
+    <zipkin.version>2.25.2</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>

--- a/kafka/src/test/java/zipkin2/reporter/kafka/KafkaExtension.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/KafkaExtension.java
@@ -90,7 +90,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.1"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.25.2"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinExtension.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinExtension.java
@@ -76,7 +76,7 @@ class ZipkinExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ZipkinContainer extends GenericContainer<ZipkinContainer> {
     ZipkinContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin:2.25.1"));
+      super(parse("ghcr.io/openzipkin/zipkin:2.25.2"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <errorprone.version>2.23.0</errorprone.version>
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.25.1</zipkin.version>
+    <zipkin.version>2.25.2</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
     <brave.version>5.16.0</brave.version>


### PR DESCRIPTION
More important is the docker test image alignment, but also this helps applications pull less different recent versions of zipkin jar.