### PR TITLE
build: fixes bytecode level and updates build versions

### DIFF
--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -34,11 +34,6 @@
          as the former uses javax.jms and latter jakarta.jms. It could be
          better to make an activemq-client6 module. -->
     <activemq.version>5.18.3</activemq.version>
-
-    <!-- CI should run the "release" profile during tests to ensure no 1.8
-         features are in use. -->
-    <!-- activemq is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -67,7 +62,9 @@
       <id>release</id>
       <properties>
         <!-- activemq is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java
+++ b/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -77,7 +77,7 @@ public final class ActiveMQSender extends Sender {
     ActiveMQConnectionFactory connectionFactory;
     String queue = "zipkin";
     Encoding encoding = Encoding.JSON;
-    int messageMaxBytes = 500_000;
+    int messageMaxBytes = 500000;
 
     public Builder connectionFactory(ActiveMQConnectionFactory connectionFactory) {
       if (connectionFactory == null) throw new NullPointerException("connectionFactory == null");
@@ -159,9 +159,9 @@ public final class ActiveMQSender extends Sender {
   @Override public CheckResult check() {
     try {
       lazyInit.get();
-    } catch (IOException | RuntimeException | Error e) {
-      Call.propagateIfFatal(e);
-      return CheckResult.failed(e);
+    } catch (Throwable t) {
+      Call.propagateIfFatal(t);
+      return CheckResult.failed(t);
     }
     return lazyInit.result.checkResult;
   }
@@ -210,8 +210,9 @@ public final class ActiveMQSender extends Sender {
       try {
         send();
         callback.onSuccess(null);
-      } catch (IOException | RuntimeException | Error e) {
-        callback.onError(e);
+      } catch (Throwable t) {
+        Call.propagateIfFatal(t);
+        callback.onError(t);
       }
     }
   }

--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQExtension.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQExtension.java
@@ -64,7 +64,7 @@ class ActiveMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
     ActiveMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-activemq:2.26.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-activemq:2.27.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -34,9 +34,6 @@
     <amqp-client.version>5.20.0</amqp-client.version>
     <!-- Last pre-1.8 version -->
     <old-amqp-client.version>4.12.0</old-amqp-client.version>
-
-    <!-- amqp-client 4.x is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -97,7 +94,9 @@
       <id>release</id>
       <properties>
         <!-- amqp-client 4.x is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/amqp-client/src/it/amqp_v4/pom.xml
+++ b/amqp-client/src/it/amqp_v4/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2023 The OpenZipkin Authors
+    Copyright 2016-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,6 +30,7 @@
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQExtension.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQExtension.java
@@ -82,7 +82,7 @@ class RabbitMQExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     RabbitMQContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.26.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:2.27.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
@@ -41,7 +41,7 @@ public class KafkaSenderBenchmarks extends SenderBenchmarks {
 
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.26.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.27.0"));
       waitStrategy = Wait.forHealthcheck();
       // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
       addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- use the same value in ../pom.xml -->
-    <zipkin.version>2.26.0</zipkin.version>
+    <zipkin.version>2.27.0</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -31,9 +31,6 @@
     <module.name>zipkin2.reporter.brave</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- The brave jar needs to be Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -75,7 +72,9 @@
       <id>release</id>
       <properties>
         <!-- The brave jar needs to be Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/brave/src/main/java/zipkin2/reporter/brave/ConvertingSpanReporter.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ConvertingSpanReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -129,7 +129,7 @@ final class ConvertingSpanReporter implements Reporter<MutableSpan> {
    * Zipkin kind values.
    */
   static Map<Kind, Span.Kind> generateKindMap() {
-    Map<Kind, Span.Kind> result = new LinkedHashMap<>();
+    Map<Kind, Span.Kind> result = new LinkedHashMap<Kind, Span.Kind>();
     // Note: Both Brave and Zipkin treat null kind as a local/in-process span
     for (Kind kind : Kind.values()) {
       try {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,9 +31,6 @@
     <module.name>zipkin2.reporter</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- The core jar needs to be Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -49,7 +46,9 @@
       <id>release</id>
       <properties>
         <!-- The core jar needs to be Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/core/src/main/java/zipkin2/reporter/BufferNextMessage.java
+++ b/core/src/main/java/zipkin2/reporter/BufferNextMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,23 +19,22 @@ import zipkin2.codec.Encoding;
 
 /** Use of this type happens off the application's main thread. This type is not thread-safe */
 abstract class BufferNextMessage<S> implements SpanWithSizeConsumer<S> {
-
   static <S> BufferNextMessage<S> create(Encoding encoding, int maxBytes, long timeoutNanos) {
     switch (encoding) {
       case JSON:
-        return new BufferNextJsonMessage<>(maxBytes, timeoutNanos);
+        return new BufferNextJsonMessage<S>(maxBytes, timeoutNanos);
       case THRIFT:
-        return new BufferNextThriftMessage<>(maxBytes, timeoutNanos);
+        return new BufferNextThriftMessage<S>(maxBytes, timeoutNanos);
       case PROTO3:
-        return new BufferNextProto3Message<>(maxBytes, timeoutNanos);
+        return new BufferNextProto3Message<S>(maxBytes, timeoutNanos);
     }
     throw new UnsupportedOperationException("encoding: " + encoding);
   }
 
   final int maxBytes;
   final long timeoutNanos;
-  final ArrayList<S> spans = new ArrayList<>();
-  final ArrayList<Integer> sizes = new ArrayList<>();
+  final ArrayList<S> spans = new ArrayList<S>();
+  final ArrayList<Integer> sizes = new ArrayList<Integer>();
 
   long deadlineNanoTime;
   int messageSizeInBytes;

--- a/core/src/main/java/zipkin2/reporter/InMemoryReporterMetrics.java
+++ b/core/src/main/java/zipkin2/reporter/InMemoryReporterMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,9 +30,9 @@ public final class InMemoryReporterMetrics implements ReporterMetrics {
   }
 
   private final ConcurrentHashMap<MetricKey, AtomicLong> metrics =
-      new ConcurrentHashMap<>();
+      new ConcurrentHashMap<MetricKey, AtomicLong>();
   private final ConcurrentHashMap<Class<? extends Throwable>, AtomicLong> messagesDropped =
-      new ConcurrentHashMap<>();
+      new ConcurrentHashMap<Class<? extends Throwable>, AtomicLong>();
 
   @Override public void incrementMessages() {
     increment(MetricKey.messages, 1);
@@ -47,7 +47,8 @@ public final class InMemoryReporterMetrics implements ReporterMetrics {
   }
 
   public Map<Class<? extends Throwable>, Long> messagesDroppedByCause() {
-    Map<Class<? extends Throwable>, Long> result = new LinkedHashMap<>(messagesDropped.size());
+    Map<Class<? extends Throwable>, Long> result =
+      new LinkedHashMap<Class<? extends Throwable>, Long>(messagesDropped.size());
     for (Map.Entry<Class<? extends Throwable>, AtomicLong> kv : messagesDropped.entrySet()) {
       result.put(kv.getKey(), kv.getValue().longValue());
     }
@@ -130,7 +131,7 @@ public final class InMemoryReporterMetrics implements ReporterMetrics {
       AtomicLong metric = metrics.get(key);
       if (metric == null) {
         metric = metrics.putIfAbsent(key, new AtomicLong(quantity));
-        if (metric == null) return; // won race creating the entry 
+        if (metric == null) return; // won race creating the entry
       }
 
       while (true) {

--- a/core/src/test/java/zipkin2/reporter/AwaitableCallbackTest.java
+++ b/core/src/test/java/zipkin2/reporter/AwaitableCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,19 +23,14 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 class AwaitableCallbackTest {
   @Test void awaitIsUninterruptable() {
-    AtomicBoolean returned = new AtomicBoolean();
     AwaitableCallback captor = new AwaitableCallback();
-    Thread thread = new Thread(() -> {
-      captor.await();
-      returned.set(true);
-    });
+    Thread thread = new Thread(captor::await);
     thread.start();
     thread.interrupt();
 
     assertThat(thread.isInterrupted()).isTrue();
     // The callback thread receiving an interrupt has nothing to do with the caller of the captor
     assertThat(Thread.currentThread().isInterrupted()).isFalse();
-    assertThat(returned.get()).isFalse();
   }
 
   @Test void onSuccessReturns() {

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -31,9 +31,6 @@
     <module.name>zipkin2.reporter.kafka</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- Kafka 0.11+ is Java 1.7 bytecode -->
-    <main.signature.artifact>java17</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -63,7 +60,9 @@
       <id>release</id>
       <properties>
         <!-- Kafka 0.11+ is Java 1.7 bytecode -->
-        <main.java.version>1.7</main.java.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.release>7</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,6 @@
  */
 package zipkin2.reporter.kafka;
 
-import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -323,15 +322,15 @@ public final class KafkaSender extends Sender {
       this.message = message;
     }
 
-    @Override protected Void doExecute() throws IOException {
+    @Override protected Void doExecute() {
       AwaitableCallback callback = new AwaitableCallback();
-      get().send(new ProducerRecord<>(topic, message), new CallbackAdapter(callback));
+      get().send(new ProducerRecord<byte[], byte[]>(topic, message), new CallbackAdapter(callback));
       callback.await();
       return null;
     }
 
     @Override protected void doEnqueue(Callback<Void> callback) {
-      get().send(new ProducerRecord<>(topic, message), new CallbackAdapter(callback));
+      get().send(new ProducerRecord<byte[], byte[]>(topic, message), new CallbackAdapter(callback));
     }
 
     @Override public Call<Void> clone() {

--- a/kafka/src/test/java/zipkin2/reporter/kafka/KafkaExtension.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/KafkaExtension.java
@@ -90,7 +90,7 @@ class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.26.0"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:2.27.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -31,9 +31,6 @@
     <module.name>zipkin2.reporter.libthrift</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- Libthrift is Java 1.6 bytecode -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -74,7 +71,9 @@
       <id>release</id>
       <properties>
         <!-- Libthrift is Java 1.6 bytecode -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/libthrift/src/main/java/zipkin2/reporter/libthrift/LibthriftSender.java
+++ b/libthrift/src/main/java/zipkin2/reporter/libthrift/LibthriftSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -42,7 +42,7 @@ public final class LibthriftSender extends Sender {
   public static final class Builder {
     String host;
     int port = 9410;
-    int messageMaxBytes = 500_000; // TFramedTransport.DEFAULT_MAX_LENGTH
+    int messageMaxBytes = 500000; // TFramedTransport.DEFAULT_MAX_LENGTH
     int connectTimeout = 10 * 1000, socketTimeout = 60 * 1000;
 
     Builder(LibthriftSender sender) {
@@ -151,7 +151,7 @@ public final class LibthriftSender extends Sender {
   @Override
   public CheckResult check() {
     try {
-      if (get().log(Collections.emptyList())) {
+      if (get().log(Collections.<byte[]>emptyList())) {
         return CheckResult.OK;
       }
       throw new IllegalStateException("try later");
@@ -197,8 +197,9 @@ public final class LibthriftSender extends Sender {
           callback.onError(new IllegalStateException("try later"));
         }
         callback.onSuccess(null);
-      } catch (TException |RuntimeException | Error e) {
-        callback.onError(e);
+      } catch (Throwable t) {
+        Call.propagateIfFatal(t);
+        callback.onError(t);
       }
     }
 

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinExtension.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinExtension.java
@@ -76,7 +76,7 @@ class ZipkinExtension implements BeforeAllCallback, AfterAllCallback {
   // mostly waiting for https://github.com/testcontainers/testcontainers-java/issues/3537
   static final class ZipkinContainer extends GenericContainer<ZipkinContainer> {
     ZipkinContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin:2.26.0"));
+      super(parse("ghcr.io/openzipkin/zipkin:2.27.0"));
       if ("true".equals(System.getProperty("docker.skip"))) {
         throw new TestAbortedException("${docker.skip} == true");
       }

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -33,20 +33,9 @@
     <main.basedir>${project.basedir}/..</main.basedir>
     <!-- pre-1.8, pre-kotlin, and last version before Call.timeout. -->
     <old-okhttp.version>3.11.0</old-okhttp.version>
-
-    <!-- OkHttp 3.x is Java 1.7 bytecode -->
-    <main.signature.artifact>java17</main.signature.artifact>
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>org.jvnet</groupId>
-      <artifactId>animal-sniffer-annotation</artifactId>
-      <version>1.0</version>
-      <!-- annotations are not runtime retention, so don't need a runtime dep -->
-      <scope>provided</scope>
-    </dependency>
-
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>zipkin-reporter</artifactId>
@@ -104,7 +93,9 @@
       <id>release</id>
       <properties>
         <!-- OkHttp 3.x is Java 1.7 bytecode -->
-        <main.java.version>1.7</main.java.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.release>7</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/okhttp3/src/it/okhttp3_v3/pom.xml
+++ b/okhttp3/src/it/okhttp3_v3/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2023 The OpenZipkin Authors
+    Copyright 2016-2024 The OpenZipkin Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -30,6 +30,7 @@
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -225,7 +225,7 @@ public final class OkHttpSender extends Sender {
         // in-flight requests. Once max requests are hit, send will block the caller, which is
         // the AsyncReporter flush thread. This is ok, as the AsyncReporter has a buffer of
         // unsent spans for this purpose.
-        new SynchronousQueue<>(),
+        new SynchronousQueue<Runnable>(),
         OkHttpSenderThreadFactory.INSTANCE);
 
     Dispatcher dispatcher = new Dispatcher(dispatchExecutor);

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/PlatformTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/PlatformTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.okhttp3;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlatformTest {
+  // Tests run in JDK 11+, so this should always work.
+  @Test void uncheckedIOException() {
+    IOException ioe = new IOException("drat");
+    assertThat(Platform.get().uncheckedIOException(ioe))
+      .isInstanceOf(UncheckedIOException.class)
+      .hasCause(ioe);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -44,38 +44,41 @@
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <!-- default bytecode version for src/main -->
-    <main.java.version>1.8</main.java.version>
-    <main.signature.artifact>java18</main.signature.artifact>
-
-    <!-- default bytecode version for src/test -->
+    <!-- Except for the module named zipkin, all source is Java 8 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <!-- We don't use animal-sniffer anymore as release obviates it.
+         See https://github.com/mojohaus/animal-sniffer/issues/62 -->
+    <maven.compiler.release>8</maven.compiler.release>
+
+    <!-- Tests use the floor Java version (used in release) -->
+    <maven.compiler.testSource>11</maven.compiler.testSource>
+    <maven.compiler.testTarget>11</maven.compiler.testTarget>
+    <maven.compiler.testRelease>11</maven.compiler.testRelease>
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.23.0</errorprone.version>
+    <errorprone.version>2.24.1</errorprone.version>
 
     <!-- use the same value in bom/pom.xml -->
-    <zipkin.version>2.26.0</zipkin.version>
+    <zipkin.version>2.27.0</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>5.16.0</brave.version>
+    <brave.version>5.17.0</brave.version>
 
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
-    <assertj.version>3.24.2</assertj.version>
+    <assertj.version>3.25.1</assertj.version>
     <okhttp.version>4.12.0</okhttp.version>
-    <log4j.version>2.22.0</log4j.version>
+    <log4j.version>2.22.1</log4j.version>
     <testcontainers.version>1.19.3</testcontainers.version>
 
     <license.skip>${skipTests}</license.skip>
 
-    <animal-sniffer-maven-plugin.version>1.23</animal-sniffer-maven-plugin.version>
     <go-offline-maven-plugin.version>1.2.8</go-offline-maven-plugin.version>
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.3</license-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -84,12 +87,12 @@
     <maven-help-plugin.version>3.4.0</maven-help-plugin.version>
     <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
     <maven-invoker-plugin.version>3.6.0</maven-invoker-plugin.version>
-    <maven-javadoc-plugin.version>3.6.2</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>
 
@@ -253,10 +256,7 @@
           <version>${maven-compiler-plugin.version}</version>
           <inherited>true</inherited>
           <configuration>
-            <source>${main.java.version}</source>
-            <target>${main.java.version}</target>
             <fork>true</fork>
-            <release>8</release>
             <showWarnings>true</showWarnings>
           </configuration>
         </plugin>
@@ -380,29 +380,6 @@
       <plugin>
         <artifactId>maven-help-plugin</artifactId>
         <version>${maven-help-plugin.version}</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>${animal-sniffer-maven-plugin.version}</version>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>${main.signature.artifact}</artifactId>
-            <version>1.0</version>
-          </signature>
-          <checkTestClasses>false</checkTestClasses>
-        </configuration>
-        <executions>
-          <execution>
-            <id>animal-sniffer</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>
@@ -561,8 +538,6 @@
             <version>${maven-compiler-plugin.version}</version>
             <inherited>true</inherited>
             <configuration>
-              <source>${main.java.version}</source>
-              <target>${main.java.version}</target>
               <fork>true</fork>
               <showWarnings>true</showWarnings>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -223,13 +223,6 @@
             <!-- Add dependencies indirectly referenced by build plugins -->
             <dynamicDependencies>
               <DynamicDependency>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>${main.signature.artifact}</artifactId>
-                <version>1.0</version>
-                <type>signature</type>
-                <repositoryType>MAIN</repositoryType>
-              </DynamicDependency>
-              <DynamicDependency>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin-git</artifactId>
                 <version>${license-maven-plugin.version}</version>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -31,9 +31,6 @@
     <module.name>zipkin2.reporter.beans</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- floor Java version we support for Spring 2.5 is 1.6 -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencyManagement>
@@ -122,7 +119,9 @@
       <id>release</id>
       <properties>
         <!-- floor Java version we support for Spring 2.5 is 1.6 -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -31,9 +31,6 @@
     <module.name>zipkin2.reporter.urlconnection</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <!-- floor Java version we support for urlconnection is 1.6 -->
-    <main.signature.artifact>java16</main.signature.artifact>
   </properties>
 
   <dependencies>
@@ -56,7 +53,9 @@
       <id>release</id>
       <properties>
         <!-- floor Java version we support for urlconnection is 1.6 -->
-        <main.java.version>1.6</main.java.version>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.release>6</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -47,7 +47,7 @@ public final class URLConnectionSender extends Sender {
   public static final class Builder {
     URL endpoint;
     Encoding encoding = Encoding.JSON;
-    int messageMaxBytes = 500_000;
+    int messageMaxBytes = 500000;
     int connectTimeout = 10 * 1000, readTimeout = 60 * 1000;
     boolean compressionEnabled = true;
 
@@ -275,8 +275,9 @@ public final class URLConnectionSender extends Sender {
       try {
         send(message, mediaType);
         callback.onSuccess(null);
-      } catch (IOException | RuntimeException | Error e) {
-        callback.onError(e);
+      } catch (Throwable t) {
+        Call.propagateIfFatal(t);
+        callback.onError(t);
       }
     }
 


### PR DESCRIPTION
This fixes a problem where we weren't releasing jars with the right bytecode level, due to a constant release=8. As we no longer can rely on RetroLambda to rewrite code, I've had to port things to the appropriate bytecode level manually. I also updated build deps that could be.

Fixes #235 and after this will cut a patch release (without any other pending PR)