### PR TITLE
Decouples AsyncZipkinSpanHandler from ZipkinSpanHandler to avoid leak

### DIFF
--- a/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
@@ -17,6 +17,7 @@ import brave.Tag;
 import brave.handler.MutableSpan;
 import brave.handler.SpanHandler;
 import brave.propagation.TraceContext;
+import java.io.Closeable;
 import java.io.Flushable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +42,7 @@ import zipkin2.reporter.internal.AsyncReporter;
  * @see brave.Tracing.Builder#addSpanHandler(SpanHandler)
  * @since 2.14
  */
-public final class AsyncZipkinSpanHandler extends SpanHandler implements Flushable {
+public final class AsyncZipkinSpanHandler extends SpanHandler implements Closeable, Flushable {
   /** @since 2.14 */
   public static AsyncZipkinSpanHandler create(Sender sender) {
     return newBuilder(sender).build();
@@ -176,7 +177,7 @@ public final class AsyncZipkinSpanHandler extends SpanHandler implements Flushab
    *
    * @since 2.15
    */
-  public void close() {
+  @Override public void close() {
     ((AsyncReporter<MutableSpan>) spanReporter).close();
   }
 

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Async.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.reporter.brave;
 
+import brave.handler.SpanHandler;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -27,8 +28,16 @@ class BasicUsageTest_Async extends BasicUsageTest<AsyncZipkinSpanHandler> {
 
   @Override AsyncZipkinSpanHandler zipkinSpanHandler(List<Span> spans) {
     return AsyncZipkinSpanHandler.newBuilder(sender)
-        .messageTimeout(0, TimeUnit.MILLISECONDS) // don't spawn a thread
-        .build();
+      .messageTimeout(0, TimeUnit.MILLISECONDS) // don't spawn a thread
+      .build();
+  }
+
+  @Override void close(AsyncZipkinSpanHandler handler) {
+    handler.close();
+  }
+
+  @Override SpanHandler alwaysReportSpans(AsyncZipkinSpanHandler handler) {
+    return handler.toBuilder().alwaysReportSpans(true).build();
   }
 
   @Override void triggerReport() {

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/BasicUsageTest_Converting.java
@@ -13,11 +13,20 @@
  */
 package zipkin2.reporter.brave;
 
+import brave.handler.SpanHandler;
 import java.util.List;
 import zipkin2.Span;
 
 class BasicUsageTest_Converting extends BasicUsageTest<ZipkinSpanHandler> {
   @Override ZipkinSpanHandler zipkinSpanHandler(List<Span> spans) {
     return (ZipkinSpanHandler) ZipkinSpanHandler.create(spans::add);
+  }
+
+  @Override void close(ZipkinSpanHandler handler) {
+    handler.close();
+  }
+
+  @Override SpanHandler alwaysReportSpans(ZipkinSpanHandler handler) {
+    return handler.toBuilder().alwaysReportSpans(true).build();
   }
 }


### PR DESCRIPTION
ZipkinSpanHandler leaks the `zipkin2.Span` type through its factory methods. This prevents libraries that scan types, such as Spring, from avoiding a zipkin dep. The error shows up like below.

The alternative is to not share a base class that uses a type you can't load. So, this changes AsyncZipkinSpanHandler to not extend ZipkinSpanHandler. This allows a portable change, except the more extreme interpretation, and lets spring apps exclude zipkin2.Span (or rather not include it when using brave).

```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'zipkinSpanHandler' defined in class path resource [brave/example/TracingAutoConfiguration.class]: Initialization of bean failed; nested exception is java.lang.TypeNotPresentException: Type zipkin2.Span not present
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:562) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:211) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1131) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1059) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:835) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:741) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	... 74 common frames omitted
Caused by: java.lang.TypeNotPresentException: Type zipkin2.Span not present
	at sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:117) ~[na:1.8.0_392]
	at sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:125) ~[na:1.8.0_392]
	at sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49) ~[na:1.8.0_392]
	at sun.reflect.generics.visitor.Reifier.reifyTypeArguments(Reifier.java:68) ~[na:1.8.0_392]
	at sun.reflect.generics.visitor.Reifier.visitClassTypeSignature(Reifier.java:138) ~[na:1.8.0_392]
	at sun.reflect.generics.tree.ClassTypeSignature.accept(ClassTypeSignature.java:49) ~[na:1.8.0_392]
	at sun.reflect.generics.repository.ConstructorRepository.getParameterTypes(ConstructorRepository.java:94) ~[na:1.8.0_392]
	at java.lang.reflect.Executable.getGenericParameterTypes(Executable.java:283) ~[na:1.8.0_392]
	at java.lang.reflect.Method.getGenericParameterTypes(Method.java:283) ~[na:1.8.0_392]
	at java.beans.FeatureDescriptor.getParameterTypes(FeatureDescriptor.java:387) ~[na:1.8.0_392]
	at java.beans.MethodDescriptor.setMethod(MethodDescriptor.java:116) ~[na:1.8.0_392]
	at java.beans.MethodDescriptor.<init>(MethodDescriptor.java:72) ~[na:1.8.0_392]
	at java.beans.MethodDescriptor.<init>(MethodDescriptor.java:56) ~[na:1.8.0_392]
	at java.beans.Introspector.getTargetMethodInfo(Introspector.java:1205) ~[na:1.8.0_392]
	at java.beans.Introspector.getBeanInfo(Introspector.java:426) ~[na:1.8.0_392]
	at java.beans.Introspector.getBeanInfo(Introspector.java:262) ~[na:1.8.0_392]
	at java.beans.Introspector.<init>(Introspector.java:407) ~[na:1.8.0_392]
	at java.beans.Introspector.getBeanInfo(Introspector.java:262) ~[na:1.8.0_392]
	at java.beans.Introspector.getBeanInfo(Introspector.java:204) ~[na:1.8.0_392]
	at org.springframework.beans.CachedIntrospectionResults.<init>(CachedIntrospectionResults.java:278) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.CachedIntrospectionResults.forClass(CachedIntrospectionResults.java:189) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.BeanWrapperImpl.getCachedIntrospectionResults(BeanWrapperImpl.java:173) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.BeanWrapperImpl.getPropertyDescriptors(BeanWrapperImpl.java:244) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.filterPropertyDescriptorsForDependencyCheck(AbstractAutowireCapableBeanFactory.java:1422) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.filterPropertyDescriptorsForDependencyCheck(AbstractAutowireCapableBeanFactory.java:1401) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.populateBean(AbstractAutowireCapableBeanFactory.java:1263) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:551) ~[spring-beans-4.3.25.RELEASE.jar:4.3.25.RELEASE]
	... 84 common frames omitted
Caused by: java.lang.ClassNotFoundException: zipkin2.Span
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387) ~[na:1.8.0_392]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419) ~[na:1.8.0_392]
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352) ~[na:1.8.0_392]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352) ~[na:1.8.0_392]
	at java.lang.Class.forName0(Native Method) ~[na:1.8.0_392]
	at java.lang.Class.forName(Class.java:348) ~[na:1.8.0_392]
	at sun.reflect.generics.factory.CoreReflectionFactory.makeNamedType(CoreReflectionFactory.java:114) ~[na:1.8.0_392]
	... 110 common frames omitted
```