### PR TITLE
Increases deploy timeouts due to recent failures uploading to sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -585,9 +585,14 @@
             <configuration>
               <serverId>ossrh</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <!-- Double the normal timeout even though we haven't had a problem in this project.
-                   The only outcome of timing out client side is trying again. -->
-              <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
+              <!-- Increase timeouts due to recent load related failures described in OSSRH-76308:
+
+                   A message body reader for Java class com.sonatype.nexus.staging.api.dto.StagingProfileRepositoryDTO,
+                   and Java type class com.sonatype.nexus.staging.api.dto.StagingProfileRepositoryDTO,
+                   and MIME media type text/html was not found -> [Help 1]
+              -->
+              <stagingProgressPauseDurationSeconds>20</stagingProgressPauseDurationSeconds>
+              <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
           </plugin>


### PR DESCRIPTION
Last version had a partial deploy again with this error. Will release 3.10.1 as the bom never deployed either. I copied the settings from zipkin which is a larger project and hasn't had this problem recently.

```
 Waiting for operation to complete...
Jan 09, 2024 6:48:37 AM com.sun.jersey.api.client.ClientResponse getEntity
SEVERE: A message body reader for Java class com.sonatype.nexus.staging.api.dto.StagingProfileRepositoryDTO, and Java type class com.sonatype.nexus.staging.api.dto.StagingProfileRepositoryDTO, and MIME media type text/html was not found
Jan 09, 2024 6:48:37 AM com.sun.jersey.api.client.ClientResponse getEntity
SEVERE: The registered message body readers compatible with the MIME media type are:
*/* ->
````