### PR TITLE
ci: deploys bom separately to allow re-do on partial failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,17 @@ on:
 
 jobs:
   deploy:
+    name: deploy (${{ matrix.name }})
     runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    strategy:
+      fail-fast: false  # don't fail fast as we can re-run one job that failed
+      matrix:
+        include:
+          - name: jars
+            deploy_script: build-bin/deploy
+          # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
+          - name: bom
+            deploy_script: build-bin/deploy_bom
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -51,4 +61,4 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: |  # GITHUB_REF will be refs/heads/master or refs/tags/MAJOR.MINOR.PATCH
           build-bin/configure_deploy &&
-          build-bin/deploy $(echo ${GITHUB_REF} | cut -d/ -f 3)
+          ${{ matrix.deploy_script }} $(echo ${GITHUB_REF} | cut -d/ -f 3)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,4 +69,4 @@ jobs:
       # via forks, and login session ends up in ~/.docker. This is ok because
       # we publish DOCKER_PARENT_IMAGE to ghcr.io, hence local to the runner.
       - name: Test
-        run: build-bin/configure_test && build-bin/test
+        run: build-bin/configure_test && build-bin/test ${{ matrix.maven_args }}

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -5,6 +5,9 @@ This is a Maven project, which uses standard conventions for test and deploy.
 What's notable is that it has Docker (testcontainers) tests and that it has a Maven BOM.
 The latter implies deploy runs twice: once for the normal project modules, and again for the BOM.
 
+On deploy_bom:
+* The artifact `brave-bom` is deployed. Intentionally separate to allow a retry.
+
 [//]: # (Below here should be standard for all projects)
 
 ## Build Overview

--- a/build-bin/deploy
+++ b/build-bin/deploy
@@ -5,5 +5,3 @@
 # See [README.md] for an explanation of this and how CI should use it.
 
 build-bin/maven/maven_deploy -pl -:zipkin-reporter-bom
-# Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
-build-bin/maven/maven_deploy -f bom/pom.xml

--- a/build-bin/deploy_bom
+++ b/build-bin/deploy_bom
@@ -1,0 +1,8 @@
+#!/bin/sh -ue
+
+# This script deploys a master or release version.
+#
+# See [README.md] for an explanation of this and how CI should use it.
+
+# Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
+build-bin/maven/maven_deploy -f bom/pom.xml


### PR DESCRIPTION
Before, the bom project deployed only after the parent succeeded. This meant a timeout would prevent it from being deployed, even if the timeout was not critical. This deploys the bom independently so that such a situation doesn't cause us to have to re-cut a version.

This also fixes where we didn't actually use the release args in tests.