### PR TITLE
Deprecates Sender for much simpler BytesMessageSender

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -4,7 +4,7 @@
 
 Historically, we had a `Sender.check()` function for fail fast reasons, but it was rarely used and
 rarely implemented correctly. In some cases, people returned `OK` having no knowledge of if the
-health was good or not. In one case, stackdriver, a seemingly good implementation was avoided for
+health was good or not. In one case, Stackdriver, a seemingly good implementation was avoided for
 directly sending an empty list of spans, until `check()` was changed to do the same. Rather than
 define a poorly implementable `Sender.check()` which would likely still require sending an empty
 list, we decided to document a call to send no spans should pass through.
@@ -26,7 +26,7 @@ Note that zipkin server does obviate calls to storage when incoming lists are em
 just for things like this, but 3rd party instrumentation which bugged out and sent no spans.
 
 Messaging senders came close to implementing health except would suffer similar problems as
-StackDriver did. For example, verifying broker connectivity doesn't mean the queue or topic works.
+Stackdriver did. For example, verifying broker connectivity doesn't mean the queue or topic works.
 While you can dig around and solve this for some brokers, it ends up the same situation.
 
 Another way could be to catch an exception from a prior "POST", and if that failed, return a
@@ -43,7 +43,7 @@ We had the following choices:
 * document that implementors can skip `send(empty)` even though call sites use this today
 * document that you should not skip `send(empty)`, so that the few callers can use it for fail-fast
 
-The main driving points were how niche this function is (not called by many, and often on interval),
+The main driving points were how niche this function is (not called by many, or on interval),
 and how much work it is to implement a `check()` vs allowing an empty send to proceed. In the
 current code base, the only work required for the latter was documentation, as all senders would
 pass an empty list. Secondary driving force was that the `BytesMessageSender` main goal is easier

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,55 @@
+# zipkin-reporter rationale
+
+## Sending an empty list is permitted
+
+Historically, we had a `Sender.check()` function for fail fast reasons, but it was rarely used and
+rarely implemented correctly. In some cases, people returned `OK` having no knowledge of if the
+health was good or not. In one case, stackdriver, a seemingly good implementation was avoided for
+directly sending an empty list of spans, until `check()` was changed to do the same. Rather than
+define a poorly implementable `Sender.check()` which would likely still require sending an empty
+list, we decided to document a call to send no spans should pass through.
+
+Two known examples of using `check()` were in server modules that forward spans with zipkin reporter
+and finagle. `zipkin-finagle` is no longer maintained, so we'll focus on the server modules.
+
+zipkin-stackdriver (now zipkin-gcp) was both important to verify and difficult to implement a
+meaningful `check()`. First attempts looked good, but would pass even when users had no permission
+to write spans. For this reason, people ignored the check and did out-of-band sending zero spans to
+the POST endpoint. Later, this logic was made the primary impl of `check()`.
+
+In HTTP senders a `check()` would be invalid for non-intuitive reasons unless you also just posted
+no spans. For example, while zipkin has a `/health` endpoint, most clones do not implement that or
+put it at a different path. So, you can't check with `/health` and are left with either falsely
+returning `OK` or sending an empty list of spans.
+
+Note that zipkin server does obviate calls to storage when incoming lists are empty. This is not
+just for things like this, but 3rd party instrumentation which bugged out and sent no spans.
+
+Messaging senders came close to implementing health except would suffer similar problems as
+StackDriver did. For example, verifying broker connectivity doesn't mean the queue or topic works.
+While you can dig around and solve this for some brokers, it ends up the same situation.
+
+Another way could be to catch an exception from a prior "POST", and if that failed, return a
+corresponding status. This could not be for fail-fast because the caller wouldn't have any spans to
+send, yet. It is complicated code for a function uncommon in instrumentation and the impl would be
+hard to reason with concurrently.
+
+The main problem is that we used the same `Component` type in reporter as we did for zipkin server,
+which defined `check()` in a hardly used and hardly implementable way except sending no spans.
+
+We had the following choices:
+
+* force implementation of `check()` knowing its problems and that it is usual in instrumentation
+* document that implementors can skip `send(empty)` even though call sites use this today
+* document that you should not skip `send(empty)`, so that the few callers can use it for fail-fast
+
+The main driving points were how niche this function is (not called by many, and often on interval),
+and how much work it is to implement a `check()` vs allowing an empty send to proceed. In the
+current code base, the only work required for the latter was documentation, as all senders would
+pass an empty list. Secondary driving force was that the `BytesMessageSender` main goal is easier
+implementation and re-introducing a bad `check()` api gets in the way of this.
+
+Due to the complexity of this problem, we decided that rather to leave empty undefined, document
+sending empty is ok. This allows a couple users to implement a fail-fast in a portable way, without
+burdening implementers of `BytesMessageSender` with an unimplementable or wrong `check()` function
+for most platforms.

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-reporter-parent</artifactId>
     <groupId>io.zipkin.reporter2</groupId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ITActiveMQSender.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ITActiveMQSender.java
@@ -14,6 +14,7 @@
 package zipkin2.reporter.activemq;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.stream.Stream;
 import javax.jms.BytesMessage;
 import javax.jms.MessageConsumer;
@@ -25,12 +26,10 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesDecoder;
-import zipkin2.reporter.SpanBytesEncoder;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.Call;
-import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Encoding;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.SpanBytesEncoder;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,55 +42,46 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 class ITActiveMQSender {
   @Container ActiveMQContainer activemq = new ActiveMQContainer();
 
-  @Test void checkPasses() {
+  @Test void emptyOk() throws Exception {
     try (ActiveMQSender sender = activemq.newSenderBuilder("checkPasses").build()) {
-      assertThat(sender.check().ok()).isTrue();
-    }
-  }
-
-  @Test void checkFalseWhenBrokerIsDown() {
-    // we can be pretty certain ActiveMQ isn't running on localhost port 80
-    try (ActiveMQSender sender = ActiveMQSender.create("tcp://localhost:80")) {
-      CheckResult check = sender.check();
-      assertThat(check.ok()).isFalse();
-      assertThat(check.error()).isInstanceOf(IOException.class);
+      sender.send(Collections.emptyList());
     }
   }
 
   @Test void sendFailsWithInvalidActiveMqServer() {
     // we can be pretty certain ActiveMQ isn't running on localhost port 80
     try (ActiveMQSender sender = ActiveMQSender.create("tcp://localhost:80")) {
-      assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN).execute()).isInstanceOf(
-          IOException.class)
+      assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN))
+        .isInstanceOf(IOException.class)
         .hasMessageContaining("Unable to establish connection to ActiveMQ broker");
     }
   }
 
-  @Test void sendsSpans() throws Exception {
-    try (ActiveMQSender sender = activemq.newSenderBuilder("sendsSpans").build()) {
-      send(sender, CLIENT_SPAN, CLIENT_SPAN).execute();
+  @Test void send() throws Exception {
+    try (ActiveMQSender sender = activemq.newSenderBuilder("send").build()) {
+      send(sender, CLIENT_SPAN, CLIENT_SPAN);
 
       assertThat(SpanBytesDecoder.JSON_V2.decodeList(readMessage(sender))).containsExactly(
         CLIENT_SPAN, CLIENT_SPAN);
     }
   }
 
-  @Test void sendsSpans_PROTO3() throws Exception {
-    try (ActiveMQSender sender = activemq.newSenderBuilder("sendsSpans_PROTO3")
+  @Test void send_PROTO3() throws Exception {
+    try (ActiveMQSender sender = activemq.newSenderBuilder("send_PROTO3")
       .encoding(Encoding.PROTO3)
       .build()) {
-      send(sender, CLIENT_SPAN, CLIENT_SPAN).execute();
+      send(sender, CLIENT_SPAN, CLIENT_SPAN);
 
       assertThat(SpanBytesDecoder.PROTO3.decodeList(readMessage(sender))).containsExactly(
         CLIENT_SPAN, CLIENT_SPAN);
     }
   }
 
-  @Test void sendsSpans_THRIFT() throws Exception {
-    try (ActiveMQSender sender = activemq.newSenderBuilder("sendsSpans_THRIFT")
+  @Test void send_THRIFT() throws Exception {
+    try (ActiveMQSender sender = activemq.newSenderBuilder("send_THRIFT")
       .encoding(Encoding.THRIFT)
       .build()) {
-      send(sender, CLIENT_SPAN, CLIENT_SPAN).execute();
+      send(sender, CLIENT_SPAN, CLIENT_SPAN);
 
       assertThat(SpanBytesDecoder.THRIFT.decodeList(readMessage(sender))).containsExactly(
         CLIENT_SPAN, CLIENT_SPAN);
@@ -101,16 +91,16 @@ class ITActiveMQSender {
   @Test void illegalToSendWhenClosed() {
     try (ActiveMQSender sender = activemq.newSenderBuilder("illegalToSendWhenClosed").build()) {
       sender.close();
-      assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN).execute()).isInstanceOf(
+      assertThatThrownBy(() -> send(sender, CLIENT_SPAN, CLIENT_SPAN)).isInstanceOf(
         IllegalStateException.class);
     }
   }
 
   /**
-   * The output of toString() on {@link Sender} implementations appears in thread names created by
-   * {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other monitoring
-   * tools, care should be taken to ensure the toString() output is a reasonable length and does not
-   * contain sensitive information.
+   * The output of toString() on {@link BytesMessageSender} implementations appears in thread names
+   * created by {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other
+   * monitoring tools, care should be taken to ensure the toString() output is a reasonable length
+   * and does not contain sensitive information.
    */
   @Test void toStringContainsOnlySummaryInformation() {
     try (ActiveMQSender sender = activemq.newSenderBuilder("toString").build()) {
@@ -119,7 +109,7 @@ class ITActiveMQSender {
     }
   }
 
-  Call<Void> send(ActiveMQSender sender, Span... spans) {
+  void send(ActiveMQSender sender, Span... spans) throws IOException {
     SpanBytesEncoder bytesEncoder;
     switch (sender.encoding()) {
       case JSON:
@@ -134,7 +124,7 @@ class ITActiveMQSender {
       default:
         throw new UnsupportedOperationException("encoding: " + sender.encoding());
     }
-    return sender.sendSpans(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
+    sender.send(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
   }
 
   byte[] readMessage(ActiveMQSender sender) throws Exception {

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-amqp-client</artifactId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/benchmarks/src/main/java/zipkin2/reporter/HttpSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/HttpSenderBenchmarks.java
@@ -26,7 +26,7 @@ import static com.linecorp.armeria.common.MediaType.JSON;
 public abstract class HttpSenderBenchmarks extends SenderBenchmarks {
   Server server;
 
-  @Override protected Sender createSender() {
+  @Override protected BytesMessageSender createSender() {
     Route v2JsonSpans = Route.builder().methods(POST).consumes(JSON).path("/api/v2/spans").build();
     server = Server.builder()
       .http(0)
@@ -37,7 +37,7 @@ public abstract class HttpSenderBenchmarks extends SenderBenchmarks {
     return newHttpSender(url("/api/v2/spans"));
   }
 
-  abstract Sender newHttpSender(String endpoint);
+  abstract BytesMessageSender newHttpSender(String endpoint);
 
   @Override protected void afterSenderClose() {
     server.stop().join();

--- a/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
@@ -57,7 +57,7 @@ public class KafkaSenderBenchmarks extends SenderBenchmarks {
   KafkaContainer kafka;
   KafkaConsumer<byte[], byte[]> consumer;
 
-  @Override protected Sender createSender() {
+  @Override protected BytesMessageSender createSender() {
     kafka = new KafkaContainer();
     kafka.start();
 

--- a/benchmarks/src/main/java/zipkin2/reporter/OkHttpSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/OkHttpSenderBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,7 @@ import zipkin2.reporter.okhttp3.OkHttpSender;
 
 public class OkHttpSenderBenchmarks extends HttpSenderBenchmarks {
 
-  @Override Sender newHttpSender(String endpoint) {
+  @Override BytesMessageSender newHttpSender(String endpoint) {
     return OkHttpSender.create(endpoint);
   }
 

--- a/benchmarks/src/main/java/zipkin2/reporter/URLConnectionSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/URLConnectionSenderBenchmarks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -21,7 +21,7 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 public class URLConnectionSenderBenchmarks extends HttpSenderBenchmarks {
 
-  @Override Sender newHttpSender(String endpoint) {
+  @Override BytesMessageSender newHttpSender(String endpoint) {
     return URLConnectionSender.create(endpoint);
   }
 

--- a/benchmarks/src/main/java/zipkin2/reporter/internal/NoopSender.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/internal/NoopSender.java
@@ -15,21 +15,18 @@ package zipkin2.reporter.internal;
 
 import java.util.List;
 import zipkin2.reporter.BytesMessageEncoder;
-import zipkin2.reporter.Call;
-import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Encoding;
-import zipkin2.reporter.Sender;
 
-final class NoopSender extends Sender {
-
-  final Encoding encoding;
+/** Encodes messages on {@link #send(List)}, but doesn't do anything else. */
+final class NoopSender extends BytesMessageSender.Base {
   final BytesMessageEncoder messageEncoder;
 
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
 
   NoopSender(Encoding encoding) {
-    this.encoding = encoding;
+    super(encoding);
     this.messageEncoder = BytesMessageEncoder.forEncoding(encoding);
   }
 
@@ -37,25 +34,8 @@ final class NoopSender extends Sender {
     return Integer.MAX_VALUE;
   }
 
-  @Override public Encoding encoding() {
-    return encoding;
-  }
-
-  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
-    return encoding().listSizeInBytes(encodedSpans);
-  }
-
-  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
-    return encoding().listSizeInBytes(encodedSizeInBytes);
-  }
-
-  @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+  @Override public void send(List<byte[]> encodedSpans) {
     messageEncoder.encode(encodedSpans);
-    return Call.create(null);
-  }
-
-  @Override public CheckResult check() {
-    return CheckResult.OK;
   }
 
   @Override public void close() {

--- a/benchmarks/src/main/java/zipkin2/reporter/internal/SenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/internal/SenderBenchmarks.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.reporter.internal;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -31,9 +32,9 @@ import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 import zipkin2.Span;
 import zipkin2.TestObjects;
-import zipkin2.reporter.CheckResult;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.InMemoryReporterMetrics;
-import zipkin2.reporter.Sender;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.SpanBytesEncoder;
 
 /**
@@ -89,7 +90,7 @@ public abstract class SenderBenchmarks {
     }
   }
 
-  Sender sender;
+  BytesMessageSender sender;
 
   AsyncReporter.BoundedAsyncReporter<Span> reporter;
 
@@ -97,8 +98,8 @@ public abstract class SenderBenchmarks {
   public void setup() throws Throwable {
     sender = createSender();
 
-    CheckResult senderCheck = sender.check();
-    if (!senderCheck.ok()) throw senderCheck.error();
+    // check sender works at all
+    sender.send(Collections.emptyList());
 
     reporter = (AsyncReporter.BoundedAsyncReporter<Span>) AsyncReporter.newBuilder(sender)
       .messageMaxBytes(messageMaxBytes)
@@ -106,7 +107,7 @@ public abstract class SenderBenchmarks {
       .metrics(metrics).build(SpanBytesEncoder.JSON_V2);
   }
 
-  protected abstract Sender createSender() throws Exception;
+  protected abstract BytesMessageSender createSender() throws Exception;
 
   @Setup(Level.Iteration)
   public void fillQueue() {

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-bom</artifactId>
   <name>Zipkin Reporter BOM</name>
-  <version>3.1.2-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Bill Of Materials POM for all Zipkin reporter artifacts</description>
 

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/brave/src/it/no_zipkin_deps/src/test/java/zipkin2/reporter/brave/no_zipkin_deps/AsyncZipkinSpanHandlerTest.java
+++ b/brave/src/it/no_zipkin_deps/src/test/java/zipkin2/reporter/brave/no_zipkin_deps/AsyncZipkinSpanHandlerTest.java
@@ -40,7 +40,7 @@ class AsyncZipkinSpanHandlerTest {
   OkHttpSender sender =
     OkHttpSender.newBuilder().endpoint(endpoint).compressionEnabled(false).build();
 
-  @Test void sendsSpans() throws Exception {
+  @Test void send() throws Exception {
     server.enqueue(new MockResponse());
 
     try (AsyncZipkinSpanHandler zipkinSpanHandler = AsyncZipkinSpanHandler.newBuilder(sender)

--- a/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
@@ -22,6 +22,7 @@ import java.io.Flushable;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Reporter;
 import zipkin2.reporter.ReporterMetrics;
@@ -31,7 +32,7 @@ import zipkin2.reporter.internal.AsyncReporter;
 /**
  * A {@link brave.handler.SpanHandler} that queues spans on {@link #end} to bundle and send as a
  * bulk <a href="https://zipkin.io/zipkin-api/#/">Zipkin JSON V2</a> message. When the {@link
- * Sender} is HTTP, the endpoint is usually "http://zipkinhost:9411/api/v2/spans".
+ * BytesMessageSender} is HTTP, the endpoint is usually "http://zipkinhost:9411/api/v2/spans".
  *
  * <p>Example:
  * <pre>{@code
@@ -46,12 +47,12 @@ import zipkin2.reporter.internal.AsyncReporter;
  */
 public final class AsyncZipkinSpanHandler extends SpanHandler implements Closeable, Flushable {
   /** @since 2.14 */
-  public static AsyncZipkinSpanHandler create(Sender sender) {
+  public static AsyncZipkinSpanHandler create(BytesMessageSender sender) {
     return newBuilder(sender).build();
   }
 
   /** @since 2.14 */
-  public static Builder newBuilder(Sender sender) {
+  public static Builder newBuilder(BytesMessageSender sender) {
     if (sender == null) throw new NullPointerException("sender == null");
     return new Builder(sender);
   }
@@ -80,7 +81,7 @@ public final class AsyncZipkinSpanHandler extends SpanHandler implements Closeab
       this.errorTag = handler.errorTag;
     }
 
-    Builder(Sender sender) {
+    Builder(BytesMessageSender sender) {
       this.delegate = AsyncReporter.newBuilder(sender);
       this.encoding = sender.encoding();
     }

--- a/brave/src/test/java/zipkin2/reporter/brave/ConvertingSpanReporterTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ConvertingSpanReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -54,24 +54,24 @@ class ConvertingSpanReporterTest {
 
   @Test void generateKindMap() {
     assertThat(ConvertingSpanReporter.generateKindMap()).containsExactly(
-        entry(CLIENT, Span.Kind.CLIENT),
-        entry(SERVER, Span.Kind.SERVER),
-        entry(PRODUCER, Span.Kind.PRODUCER),
-        entry(CONSUMER, Span.Kind.CONSUMER)
+      entry(CLIENT, Span.Kind.CLIENT),
+      entry(SERVER, Span.Kind.SERVER),
+      entry(PRODUCER, Span.Kind.PRODUCER),
+      entry(CONSUMER, Span.Kind.CONSUMER)
     );
   }
 
   @Test void equalsAndHashCode() {
     assertThat(spanReporter)
-        .hasSameHashCodeAs(spans)
-        .isEqualTo(new ConvertingSpanReporter(spans, Tags.ERROR));
+      .hasSameHashCodeAs(spans)
+      .isEqualTo(new ConvertingSpanReporter(spans, Tags.ERROR));
 
     ConvertingSpanReporter otherReporter = new ConvertingSpanReporter(spans::add, Tags.ERROR);
 
     assertThat(spanReporter)
-        .isNotEqualTo(otherReporter)
-        .extracting(Objects::hashCode)
-        .isNotEqualTo(otherReporter.hashCode());
+      .isNotEqualTo(otherReporter)
+      .extracting(Objects::hashCode)
+      .isNotEqualTo(otherReporter.hashCode());
   }
 
   @Test void convertsSampledSpan() {
@@ -79,10 +79,10 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0)).usingRecursiveComparison().isEqualTo(
-        Span.newBuilder()
-            .traceId("1")
-            .id("2")
-            .build()
+      Span.newBuilder()
+        .traceId("1")
+        .id("2")
+        .build()
     );
   }
 
@@ -92,11 +92,11 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0)).usingRecursiveComparison().isEqualTo(
-        Span.newBuilder()
-            .traceId("0000000000000001")
-            .id("0000000000000002")
-            .debug(true)
-            .build()
+      Span.newBuilder()
+        .traceId("0000000000000001")
+        .id("0000000000000002")
+        .debug(true)
+        .build()
     );
   }
 
@@ -121,10 +121,10 @@ class ConvertingSpanReporterTest {
 
     spanReporter.report(span);
     assertThat(spans.get(0).tags()).containsOnly(
-        entry("1", "1"),
-        entry("foo", "baz"),
-        entry("2", "2"),
-        entry("3", "3")
+      entry("1", "1"),
+      entry("foo", "baz"),
+      entry("2", "2"),
+      entry("3", "3")
     );
   }
 
@@ -138,7 +138,7 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0).tags())
-        .containsOnly(entry("error", "RuntimeException"));
+      .containsOnly(entry("error", "RuntimeException"));
   }
 
   @Test void doesntOverwriteErrorTag() {
@@ -150,7 +150,7 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0).tags())
-        .containsOnly(entry("error", ""));
+      .containsOnly(entry("error", ""));
   }
 
   @Test void addsAnnotations() {
@@ -163,7 +163,7 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0).annotations())
-        .containsOnly(Annotation.create(2L, "foo"));
+      .containsOnly(Annotation.create(2L, "foo"));
   }
 
   @Test void finished_client() {
@@ -232,10 +232,10 @@ class ConvertingSpanReporterTest {
     MutableSpan span = new MutableSpan(context, null);
 
     Endpoint endpoint = Endpoint.newBuilder()
-        .serviceName("fooService")
-        .ip("1.2.3.4")
-        .port(80)
-        .build();
+      .serviceName("fooService")
+      .ip("1.2.3.4")
+      .port(80)
+      .build();
 
     span.kind(CLIENT);
     span.remoteServiceName(endpoint.serviceName());
@@ -246,7 +246,7 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0).remoteEndpoint())
-        .isEqualTo(endpoint);
+      .isEqualTo(endpoint);
   }
 
   // This prevents the server startTimestamp from overwriting the client one on the collector
@@ -261,7 +261,7 @@ class ConvertingSpanReporterTest {
     spanReporter.report(span);
 
     assertThat(spans.get(0).shared())
-        .isTrue();
+      .isTrue();
   }
 
   @Test void flushUnstartedNeitherSetsTimestampNorDuration() {
@@ -271,6 +271,6 @@ class ConvertingSpanReporterTest {
     spanReporter.report(flushed);
 
     assertThat(spans.get(0)).extracting(Span::timestampAsLong, Span::durationAsLong)
-        .allSatisfy(u -> assertThat(u).isEqualTo(0L));
+      .allSatisfy(u -> assertThat(u).isEqualTo(0L));
   }
 }

--- a/brave/src/test/java/zipkin2/reporter/brave/FakeSender.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/FakeSender.java
@@ -58,6 +58,10 @@ public final class FakeSender extends BytesMessageSender.Base {
       onSpans);
   }
 
+  FakeSender onSpans(Consumer<List<Span>> onSpans) {
+    return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
+  }
+
   @Override public int messageMaxBytes() {
     return messageMaxBytes;
   }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter</artifactId>

--- a/core/src/main/java/zipkin2/reporter/AwaitableCallback.java
+++ b/core/src/main/java/zipkin2/reporter/AwaitableCallback.java
@@ -17,8 +17,10 @@ import java.util.concurrent.CountDownLatch;
 
 /**
  * Blocks until {@link Callback#onSuccess(Object)} or {@link Callback#onError(Throwable)}.
+ *
+ * @deprecated since 3.2 this is no longer used.
  */
-public final class AwaitableCallback implements Callback<Void> {
+@Deprecated public final class AwaitableCallback implements Callback<Void> {
   final CountDownLatch countDown = new CountDownLatch(1);
   Throwable throwable; // thread visibility guaranteed by the countdown latch
 

--- a/core/src/main/java/zipkin2/reporter/BytesMessageSender.java
+++ b/core/src/main/java/zipkin2/reporter/BytesMessageSender.java
@@ -109,7 +109,11 @@ public interface BytesMessageSender extends Closeable {
   /**
    * Sends a list of encoded spans to a transport such as HTTP or Kafka.
    *
-   * @param encodedSpans list of encoded spans.
+   * <p><em>Empty input is permitted</em>. While async reporters in this repository will always send
+   * a non-empty list. Some external callers might use an empty send for fail-fast checking. If you
+   * obviate empty lists, you might break them. See /RATIONALE.md for more.
+   *
+   * @param encodedSpans a potentially empty list of encoded spans.
    * @throws IllegalStateException if {@link #close() close} was called.
    */
   void send(List<byte[]> encodedSpans) throws IOException;

--- a/core/src/main/java/zipkin2/reporter/BytesMessageSender.java
+++ b/core/src/main/java/zipkin2/reporter/BytesMessageSender.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Sends a list of encoded spans to a transport such as HTTP or Kafka. Usually, this involves
+ * encoding them into a message and enqueueing them for transport in a corresponding client library.
+ * The typical end recipient is a zipkin collector.
+ *
+ * <p>Unless mentioned otherwise, senders are not thread-safe. They were designed to be used by a
+ * single reporting thread, hence the operation is blocking
+ *
+ * <p>Those looking to initialize eagerly can {@link #send(List)} with an empty list. This can be
+ * used to reduce latency on the first send operation, or to fail fast.
+ *
+ * <p><em>Implementation notes</em>
+ *
+ * <p>The parameter is a list of encoded spans as opposed to an encoded message. This allows
+ * implementations flexibility on how to encode spans into a message. For example, a large span
+ * might need to be sent as a separate message to avoid kafka limits. Also, logging transports like
+ * scribe will likely write each span as a separate log line.
+ *
+ * <p>This accepts a list of {@link BytesEncoder#encode(Object) encoded spans}, as opposed a list of
+ * spans like {@code zipkin2.Span}. This allows senders to be re-usable as model shapes change. This
+ * also allows them to use their most natural message type. For example, kafka would more naturally
+ * send messages as byte arrays.
+ *
+ * @since 3.2
+ */
+public interface BytesMessageSender extends Closeable {
+
+  /**
+   * Base class for implementation, which implements {@link #messageSizeInBytes(List)} and
+   * {@link #messageSizeInBytes(List)} with a given {@linkplain Encoding}
+   */
+  abstract class Base implements BytesMessageSender {
+    protected final Encoding encoding;
+
+    protected Base(Encoding encoding) {
+      this.encoding = encoding;
+    }
+
+    /** {@inheritDoc} */
+    @Override public Encoding encoding() {
+      return encoding;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
+      return encoding.listSizeInBytes(encodedSpans);
+    }
+
+    /** {@inheritDoc} */
+    @Override public int messageSizeInBytes(int encodedSizeInBytes) {
+      return encoding.listSizeInBytes(encodedSizeInBytes);
+    }
+  }
+
+  /** Returns the encoding this sender requires spans to have. */
+  Encoding encoding();
+
+  /**
+   * Maximum bytes sendable per message including overhead. This can be calculated using {@link
+   * #messageSizeInBytes(List)}
+   * <p>
+   * Defaults to 500KB as a conservative default. You may get better or reduced performance
+   * by changing this value based on, e.g., machine size or network bandwidth in your
+   * infrastructure. Finding a perfect value will require trying out different values in production,
+   * but the default should work well enough in most cases.
+   */
+  int messageMaxBytes();
+
+  /**
+   * Before invoking {@link BytesMessageSender#send(List)}, callers must consider message overhead,
+   * which might be more than encoding overhead. This is used to not exceed {@link
+   * BytesMessageSender#messageMaxBytes()}.
+   *
+   * <p>Note this is not always {@link Encoding#listSizeInBytes(List)}, as some senders have
+   * inefficient list encoding. For example, Scribe base64's then tags each span with a category.
+   */
+  int messageSizeInBytes(List<byte[]> encodedSpans);
+
+  /**
+   * Like {@link #messageSizeInBytes(List)}, except for a single-span. This is used to ensure a span
+   * is never accepted that can never be sent.
+   *
+   * <p>Note this is not always {@link Encoding#listSizeInBytes(int)}, as some senders have
+   * inefficient list encoding. For example, Stackdriver's proto message contains other fields.
+   *
+   * @param encodedSizeInBytes the {@link BytesEncoder#sizeInBytes(Object) encoded size} of a span
+   */
+  int messageSizeInBytes(int encodedSizeInBytes);
+
+  /**
+   * Sends a list of encoded spans to a transport such as HTTP or Kafka.
+   *
+   * @param encodedSpans list of encoded spans.
+   * @throws IllegalStateException if {@link #close() close} was called.
+   */
+  void send(List<byte[]> encodedSpans) throws IOException;
+}

--- a/core/src/main/java/zipkin2/reporter/Call.java
+++ b/core/src/main/java/zipkin2/reporter/Call.java
@@ -48,7 +48,9 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @param <V> the success type, typically not null except when {@code V} is {@linkplain Void}.
  * @since 3.0
+ * @deprecated since 3.2 this is no longer used. This will be removed in v4.0.
  */
+@Deprecated
 public abstract class Call<V> implements Cloneable {
   /**
    * Returns a completed call which has the supplied value. This is useful when input parameters
@@ -373,6 +375,10 @@ public abstract class Call<V> implements Cloneable {
     }
   }
 
+  /**
+   * @deprecated since 3.2 this is no longer used. This will be removed in v4.0.
+   */
+  @Deprecated
   public static abstract class Base<V> extends Call<V> {
     volatile boolean canceled;
     boolean executed;

--- a/core/src/main/java/zipkin2/reporter/ClosedSenderException.java
+++ b/core/src/main/java/zipkin2/reporter/ClosedSenderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,7 +13,7 @@
  */
 package zipkin2.reporter;
 
-/** An exception thrown when a {@link Sender} is used after it has been closed. */
+/** An exception thrown when a {@link BytesMessageSender} is used after it has been closed. */
 public final class ClosedSenderException extends IllegalStateException {
   static final long serialVersionUID = -4636520624634625689L;
 }

--- a/core/src/main/java/zipkin2/reporter/Component.java
+++ b/core/src/main/java/zipkin2/reporter/Component.java
@@ -24,7 +24,9 @@ import java.io.IOException;
  * avoid crashing the application graph if a network service is unavailable.
  *
  * @since 3.0
+ * @deprecated since 3.2 this is no longer used. This will be removed in v4.0.
  */
+@Deprecated
 public abstract class Component implements Closeable {
 
   /**
@@ -35,7 +37,10 @@ public abstract class Component implements Closeable {
    * possible to establish a meaningful result, and be safe to call many times, even concurrently.
    *
    * @see CheckResult#OK
+   * @deprecated since 3.2 this is no longer used. If you need to check a sender, send a zero-length
+   * list of spans. This will be removed in v4.0.
    */
+  @Deprecated
   public CheckResult check() {
     return CheckResult.OK;
   }

--- a/core/src/main/java/zipkin2/reporter/ReporterMetrics.java
+++ b/core/src/main/java/zipkin2/reporter/ReporterMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -70,7 +70,7 @@ public interface ReporterMetrics {
    *
    * <p>This is a function of span bytes per message and overhead
    *
-   * @see Sender#messageSizeInBytes
+   * @see BytesMessageSender#messageSizeInBytes
    */
   void incrementMessageBytes(int quantity);
 

--- a/core/src/test/java/zipkin2/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeSender.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package zipkin2.reporter.internal;
+package zipkin2.reporter;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -19,12 +19,6 @@ import java.util.stream.Collectors;
 import zipkin2.Span;
 import zipkin2.codec.BytesDecoder;
 import zipkin2.codec.SpanBytesDecoder;
-import zipkin2.reporter.BytesEncoder;
-import zipkin2.reporter.BytesMessageEncoder;
-import zipkin2.reporter.BytesMessageSender;
-import zipkin2.reporter.ClosedSenderException;
-import zipkin2.reporter.Encoding;
-import zipkin2.reporter.SpanBytesEncoder;
 
 public final class FakeSender extends BytesMessageSender.Base {
 
@@ -51,18 +45,18 @@ public final class FakeSender extends BytesMessageSender.Base {
     this.onSpans = onSpans;
   }
 
-  FakeSender encoding(Encoding encoding) {
+  public FakeSender encoding(Encoding encoding) {
     return new FakeSender(encoding, messageMaxBytes, messageEncoder, // invalid but not needed, yet
       encoder, // invalid but not needed, yet
       decoder, // invalid but not needed, yet
       onSpans);
   }
 
-  FakeSender onSpans(Consumer<List<Span>> onSpans) {
+  public FakeSender onSpans(Consumer<List<Span>> onSpans) {
     return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
   }
 
-  FakeSender messageMaxBytes(int messageMaxBytes) {
+  public FakeSender messageMaxBytes(int messageMaxBytes) {
     return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
   }
 

--- a/core/src/test/java/zipkin2/reporter/internal/AsyncReporterTest.java
+++ b/core/src/test/java/zipkin2/reporter/internal/AsyncReporterTest.java
@@ -32,6 +32,7 @@ import zipkin2.TestObjects;
 import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Encoding;
+import zipkin2.reporter.FakeSender;
 import zipkin2.reporter.InMemoryReporterMetrics;
 import zipkin2.reporter.SpanBytesEncoder;
 import zipkin2.reporter.internal.AsyncReporter.BoundedAsyncReporter;

--- a/core/src/test/java/zipkin2/reporter/internal/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/internal/FakeSender.java
@@ -21,13 +21,12 @@ import zipkin2.codec.BytesDecoder;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.BytesMessageEncoder;
-import zipkin2.reporter.Call;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Encoding;
-import zipkin2.reporter.Sender;
 import zipkin2.reporter.SpanBytesEncoder;
 
-public final class FakeSender extends Sender {
+public final class FakeSender extends BytesMessageSender.Base {
 
   public static FakeSender create() {
     return new FakeSender(Encoding.JSON, Integer.MAX_VALUE,
@@ -36,7 +35,6 @@ public final class FakeSender extends Sender {
     });
   }
 
-  final Encoding encoding;
   final int messageMaxBytes;
   final BytesMessageEncoder messageEncoder;
   final BytesEncoder<Span> encoder;
@@ -45,7 +43,7 @@ public final class FakeSender extends Sender {
 
   FakeSender(Encoding encoding, int messageMaxBytes, BytesMessageEncoder messageEncoder,
     BytesEncoder<Span> encoder, BytesDecoder<Span> decoder, Consumer<List<Span>> onSpans) {
-    this.encoding = encoding;
+    super(encoding);
     this.messageMaxBytes = messageMaxBytes;
     this.messageEncoder = messageEncoder;
     this.encoder = encoder;
@@ -68,30 +66,17 @@ public final class FakeSender extends Sender {
     return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
   }
 
-  @Override public Encoding encoding() {
-    return encoding;
-  }
-
   @Override public int messageMaxBytes() {
     return messageMaxBytes;
-  }
-
-  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
-    return encoding.listSizeInBytes(encodedSpans);
-  }
-
-  @Override public int messageSizeInBytes(int encodedSizeInBytes) {
-    return encoding.listSizeInBytes(encodedSizeInBytes);
   }
 
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
 
-  @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+  @Override public void send(List<byte[]> encodedSpans) {
     if (closeCalled) throw new ClosedSenderException();
     List<Span> decoded = encodedSpans.stream().map(decoder::decodeOne).collect(Collectors.toList());
     onSpans.accept(decoded);
-    return Call.create(null);
   }
 
   @Override public void close() {

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka</artifactId>

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-libthrift</artifactId>

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/InternalScribeCodecTest.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/InternalScribeCodecTest.java
@@ -40,7 +40,7 @@ class InternalScribeCodecTest {
     }
   }
 
-  @Test void sendsSpansExpectedMetrics() throws Exception {
+  @Test void sendExpectedMetrics() throws Exception {
     byte[] thrift = SpanBytesEncoder.THRIFT.encode(CLIENT_SPAN);
     List<byte[]> encodedSpans = asList(thrift, thrift);
 

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter-metrics-micrometer</artifactId>

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-okhttp3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-parent</artifactId>
-  <version>3.1.2-SNAPSHOT</version>
+  <version>3.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.2.3</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>
 

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/BaseAsyncFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/BaseAsyncFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,11 +14,12 @@
 package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
 
 abstract class BaseAsyncFactoryBean extends AbstractFactoryBean {
-  Sender sender;
+  BytesMessageSender sender;
   ReporterMetrics metrics;
   Integer messageMaxBytes;
   Integer messageTimeout;
@@ -30,7 +31,7 @@ abstract class BaseAsyncFactoryBean extends AbstractFactoryBean {
     return true;
   }
 
-  public void setSender(Sender sender) {
+  public void setSender(BytesMessageSender sender) {
     this.sender = sender;
   }
 

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/ActiveMQSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/ActiveMQSenderFactoryBeanTest.java
@@ -134,7 +134,7 @@ class ActiveMQSenderFactoryBeanTest {
       ActiveMQSender sender = context.getBean("sender", ActiveMQSender.class);
       context.close();
 
-      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+      sender.send(Arrays.asList(new byte[]{'{', '}'}));
     });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncReporterFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncReporterFactoryBeanTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Encoding;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
@@ -25,8 +26,8 @@ import zipkin2.reporter.SpanBytesEncoder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AsyncReporterFactoryBeanTest {
-  public static Sender SENDER = new FakeSender();
-  public static Sender PROTO3_SENDER = new FakeSender() {
+  public static BytesMessageSender SENDER = new FakeSender();
+  public static BytesMessageSender PROTO3_SENDER = new FakeSender() {
     @Override public Encoding encoding() {
       return Encoding.PROTO3;
     }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import brave.propagation.TraceContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
@@ -31,7 +32,7 @@ class AsyncZipkinSpanHandlerFactoryBeanTest {
       return null;
     }
   };
-  public static Sender SENDER = new FakeSender();
+  public static BytesMessageSender SENDER = new FakeSender();
   public static ReporterMetrics METRICS = ReporterMetrics.NOOP_METRICS;
 
   XmlBeans context;

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/FakeSender.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/FakeSender.java
@@ -13,25 +13,23 @@
  */
 package zipkin2.reporter.beans;
 
+import java.io.IOException;
 import java.util.List;
-import zipkin2.reporter.Call;
+import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Encoding;
-import zipkin2.reporter.Sender;
 
-class FakeSender extends Sender {
-  @Override public Encoding encoding() {
-    return Encoding.JSON;
+class FakeSender extends BytesMessageSender.Base {
+  FakeSender() {
+    super(Encoding.JSON);
   }
 
   @Override public int messageMaxBytes() {
     return 1024;
   }
 
-  @Override public int messageSizeInBytes(List<byte[]> encodedSpans) {
-    return 1024;
+  @Override public void send(List<byte[]> encodedSpans) {
   }
 
-  @Override public Call<Void> sendSpans(List<byte[]> encodedSpans) {
-    return Call.create(null);
+  @Override public void close() throws IOException {
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/KafkaSenderFactoryBeanTest.java
@@ -95,7 +95,7 @@ class KafkaSenderFactoryBeanTest {
       KafkaSender sender = context.getBean("sender", KafkaSender.class);
       context.close();
 
-      sender.sendSpans(Arrays.asList(new byte[] {'{', '}'}));
+      sender.send(Arrays.asList(new byte[] {'{', '}'}));
     });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/LibthriftSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/LibthriftSenderFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -110,7 +110,7 @@ class LibthriftSenderFactoryBeanTest {
       LibthriftSender sender = context.getBean("sender", LibthriftSender.class);
       context.close();
 
-      sender.sendSpans(Arrays.asList(new byte[0]));
+      sender.send(Arrays.asList(new byte[0]));
     });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
@@ -144,7 +144,7 @@ class OkHttpSenderFactoryBeanTest {
       OkHttpSender sender = context.getBean("sender", OkHttpSender.class);
       context.close();
 
-      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+      sender.send(Arrays.asList(new byte[]{'{', '}'}));
     });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/RabbitMQSenderFactoryBeanTest.java
@@ -132,7 +132,7 @@ class RabbitMQSenderFactoryBeanTest {
       RabbitMQSender sender = context.getBean("sender", RabbitMQSender.class);
       context.close();
 
-      sender.sendSpans(asList(new byte[] {'{', '}'}));
+      sender.send(asList(new byte[] {'{', '}'}));
     });
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
@@ -124,7 +124,7 @@ class URLConnectionSenderFactoryBeanTest {
       URLConnectionSender sender = context.getBean("sender", URLConnectionSender.class);
       context.close();
 
-      sender.sendSpans(Arrays.asList(new byte[]{'{', '}'}));
+      sender.send(Arrays.asList(new byte[]{'{', '}'}));
     });
   }
 }

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-urlconnection</artifactId>


### PR DESCRIPTION
Yesterday @shakuzen @anuraaga @kojilin and I chatted about how the async reporters never actually use the async code of the senders. The async side was only used by zipkin-server, as the async reporter design intentionally uses a blocking loop to flush the span backlog. So, this makes things simpler by only requiring a blocking implementation: `BytesMessageSender.send` (chosen to not create symbol collisions and similar to `BytesMessageEncoder`.

The side effect is that new senders can use this interface and completely avoid the complicated `Call` then `execute` chain, deferring to whatever the library-specific blocking path is. I have implemented this in armeria as a test, and it is absolutely easier.

As older spring libraries like sleuth may not upgrade, this maintains the old types until reporter 4. However, new senders can simply implement the new type and be done with it.