### PR TITLE
Adds deprecated functions for old Sender

### DIFF
--- a/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
@@ -46,12 +46,22 @@ import zipkin2.reporter.internal.AsyncReporter;
  * @since 2.14
  */
 public final class AsyncZipkinSpanHandler extends SpanHandler implements Closeable, Flushable {
-  /** @since 2.14 */
+  /** @deprecated Since 3.2, use {@link #create(BytesMessageSender)} */
+  @Deprecated public static AsyncZipkinSpanHandler create(Sender sender) {
+    return create((BytesMessageSender) sender);
+  }
+
+  /** @since 3.2 */
   public static AsyncZipkinSpanHandler create(BytesMessageSender sender) {
     return newBuilder(sender).build();
   }
 
-  /** @since 2.14 */
+  /** @deprecated Since 3.2, use {@link #newBuilder(BytesMessageSender)} */
+  @Deprecated public static Builder newBuilder(Sender sender) {
+    return newBuilder((BytesMessageSender) sender);
+  }
+
+  /** @since 3.2 */
   public static Builder newBuilder(BytesMessageSender sender) {
     if (sender == null) throw new NullPointerException("sender == null");
     return new Builder(sender);

--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -36,6 +36,10 @@ import java.util.concurrent.TimeUnit;
  */
 // This is effectively, but not explicitly final as it was not final in version 2.x.
 public class AsyncReporter<S> extends Component implements Reporter<S>, Closeable, Flushable {
+  /** @deprecated Since 3.2, use {@link #create(BytesMessageSender)} */
+  @Deprecated public static AsyncReporter<zipkin2.Span> create(Sender sender) {
+    return create((BytesMessageSender) sender);
+  }
 
   /**
    * Builds a json reporter for <a href="https://zipkin.io/zipkin-api/#/">Zipkin V2</a>. If http,
@@ -43,9 +47,16 @@ public class AsyncReporter<S> extends Component implements Reporter<S>, Closeabl
    *
    * <p>After a certain threshold, spans are drained and {@link BytesMessageSender#send(List) sent}
    * to Zipkin collectors.
+   *
+   * @since 3.2
    */
   public static AsyncReporter<zipkin2.Span> create(BytesMessageSender sender) {
     return new Builder(sender).build();
+  }
+
+  /** @deprecated Since 3.2, use {@link #builder(BytesMessageSender)} */
+  @Deprecated public static Builder builder(Sender sender) {
+    return builder((BytesMessageSender) sender);
   }
 
   /** Like {@link #create(BytesMessageSender)}, except you can configure settings such as the timeout. */


### PR DESCRIPTION
@anuraaga was right as there is a link error otherwise, noticed in cassandra.

```
java.lang.NoSuchMethodError: zipkin2.reporter.brave.AsyncZipkinSpanHandler.create(Lzipkin2/reporter/Sender;)Lzipkin2/reporter/brave/AsyncZipkinSpanHandler;
	at brave.cassandra.Tracing.<init>(Tracing.java:75)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
```

I will cut 3.2.1 right after!