### PR TITLE
Adds HttpEndpointSupplier to allow generic discovery of HTTP endpoints

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -36,6 +36,14 @@ Someone who wants to employ client-side loadbalancer logic can do that inside th
 `HttpEndpointSupplier`, and return a chosen endpoint. This will work because the supplier is
 documented to not be cached, unless it implements `HttpEndpointSupplier.Constant`.
 
+### Why is `HttpEndpointSupplier` closeable?
+
+Just like `BytesMessageSender`, an `HttpEndpointSupplier` can open resources. An example could be
+an HTTP client for the Netflix Eureka API. A sender is passed an endpoint supplier factory and uses
+it during construction, usually in `senderBuilder.build()`. The caller of `senderBuilder.build()`
+has no reference to the `HttpEndpointSupplier` created. Hence, the sender needs to close it, during
+`sender.close()`.
+
 ## Sending an empty list is permitted
 
 Historically, we had a `Sender.check()` function for fail fast reasons, but it was rarely used and

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,5 +1,41 @@
 # zipkin-reporter rationale
 
+## HttpEndpointSupplier
+
+`HttpEndpointSupplier` was generalizes endpoint resolution for built-in and third-party senders.
+Specifically, it allows Zipkin to be looked up in a way besides DNS.
+
+For example, Netflix/Eureka was formalized in Zipkin 2.27 and until `HttpEndpointSupplier`, there
+was no means for Zipkin Reporter users to integrate, except for the discontinued spring-cloud-sleuth
+project. By adding support a common hook, any framework, new or old, can integrate a custom
+discovery or client-side loadbalancer.
+
+### Why does the `Factory` accept a string endpoint?
+
+Not all discovery solutions include components to build a zipkin endpoint. For example,
+Netflix/Eureka instance information includes vipAddress and port details, but not the path, and
+which of the secure or non-secure IP addresses should be used. Since HTTP based senders already
+configure a static endpoint, this can be re-used to pass a virtual endpoint. Specifically, a fake
+hostname can represent a symbolic application, and be substituted with a real host or IP address
+later.
+
+A string is used for two reasons. One is that it is the least common denominator across typical
+endpoint types, which could be `URL` or a library-specific `HttpUrl`. The other reason is that
+allowing the (configuration) endpoint to be a string, a user can supply an invalid URL, but valid
+configuration through. For example, it could be a comma-separated list of well-known addresses the
+endpoint supplier will seed its configuration with.
+
+### Why does the `HttpEndpointSupplier` only return a single endpoint?
+
+The `HttpEndpointSupplier` returns a single endpoint to integrate with existing
+`URLConnectionSender` and `OkHttpSender` logic, which doesn't act like a client-side loadbalancer.
+While HTTP libraries may internally resolve a name to multiple IP addresses, this is usually an
+internal detail.
+
+Someone who wants to employ client-side loadbalancer logic can do that inside the
+`HttpEndpointSupplier`, and return a chosen endpoint. This will work because the supplier is
+documented to not be cached, unless it implements `HttpEndpointSupplier.Constant`.
+
 ## Sending an empty list is permitted
 
 Historically, we had a `Sender.check()` function for fail fast reasons, but it was rarely used and

--- a/activemq-client/pom.xml
+++ b/activemq-client/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>zipkin-reporter-parent</artifactId>
     <groupId>io.zipkin.reporter2</groupId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQContainer.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQContainer.java
@@ -28,7 +28,7 @@ final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
   static final int ACTIVEMQ_PORT = 61616;
 
   ActiveMQContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-activemq:3.0.2"));
+    super(parse("ghcr.io/openzipkin/zipkin-activemq:3.0.6"));
     withExposedPorts(ACTIVEMQ_PORT);
     waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
     withStartupTimeout(Duration.ofSeconds(60));

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-amqp-client</artifactId>

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQContainer.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQContainer.java
@@ -29,7 +29,7 @@ final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
   static final int RABBIT_PORT = 5672;
 
   RabbitMQContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.0.2"));
+    super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.0.6"));
     withExposedPorts(RABBIT_PORT);
     waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
     withStartupTimeout(Duration.ofSeconds(60));

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>benchmarks</artifactId>

--- a/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
@@ -42,7 +42,7 @@ public class KafkaSenderBenchmarks extends SenderBenchmarks {
 
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.2"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.6"));
       waitStrategy = Wait.forHealthcheck();
       // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
       addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-bom</artifactId>
   <name>Zipkin Reporter BOM</name>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <description>Bill Of Materials POM for all Zipkin reporter artifacts</description>
 

--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter</artifactId>

--- a/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
+++ b/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package zipkin2.reporter;
 
 import java.util.List;

--- a/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
+++ b/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
@@ -1,0 +1,84 @@
+package zipkin2.reporter;
+
+import java.util.List;
+
+/**
+ * HTTP-based {@link BytesMessageSender senders} use this to resolve a potentially-pseudo endpoint
+ * passed by configuration to a real endpoint.
+ *
+ * <p>Senders should consider the special value {@link #FIXED_FACTORY} and the type {@link Fixed} to
+ * avoid dynamic lookups when constants will be returned.
+ *
+ * <p>Senders are not called during production requests, rather in time or size bounded loop, in a
+ * separate async reporting thread. Implementations that resolve endpoints via remote calls, such as
+ * from Eureka, should cache internally to avoid blocking the reporter thread on each loop.
+ *
+ * <p>Some senders, such as Armeria, may have more efficient and precise endpoint group logic. In
+ * scenarios where the sender is known, interfaces here may be used as markers. Doing so can satisfy
+ * dependency injection, without limiting an HTTP framework that can handle groups, to a
+ * single-endpoint supplier.
+ *
+ * @since 3.3
+ */
+public interface HttpEndpointSupplier {
+  /**
+   * HTTP {@link BytesMessageSender sender} builders check for this symbol, and will substitute its
+   * input as a fixed endpoint value rather than perform dynamic lookups.
+   *
+   * @since 3.3
+   */
+  Factory FIXED_FACTORY = new Factory() {
+    @Override public HttpEndpointSupplier create(String endpoint) {
+      return new Fixed(endpoint);
+    }
+  };
+
+  /**
+   * Returns a possibly cached endpoint to an HTTP {@link BytesMessageSender sender}.
+   *
+   * <p>This will be called inside {@linkplain BytesMessageSender#send(List)}, unless this is an
+   * instance of {@linkplain Fixed}.
+   *
+   * @since 3.3
+   */
+  String get();
+
+  /**
+   * Factory passed to HTTP {@link BytesMessageSender sender} builders to control resolution of the
+   * static endpoint from configuration.
+   *
+   * <p>Unless this is {@linkplain #FIXED_FACTORY}, {@linkplain #create(String)} will be deferred to
+   * the first call to {@linkplain BytesMessageSender#send(List)}.
+   *
+   * @since 3.3
+   */
+  interface Factory {
+
+    /**
+     * Returns a possibly {@linkplain Fixed} endpoint supplier, given a static endpoint from
+     * configuration.
+     *
+     * <p>Note: Some factories may perform I/O to lazy-create a {@linkplain Fixed} endpoint.
+     *
+     * @param endpoint a static HTTP endpoint from configuration. For example,
+     *                 http://localhost:9411/api/v2/spans
+     */
+    HttpEndpointSupplier create(String endpoint);
+  }
+
+  /**
+   * HTTP {@link BytesMessageSender senders} check for this type, and will cache its first value.
+   */
+  final class Fixed implements HttpEndpointSupplier {
+    private final String endpoint;
+
+    public Fixed(String endpoint) {
+      if (endpoint == null) throw new NullPointerException("endpoint == null");
+      this.endpoint = endpoint;
+    }
+
+    @Override public String get() {
+      return endpoint;
+    }
+  }
+}

--- a/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
+++ b/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
@@ -24,7 +24,7 @@ import java.util.List;
  * <p>Sender should implement the following logic:
  * <ul>
  *   <li>During build, the sender should invoke the {@linkplain Factory}.</li>
- *   <li>If the result is {@link Fixed}, build the sender to use a static value.</li>
+ *   <li>If the result is {@link Constant}, build the sender to use a static value.</li>
  *   <li>Otherwise, call {@link HttpEndpointSupplier#get()} each time
  *       {@linkplain BytesMessageSender#send(List)} is invoked.</li>
  * </ul>
@@ -48,13 +48,13 @@ import java.util.List;
 public interface HttpEndpointSupplier {
   /**
    * HTTP {@link BytesMessageSender sender} builders check for this symbol, and return the input as
-   * a {@linkplain Fixed} result rather than perform dynamic lookups.
+   * a {@linkplain Constant} result rather than perform dynamic lookups.
    *
    * @since 3.3
    */
-  Factory FIXED_FACTORY = new Factory() {
-    @Override public Fixed create(String endpoint) {
-      return new Fixed(endpoint);
+  Factory CONSTANT_FACTORY = new Factory() {
+    @Override public Constant create(String endpoint) {
+      return new Constant(endpoint);
     }
   };
 
@@ -62,7 +62,7 @@ public interface HttpEndpointSupplier {
    * Returns a possibly cached endpoint to an HTTP {@link BytesMessageSender sender}.
    *
    * <p>This will be called inside {@linkplain BytesMessageSender#send(List)}, unless this is an
-   * instance of {@linkplain Fixed}.
+   * instance of {@linkplain Constant}.
    *
    * @since 3.3
    */
@@ -79,10 +79,10 @@ public interface HttpEndpointSupplier {
   interface Factory {
 
     /**
-     * Returns a possibly {@linkplain Fixed} endpoint supplier, given a static endpoint from
+     * Returns a possibly {@linkplain Constant} endpoint supplier, given a static endpoint from
      * configuration.
      *
-     * <p>Note: Some factories may perform I/O to lazy-create a {@linkplain Fixed} endpoint.
+     * <p>Note: Some factories may perform I/O to lazy-create a {@linkplain Constant} endpoint.
      *
      * @param endpoint a static HTTP endpoint from configuration. For example,
      *                 http://localhost:9411/api/v2/spans
@@ -95,10 +95,10 @@ public interface HttpEndpointSupplier {
    *
    * @since 3.3
    */
-  final class Fixed implements HttpEndpointSupplier {
+  final class Constant implements HttpEndpointSupplier {
     private final String endpoint;
 
-    public Fixed(String endpoint) {
+    public Constant(String endpoint) {
       if (endpoint == null) throw new NullPointerException("endpoint == null");
       this.endpoint = endpoint;
     }

--- a/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
+++ b/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
@@ -13,6 +13,7 @@
  */
 package zipkin2.reporter;
 
+import java.io.Closeable;
 import java.util.List;
 
 /**
@@ -21,12 +22,13 @@ import java.util.List;
  *
  * <h3>Usage Notes</h3>
  *
- * <p>Sender should implement the following logic:
+ * <p>{@link BytesMessageSender senders} should implement the following logic:
  * <ul>
  *   <li>During build, the sender should invoke the {@linkplain Factory}.</li>
  *   <li>If the result is {@link Constant}, build the sender to use a static value.</li>
  *   <li>Otherwise, call {@link HttpEndpointSupplier#get()} each time
  *       {@linkplain BytesMessageSender#send(List)} is invoked.</li>
+ *   <li>Call {@link #close()} once during {@link BytesMessageSender#close()}.</li>
  * </ul>
  *
  * <h3>Implementation Notes</h3>
@@ -45,7 +47,7 @@ import java.util.List;
  *
  * @since 3.3
  */
-public interface HttpEndpointSupplier {
+public interface HttpEndpointSupplier extends Closeable {
   /**
    * HTTP {@link BytesMessageSender sender} builders check for this symbol, and return the input as
    * a {@linkplain Constant} result rather than perform dynamic lookups.
@@ -105,6 +107,9 @@ public interface HttpEndpointSupplier {
 
     @Override public String get() {
       return endpoint;
+    }
+
+    @Override public void close() {
     }
   }
 }

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-kafka</artifactId>

--- a/kafka/src/test/java/zipkin2/reporter/kafka/KafkaContainer.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/KafkaContainer.java
@@ -37,7 +37,7 @@ final class KafkaContainer extends GenericContainer<KafkaContainer> {
   static final int KAFKA_PORT = 19092;
 
   KafkaContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.2"));
+    super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.6"));
     waitStrategy = Wait.forHealthcheck();
     // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
     addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-libthrift</artifactId>

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinContainer.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinContainer.java
@@ -31,7 +31,7 @@ final class ZipkinContainer extends GenericContainer<ZipkinContainer> {
   static final int HTTP_PORT = 9411;
 
   ZipkinContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin:3.0.2"));
+    super(parse("ghcr.io/openzipkin/zipkin:3.0.6"));
     // zipkin-server disables scribe by default.
     withEnv("COLLECTOR_SCRIBE_ENABLED", "true");
     withExposedPorts(SCRIBE_PORT, HTTP_PORT);

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-reporter-metrics-micrometer</artifactId>

--- a/okhttp3/pom.xml
+++ b/okhttp3/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-okhttp3</artifactId>

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -283,8 +283,9 @@ public final class OkHttpSender extends Sender {
   final boolean compressionEnabled;
 
   OkHttpSender(Builder builder, HttpUrlSupplier urlSupplier) {
-    endpointSupplierFactory = builder.endpointSupplierFactory;
-    endpoint = builder.endpoint;
+    endpointSupplierFactory = builder.endpointSupplierFactory; // for toBuilder()
+    endpoint = builder.endpoint; // for toBuilder()
+
     this.urlSupplier = urlSupplier;
     encoding = builder.encoding;
     switch (encoding) {

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -94,7 +94,7 @@ public final class OkHttpSender extends Sender {
 
   public static final class Builder {
     final OkHttpClient.Builder clientBuilder;
-    HttpEndpointSupplier.Factory endpointSupplierFactory = HttpEndpointSupplier.FIXED_FACTORY;
+    HttpEndpointSupplier.Factory endpointSupplierFactory = HttpEndpointSupplier.CONSTANT_FACTORY;
     String endpoint;
     Encoding encoding = Encoding.JSON;
     boolean compressionEnabled = true;
@@ -203,7 +203,7 @@ public final class OkHttpSender extends Sender {
       if (endpointSupplier == null) {
         throw new NullPointerException("endpointSupplierFactory.create() returned null");
       }
-      if (endpointSupplier instanceof HttpEndpointSupplier.Fixed) {
+      if (endpointSupplier instanceof HttpEndpointSupplier.Constant) {
         endpoint = endpointSupplier.get(); // eagerly resolve the endpoint
         return new OkHttpSender(this, new ConstantHttpUrlSupplier(endpoint));
       }
@@ -247,7 +247,7 @@ public final class OkHttpSender extends Sender {
     @Override public HttpUrl get() {
       String endpoint = endpointSupplier.get();
       if (endpoint == null) throw new NullPointerException("endpointSupplier.get() returned null");
-      return toHttpUrl(endpointSupplier.get());
+      return toHttpUrl(endpoint);
     }
 
     @Override public String toString() {

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/ITOkHttpSender.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/ITOkHttpSender.java
@@ -35,6 +35,7 @@ import zipkin2.reporter.Callback;
 import zipkin2.reporter.Encoding;
 import zipkin2.reporter.HttpEndpointSupplier;
 import zipkin2.reporter.SpanBytesEncoder;
+import zipkin2.reporter.okhttp3.OkHttpSenderTest.BaseHttpEndpointSupplier;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,7 +85,7 @@ public class ITOkHttpSender { // public for use in src/it
       .containsExactly(CLIENT_SPAN, CLIENT_SPAN);
   }
 
-  @Test void emptyOk() throws Exception{
+  @Test void emptyOk() throws Exception {
     server.enqueue(new MockResponse());
 
     sender.send(Collections.emptyList());
@@ -103,7 +104,12 @@ public class ITOkHttpSender { // public for use in src/it
     AtomicInteger suffix = new AtomicInteger();
     sender.close();
     sender = sender.toBuilder()
-      .endpointSupplierFactory(e -> () -> e + "/" + suffix.incrementAndGet())
+      .endpointSupplierFactory(e -> new BaseHttpEndpointSupplier() {
+          @Override public String get() {
+            return e + "/" + suffix.incrementAndGet();
+          }
+        }
+      )
       .build();
 
     sender.send(Collections.emptyList());

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -37,6 +37,31 @@ class OkHttpSenderTest {
   OkHttpSender sender = OkHttpSender.newBuilder()
     .readTimeout(100).endpoint("http://localhost:19092").build();
 
+  @Test void toBuilder() {
+    sender.close();
+
+    // Change the supplier, but not the endpoint.
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> new Constant("http://localhost:29092"))
+      .build();
+    assertThat(sender)
+      .hasToString("OkHttpSender{http://localhost:29092/}");
+
+    // Change the supplier, and see the prior endpoint.
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(HttpEndpointSupplier.CONSTANT_FACTORY)
+      .build();
+    assertThat(sender)
+      .hasToString("OkHttpSender{http://localhost:19092/}");
+
+    // Change the endpoint.
+    sender = sender.toBuilder()
+      .endpoint("http://localhost:29092")
+      .build();
+    assertThat(sender)
+      .hasToString("OkHttpSender{http://localhost:29092/}");
+  }
+
   @Test void sendFailsWhenEndpointIsDown() {
     // Depending on JRE, this could be a ConnectException or a SocketException.
     // Assert IOException to satisfy both!

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -38,8 +38,10 @@ class OkHttpSenderTest {
     .readTimeout(100).endpoint("http://localhost:19092").build();
 
   @Test void sendFailsWhenEndpointIsDown() {
+    // Depending on JRE, this could be a ConnectException or a SocketException.
+    // Assert IOException to satisfy both!
     assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
-      .isInstanceOf(ConnectException.class);
+      .isInstanceOf(IOException.class);
   }
 
   @Test void illegalToSendWhenClosed() {

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/OkHttpSenderTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.okhttp3;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.Collections;
+import java.util.stream.Stream;
+import okhttp3.HttpUrl;
+import org.junit.jupiter.api.Test;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.HttpEndpointSupplier;
+import zipkin2.reporter.HttpEndpointSupplier.Constant;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+
+class OkHttpSenderTest {
+  // We can be pretty certain Zipkin isn't listening on localhost port 19092
+  OkHttpSender sender = OkHttpSender.newBuilder()
+    .readTimeout(100).endpoint("http://localhost:19092").build();
+
+  @Test void sendFailsWhenEndpointIsDown() {
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(ConnectException.class);
+  }
+
+  @Test void illegalToSendWhenClosed() {
+    sender.close();
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(ClosedSenderException.class);
+  }
+
+  @Test void endpointSupplierFactory_defaultsToConstant() {
+    // The default connection supplier returns a constant URL
+    assertThat(sender)
+      .extracting("urlSupplier.url")
+      .isEqualTo(HttpUrl.parse("http://localhost:19092"));
+  }
+
+  @Test void endpointSupplierFactory_constant() {
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> new Constant("http://localhost:29092"))
+      .build();
+
+    // The connection supplier has a constant URL
+    assertThat(sender)
+      .extracting("urlSupplier.url")
+      .isEqualTo(HttpUrl.parse("http://localhost:29092"));
+  }
+
+  @Test void endpointSupplierFactory_constantBad() {
+    OkHttpSender.Builder builder = sender.toBuilder()
+      .endpointSupplierFactory(e -> new Constant("htp://localhost:9411/api/v1/spans"));
+
+    assertThatThrownBy(builder::build)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("invalid POST url");
+  }
+
+  @Test void endpointSupplierFactory_dynamic() {
+    HttpEndpointSupplier dynamicEndpointSupplier = () -> {
+      throw new UnsupportedOperationException();
+    };
+
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> dynamicEndpointSupplier)
+      .build();
+
+    // The connection supplier is deferred until send
+    assertThat(sender)
+      .extracting("urlSupplier.endpointSupplier")
+      .isEqualTo(dynamicEndpointSupplier);
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test void endpointSupplierFactory_dynamicNull() {
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> () -> null)
+      .build();
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("endpointSupplier.get() returned null");
+  }
+
+  @Test void endpointSupplierFactory_dynamicBad() {
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> () -> "htp://localhost:9411/api/v1/spans")
+      .build();
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("invalid POST url");
+  }
+
+  /**
+   * The output of toString() on {@link BytesMessageSender} implementations appears in thread names
+   * created by {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other
+   * monitoring tools, care should be taken to ensure the toString() output is a reasonable length
+   * and does not contain sensitive information.
+   */
+  @Test void toStringContainsOnlySummaryInformation() {
+    assertThat(sender).hasToString("OkHttpSender{http://localhost:19092/}");
+  }
+
+  @Test void outOfBandCancel() {
+    HttpCall call = (HttpCall) sender.sendSpans(Collections.emptyList());
+    call.cancel();
+
+    assertThat(call.isCanceled()).isTrue();
+  }
+
+  @Test void bugGuardCache() {
+    assertThat(sender.client.cache())
+      .withFailMessage("senders should not open a disk cache")
+      .isNull();
+  }
+
+  static void sendSpans(BytesMessageSender sender, Span... spans) throws IOException {
+    SpanBytesEncoder bytesEncoder;
+    switch (sender.encoding()) {
+      case JSON:
+        bytesEncoder = SpanBytesEncoder.JSON_V2;
+        break;
+      case THRIFT:
+        bytesEncoder = SpanBytesEncoder.THRIFT;
+        break;
+      case PROTO3:
+        bytesEncoder = SpanBytesEncoder.PROTO3;
+        break;
+      default:
+        throw new UnsupportedOperationException("encoding: " + sender.encoding());
+    }
+    sender.send(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.zipkin.reporter2</groupId>
   <artifactId>zipkin-reporter-parent</artifactId>
-  <version>3.2.2-SNAPSHOT</version>
+  <version>3.3.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/spring-beans/README.md
+++ b/spring-beans/README.md
@@ -10,9 +10,10 @@ Bean Factories exist for the following types:
 * KafkaSenderFactoryBean - for [zipkin-sender-kafka](../kafka)
 * RabbitMQSenderFactoryBean - for [zipkin-sender-amqp-client](../amqp-client)
 * URLConnectionSenderFactoryBean - for [zipkin-sender-urlconnection](../urlconnection)
-* ZipkinSpanHandlerFactoryBeanTest - for [brave](https://github.com/openzipkin/brave)
+* AsyncZipkinSpanHandlerFactoryBean - for [brave](https://github.com/openzipkin/brave)
+* ZipkinSpanHandlerFactoryBeanTest - for [brave](https://github.com/openzipkin/brave) reporter bridge
 
-Here's a basic example
+* Here's a basic example
 ```xml
   <bean id="spanReporter" class="zipkin2.reporter.beans.AsyncReporterFactoryBean">
     <property name="sender">

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/OkHttpSenderFactoryBean.java
@@ -15,11 +15,12 @@ package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.reporter.Encoding;
+import zipkin2.reporter.HttpEndpointSupplier;
 import zipkin2.reporter.okhttp3.OkHttpSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
-
+  HttpEndpointSupplier.Factory endpointSupplierFactory;
   String endpoint;
   Encoding encoding;
   Integer maxRequests;
@@ -29,6 +30,7 @@ public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
 
   @Override protected OkHttpSender createInstance() {
     OkHttpSender.Builder builder = OkHttpSender.newBuilder();
+    if (endpointSupplierFactory != null) builder.endpointSupplierFactory(endpointSupplierFactory);
     if (endpoint != null) builder.endpoint(endpoint);
     if (encoding != null) builder.encoding(encoding);
     if (connectTimeout != null) builder.connectTimeout(connectTimeout);
@@ -50,6 +52,10 @@ public class OkHttpSenderFactoryBean extends AbstractFactoryBean {
 
   @Override protected void destroyInstance(Object instance) {
     ((OkHttpSender) instance).close();
+  }
+
+  public void setEndpointSupplierFactory(HttpEndpointSupplier.Factory endpointSupplierFactory) {
+    this.endpointSupplierFactory = endpointSupplierFactory;
   }
 
   public void setEndpoint(String endpoint) {

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBean.java
@@ -15,11 +15,12 @@ package zipkin2.reporter.beans;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import zipkin2.reporter.Encoding;
+import zipkin2.reporter.HttpEndpointSupplier;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
-
+  HttpEndpointSupplier.Factory endpointSupplierFactory;
   String endpoint;
   Encoding encoding;
   Integer connectTimeout, readTimeout;
@@ -28,6 +29,7 @@ public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
 
   @Override protected URLConnectionSender createInstance() {
     URLConnectionSender.Builder builder = URLConnectionSender.newBuilder();
+    if (endpointSupplierFactory != null) builder.endpointSupplierFactory(endpointSupplierFactory);
     if (endpoint != null) builder.endpoint(endpoint);
     if (encoding != null) builder.encoding(encoding);
     if (connectTimeout != null) builder.connectTimeout(connectTimeout);
@@ -47,6 +49,10 @@ public class URLConnectionSenderFactoryBean extends AbstractFactoryBean {
 
   @Override protected void destroyInstance(Object instance) {
     ((URLConnectionSender) instance).close();
+  }
+
+  public void setEndpointSupplierFactory(HttpEndpointSupplier.Factory endpointSupplierFactory) {
+    this.endpointSupplierFactory = endpointSupplierFactory;
   }
 
   public void setEndpoint(String endpoint) {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/FakeEndpointSupplier.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/FakeEndpointSupplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.beans;
+
+import zipkin2.reporter.HttpEndpointSupplier;
+
+public enum FakeEndpointSupplier implements HttpEndpointSupplier {
+  INSTANCE;
+
+  public static final Factory FACTORY = new Factory() {
+    @Override public HttpEndpointSupplier create(String endpoint) {
+      return INSTANCE;
+    }
+  };
+
+  @Override public String get() {
+    return null;
+  }
+}

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/FakeEndpointSupplier.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/FakeEndpointSupplier.java
@@ -27,4 +27,7 @@ public enum FakeEndpointSupplier implements HttpEndpointSupplier {
   @Override public String get() {
     return null;
   }
+
+  @Override public void close() {
+  }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/OkHttpSenderFactoryBeanTest.java
@@ -39,7 +39,7 @@ class OkHttpSenderFactoryBeanTest {
 
     assertThat(context.getBean("sender", OkHttpSender.class))
         .extracting("endpoint")
-        .isEqualTo(HttpUrl.parse("http://localhost:9411/api/v2/spans"));
+        .isEqualTo("http://localhost:9411/api/v2/spans");
   }
 
   @Test void connectTimeout() {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
@@ -40,7 +40,7 @@ class URLConnectionSenderFactoryBeanTest {
 
     assertThat(context.getBean("sender", URLConnectionSender.class))
         .extracting("endpoint")
-        .isEqualTo(URI.create("http://localhost:9411/api/v2/spans").toURL());
+        .isEqualTo("http://localhost:9411/api/v2/spans");
   }
 
   @Test void connectTimeout() {

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/XmlBeans.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/XmlBeans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,14 +13,13 @@
  */
 package zipkin2.reporter.beans;
 
-import java.nio.charset.Charset;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
 import org.springframework.core.io.ByteArrayResource;
 
-class XmlBeans {
-  static final Charset UTF_8 = Charset.forName("UTF-8");
+import static java.nio.charset.StandardCharsets.UTF_8;
 
+class XmlBeans {
   final DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
 
   XmlBeans(String... beans) {
@@ -50,7 +49,7 @@ class XmlBeans {
     return (T) beanFactory.getBean(name, requiredType);
   }
 
-  void close(){
+  void close() {
     beanFactory.destroySingletons();
   }
 }

--- a/urlconnection/pom.xml
+++ b/urlconnection/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.zipkin.reporter2</groupId>
     <artifactId>zipkin-reporter-parent</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>zipkin-sender-urlconnection</artifactId>

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -46,7 +46,7 @@ public final class URLConnectionSender extends Sender {
   }
 
   public static final class Builder {
-    HttpEndpointSupplier.Factory endpointSupplierFactory = HttpEndpointSupplier.FIXED_FACTORY;
+    HttpEndpointSupplier.Factory endpointSupplierFactory = HttpEndpointSupplier.CONSTANT_FACTORY;
     String endpoint;
     Encoding encoding = Encoding.JSON;
     int messageMaxBytes = 500000;
@@ -135,7 +135,7 @@ public final class URLConnectionSender extends Sender {
       if (endpointSupplier == null) {
         throw new NullPointerException("endpointSupplierFactory.create() returned null");
       }
-      if (endpointSupplier instanceof HttpEndpointSupplier.Fixed) {
+      if (endpointSupplier instanceof HttpEndpointSupplier.Constant) {
         endpoint = endpointSupplier.get(); // eagerly resolve the endpoint
         return new URLConnectionSender(this, new ConstantHttpURLConnectionSupplier(endpoint));
       }
@@ -184,7 +184,7 @@ public final class URLConnectionSender extends Sender {
     @Override public HttpURLConnection openConnection() throws IOException {
       String endpoint = endpointSupplier.get();
       if (endpoint == null) throw new NullPointerException("endpointSupplier.get() returned null");
-      URL url = toURL(endpointSupplier.get());
+      URL url = toURL(endpoint);
       return (HttpURLConnection) url.openConnection();
     }
 

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/URLConnectionSender.java
@@ -223,8 +223,9 @@ public final class URLConnectionSender extends Sender {
   final boolean compressionEnabled;
 
   URLConnectionSender(Builder builder, HttpURLConnectionSupplier connectionSupplier) {
-    this.endpointSupplierFactory = builder.endpointSupplierFactory;
-    this.endpoint = builder.endpoint;
+    this.endpointSupplierFactory = builder.endpointSupplierFactory; // for toBuilder()
+    this.endpoint = builder.endpoint; // for toBuilder()
+
     this.connectionSupplier = connectionSupplier;
     this.encoding = builder.encoding;
     switch (builder.encoding) {

--- a/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
+++ b/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.urlconnection;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesEncoder;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.ClosedSenderException;
+import zipkin2.reporter.HttpEndpointSupplier;
+import zipkin2.reporter.HttpEndpointSupplier.Constant;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static zipkin2.TestObjects.CLIENT_SPAN;
+
+class URLConnectionSenderTest {
+  // We can be pretty certain Zipkin isn't listening on localhost port 19092
+  URLConnectionSender sender = URLConnectionSender.newBuilder()
+    .readTimeout(100).endpoint("http://localhost:19092").build();
+
+  @Test void sendFailsWhenEndpointIsDown() {
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(ConnectException.class);
+  }
+
+  @Test void illegalToSendWhenClosed() {
+    sender.close();
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(ClosedSenderException.class);
+  }
+
+  @Test void endpointSupplierFactory_defaultsToConstant() throws MalformedURLException {
+    // The default connection supplier returns a constant URL
+    assertThat(sender)
+      .extracting("connectionSupplier.url")
+      .isEqualTo(URI.create("http://localhost:19092").toURL());
+  }
+
+  @Test void endpointSupplierFactory_constant() throws MalformedURLException {
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> new Constant("http://localhost:29092"))
+      .build();
+
+    // The connection supplier has a constant URL
+    assertThat(sender)
+      .extracting("connectionSupplier.url")
+      .isEqualTo(URI.create("http://localhost:29092").toURL());
+  }
+
+  @Test void endpointSupplierFactory_constantBad() {
+    URLConnectionSender.Builder builder = sender.toBuilder()
+      .endpointSupplierFactory(e -> new Constant("htp://localhost:9411/api/v1/spans"));
+
+    assertThatThrownBy(builder::build)
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("unknown protocol: htp");
+  }
+
+  @Test void endpointSupplierFactory_dynamic() {
+    HttpEndpointSupplier dynamicEndpointSupplier = () -> {
+      throw new UnsupportedOperationException();
+    };
+
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> dynamicEndpointSupplier)
+      .build();
+
+    // The connection supplier is deferred until send
+    assertThat(sender)
+      .extracting("connectionSupplier.endpointSupplier")
+      .isEqualTo(dynamicEndpointSupplier);
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test void endpointSupplierFactory_dynamicNull() {
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> () -> null)
+      .build();
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessage("endpointSupplier.get() returned null");
+  }
+
+  @Test void endpointSupplierFactory_dynamicBad() {
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> () -> "htp://localhost:9411/api/v1/spans")
+      .build();
+
+    assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("unknown protocol: htp");
+  }
+
+  /**
+   * The output of toString() on {@link BytesMessageSender} implementations appears in thread names
+   * created by {@link AsyncReporter}. Since thread names are likely to be exposed in logs and other
+   * monitoring tools, care should be taken to ensure the toString() output is a reasonable length
+   * and does not contain sensitive information.
+   */
+  @Test void toStringContainsOnlySummaryInformation() {
+    assertThat(sender).hasToString("URLConnectionSender{http://localhost:19092}");
+  }
+
+  static void sendSpans(BytesMessageSender sender, Span... spans) throws IOException {
+    SpanBytesEncoder bytesEncoder;
+    switch (sender.encoding()) {
+      case JSON:
+        bytesEncoder = SpanBytesEncoder.JSON_V2;
+        break;
+      case THRIFT:
+        bytesEncoder = SpanBytesEncoder.THRIFT;
+        break;
+      case PROTO3:
+        bytesEncoder = SpanBytesEncoder.PROTO3;
+        break;
+      default:
+        throw new UnsupportedOperationException("encoding: " + sender.encoding());
+    }
+    sender.send(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
+  }
+}

--- a/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
+++ b/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
@@ -39,6 +39,31 @@ class URLConnectionSenderTest {
   URLConnectionSender sender = URLConnectionSender.newBuilder()
     .readTimeout(100).endpoint("http://localhost:19092").build();
 
+  @Test void toBuilder() {
+    sender.close();
+
+    // Change the supplier, but not the endpoint
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> new Constant("http://localhost:29092"))
+      .build();
+    assertThat(sender)
+      .hasToString("URLConnectionSender{http://localhost:29092}");
+
+    // Change the supplier, and see the prior endpoint.
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(HttpEndpointSupplier.CONSTANT_FACTORY)
+      .build();
+    assertThat(sender)
+      .hasToString("URLConnectionSender{http://localhost:19092}");
+
+    // Change the endpoint.
+    sender = sender.toBuilder()
+      .endpoint("http://localhost:29092")
+      .build();
+    assertThat(sender)
+      .hasToString("URLConnectionSender{http://localhost:29092}");
+  }
+
   @Test void sendFailsWhenEndpointIsDown() {
     assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
       .isInstanceOf(ConnectException.class);

--- a/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
+++ b/urlconnection/src/test/java/zipkin2/reporter/urlconnection/URLConnectionSenderTest.java
@@ -17,6 +17,8 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import zipkin2.Span;
@@ -78,8 +80,15 @@ class URLConnectionSenderTest {
   }
 
   @Test void endpointSupplierFactory_dynamic() {
-    HttpEndpointSupplier dynamicEndpointSupplier = () -> {
-      throw new UnsupportedOperationException();
+    AtomicInteger closeCalled = new AtomicInteger();
+    HttpEndpointSupplier dynamicEndpointSupplier = new HttpEndpointSupplier() {
+      @Override public String get() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override public void close() {
+        closeCalled.incrementAndGet();
+      }
     };
 
     sender.close();
@@ -94,12 +103,44 @@ class URLConnectionSenderTest {
 
     assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
       .isInstanceOf(UnsupportedOperationException.class);
+
+    // Ensure that closing the sender closes the endpoint supplier
+    sender.close();
+    sender.close(); // check only closed once
+    assertThat(closeCalled).hasValue(1);
+  }
+
+  @Test void endpointSupplierFactory_ignoresCloseFailure() {
+    AtomicInteger closeCalled = new AtomicInteger();
+    HttpEndpointSupplier dynamicEndpointSupplier = new HttpEndpointSupplier() {
+      @Override public String get() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override public void close() throws IOException {
+        closeCalled.incrementAndGet();
+        throw new IOException("unexpected");
+      }
+    };
+
+    sender.close();
+    sender = sender.toBuilder()
+      .endpointSupplierFactory(e -> dynamicEndpointSupplier)
+      .build();
+
+    // Ensure that an exception closing the endpoint supplier doesn't propagate.
+    sender.close();
+    assertThat(closeCalled).hasValue(1);
   }
 
   @Test void endpointSupplierFactory_dynamicNull() {
     sender.close();
     sender = sender.toBuilder()
-      .endpointSupplierFactory(e -> () -> null)
+      .endpointSupplierFactory(e -> new BaseHttpEndpointSupplier() {
+        @Override public String get() {
+          return null;
+        }
+      })
       .build();
 
     assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
@@ -110,7 +151,11 @@ class URLConnectionSenderTest {
   @Test void endpointSupplierFactory_dynamicBad() {
     sender.close();
     sender = sender.toBuilder()
-      .endpointSupplierFactory(e -> () -> "htp://localhost:9411/api/v1/spans")
+      .endpointSupplierFactory(e -> new BaseHttpEndpointSupplier() {
+        @Override public String get() {
+          return "htp://localhost:9411/api/v1/spans";
+        }
+      })
       .build();
 
     assertThatThrownBy(() -> sendSpans(sender, CLIENT_SPAN, CLIENT_SPAN))
@@ -144,5 +189,10 @@ class URLConnectionSenderTest {
         throw new UnsupportedOperationException("encoding: " + sender.encoding());
     }
     sender.send(Stream.of(spans).map(bytesEncoder::encode).collect(toList()));
+  }
+
+  static abstract class BaseHttpEndpointSupplier implements HttpEndpointSupplier {
+    @Override public void close() {
+    }
   }
 }


### PR DESCRIPTION
Before, users could only use spring-cloud-sleuth to integrate HTTP senders with dynamic endpoint suppliers such as consul, eureka or zookeeper. Since sleuth is discontinued, this adds a lightweight generic functionality via a new type `HttpEndpointSupplier` which can do the same sort of translation as sleuth did (e.g. substituting a placeholder URI for a real one).

This will allow those upgrading to Spring Boot 3 to continue using service discovery such as Eureka. As an additional benefit, it also allows the non-spring ecosystem the same.

There is no current plan to introduce Eureka or any other built-in endpoint discovery mechanics to this repo. However, tests will prove they can be integrated, and the types will be validated in config scenarios including Spring Boot and raw Armeria prior to merge. If users request specific discovery providers, they can raise issues and demand for them.