### PR TITLE
Decreases switch statements and deprecates BytesMessageEncoder

### DIFF
--- a/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java
+++ b/activemq-client/src/main/java/zipkin2/reporter/activemq/ActiveMQSender.java
@@ -20,7 +20,6 @@ import javax.jms.JMSException;
 import javax.jms.QueueSender;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Call;
 import zipkin2.reporter.Callback;
@@ -111,7 +110,7 @@ public final class ActiveMQSender extends Sender {
       return this;
     }
 
-    public final ActiveMQSender build() {
+    public ActiveMQSender build() {
       if (connectionFactory == null) throw new NullPointerException("connectionFactory == null");
       return new ActiveMQSender(this);
     }
@@ -122,14 +121,12 @@ public final class ActiveMQSender extends Sender {
 
   final Encoding encoding;
   final int messageMaxBytes;
-  final BytesMessageEncoder encoder;
 
   final LazyInit lazyInit;
 
   ActiveMQSender(Builder builder) {
     this.encoding = builder.encoding;
     this.messageMaxBytes = builder.messageMaxBytes;
-    this.encoder = BytesMessageEncoder.forEncoding(encoding);
     this.lazyInit = new LazyInit(builder);
   }
 
@@ -155,14 +152,14 @@ public final class ActiveMQSender extends Sender {
   /** {@inheritDoc} */
   @Override @Deprecated public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new ClosedSenderException();
-    byte[] message = encoder.encode(encodedSpans);
+    byte[] message = encoding.encode(encodedSpans);
     return new ActiveMQCall(message);
   }
 
   /** {@inheritDoc} */
   @Override public void send(List<byte[]> encodedSpans) throws IOException {
     if (closeCalled) throw new ClosedSenderException();
-    send(encoder.encode(encodedSpans));
+    send(encoding.encode(encodedSpans));
   }
 
   void send(byte[] message) throws IOException {

--- a/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
+++ b/amqp-client/src/main/java/zipkin2/reporter/amqp/RabbitMQSender.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import zipkin2.reporter.AsyncReporter;
-import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Call;
 import zipkin2.reporter.Callback;
@@ -179,12 +178,10 @@ public final class RabbitMQSender extends Sender {
   final List<Address> addresses;
   final String queue;
   final ConnectionFactory connectionFactory;
-  final BytesMessageEncoder encoder;
 
   RabbitMQSender(Builder builder) {
     if (builder.addresses == null) throw new NullPointerException("addresses == null");
     encoding = builder.encoding;
-    encoder = BytesMessageEncoder.forEncoding(encoding);
     messageMaxBytes = builder.messageMaxBytes;
     addresses = builder.addresses;
     queue = builder.queue;
@@ -218,14 +215,14 @@ public final class RabbitMQSender extends Sender {
   /** {@inheritDoc} */
   @Override @Deprecated public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new ClosedSenderException();
-    byte[] message = encoder.encode(encodedSpans);
+    byte[] message = encoding.encode(encodedSpans);
     return new RabbitMQCall(message);
   }
 
   /** {@inheritDoc} */
   @Override public void send(List<byte[]> encodedSpans) throws IOException {
     if (closeCalled) throw new ClosedSenderException();
-    publish(encoder.encode(encodedSpans));
+    publish(encoding.encode(encodedSpans));
   }
 
   void publish(byte[] message) throws IOException {

--- a/benchmarks/src/main/java/zipkin2/reporter/internal/NoopSender.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/internal/NoopSender.java
@@ -14,20 +14,16 @@
 package zipkin2.reporter.internal;
 
 import java.util.List;
-import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Encoding;
 
 /** Encodes messages on {@link #send(List)}, but doesn't do anything else. */
 final class NoopSender extends BytesMessageSender.Base {
-  final BytesMessageEncoder messageEncoder;
-
   /** close is typically called from a different thread */
   volatile boolean closeCalled;
 
   NoopSender(Encoding encoding) {
     super(encoding);
-    this.messageEncoder = BytesMessageEncoder.forEncoding(encoding);
   }
 
   @Override public int messageMaxBytes() {
@@ -35,7 +31,7 @@ final class NoopSender extends BytesMessageSender.Base {
   }
 
   @Override public void send(List<byte[]> encodedSpans) {
-    messageEncoder.encode(encodedSpans);
+    encoding.encode(encodedSpans);
   }
 
   @Override public void close() {

--- a/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/AsyncZipkinSpanHandler.java
@@ -172,12 +172,7 @@ public final class AsyncZipkinSpanHandler extends SpanHandler implements Closeab
      */
     // AsyncZipkinSpanHandler not SpanHandler, so that Flushable and Closeable are accessible
     public AsyncZipkinSpanHandler build() {
-      switch (encoding) {
-        case JSON:
-          return build(new JsonV2Encoder(errorTag));
-        default:
-          throw new UnsupportedOperationException(encoding.name());
-      }
+      return build(MutableSpanBytesEncoder.create(encoding, errorTag));
     }
 
     /**

--- a/brave/src/main/java/zipkin2/reporter/brave/JsonV2Encoder.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/JsonV2Encoder.java
@@ -14,12 +14,14 @@
 package zipkin2.reporter.brave;
 
 import brave.Tag;
+import brave.Tags;
 import brave.handler.MutableSpan;
 import brave.handler.MutableSpanBytesEncoder;
 import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.Encoding;
 
 final class JsonV2Encoder implements BytesEncoder<MutableSpan> {
+  static final BytesEncoder<MutableSpan> INSTANCE = new JsonV2Encoder(Tags.ERROR);
   final MutableSpanBytesEncoder delegate;
 
   JsonV2Encoder(Tag<Throwable> errorTag) {

--- a/brave/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoder.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tag;
+import brave.Tags;
+import brave.handler.MutableSpan;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Encoding;
+
+/** Includes built-in formats used in Zipkin. */
+public enum MutableSpanBytesEncoder implements BytesEncoder<MutableSpan> {
+  /** Corresponds to the Zipkin v2 json format */
+  JSON_V2 {
+    @Override public Encoding encoding() {
+      return Encoding.JSON;
+    }
+
+    @Override public int sizeInBytes(MutableSpan input) {
+      return JsonV2Encoder.INSTANCE.sizeInBytes(input);
+    }
+
+    @Override public byte[] encode(MutableSpan input) {
+      return JsonV2Encoder.INSTANCE.encode(input);
+    }
+  };
+
+  /**
+   * Returns the default {@linkplain MutableSpan} encoder for given encoding.
+   *
+   * @throws UnsupportedOperationException if the encoding is not yet supported.
+   * @since 3.3
+   */
+  public static BytesEncoder<MutableSpan> forEncoding(Encoding encoding) {
+    if (encoding == null) throw new NullPointerException("encoding == null");
+    switch (encoding) {
+      case JSON:
+        return JSON_V2;
+      case PROTO3:
+        throw new UnsupportedOperationException("PROTO3 is not yet a built-in encoder");
+      case THRIFT:
+        throw new UnsupportedOperationException("THRIFT is not yet a built-in encoder");
+      default: // BUG: as encoding is an enum!
+        throw new UnsupportedOperationException("BUG: " + encoding.name());
+    }
+  }
+
+  /**
+   * Like {@linkplain #forEncoding(Encoding)}, except you can override the default throwable parser,
+   * which is {@linkplain brave.Tags#ERROR}.
+   *
+   * @since 3.3
+   */
+  public static BytesEncoder<MutableSpan> create(Encoding encoding, Tag<Throwable> errorTag) {
+    if (encoding == null) throw new NullPointerException("encoding == null");
+    if (errorTag == null) throw new NullPointerException("errorTag == null");
+    if (errorTag == Tags.ERROR) return forEncoding(encoding);
+    switch (encoding) {
+      case JSON:
+        return new JsonV2Encoder(errorTag);
+      case PROTO3:
+        throw new UnsupportedOperationException("PROTO3 is not yet a built-in encoder");
+      case THRIFT:
+        throw new UnsupportedOperationException("THRIFT is not yet a built-in encoder");
+      default: // BUG: as encoding is an enum!
+        throw new UnsupportedOperationException("BUG: " + encoding.name());
+    }
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/FakeSender.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/FakeSender.java
@@ -20,7 +20,6 @@ import zipkin2.Span;
 import zipkin2.codec.BytesDecoder;
 import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.reporter.BytesEncoder;
-import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.ClosedSenderException;
 import zipkin2.reporter.Encoding;
@@ -29,37 +28,34 @@ import zipkin2.reporter.SpanBytesEncoder;
 public final class FakeSender extends BytesMessageSender.Base {
 
   public static FakeSender create() {
-    return new FakeSender(Encoding.JSON, Integer.MAX_VALUE,
-      BytesMessageEncoder.forEncoding(Encoding.JSON), SpanBytesEncoder.JSON_V2,
+    return new FakeSender(Encoding.JSON, Integer.MAX_VALUE, SpanBytesEncoder.JSON_V2,
       SpanBytesDecoder.JSON_V2, spans -> {
     });
   }
 
   final int messageMaxBytes;
-  final BytesMessageEncoder messageEncoder;
   final BytesEncoder<Span> encoder;
   final BytesDecoder<Span> decoder;
   final Consumer<List<Span>> onSpans;
 
-  FakeSender(Encoding encoding, int messageMaxBytes, BytesMessageEncoder messageEncoder,
-    BytesEncoder<Span> encoder, BytesDecoder<Span> decoder, Consumer<List<Span>> onSpans) {
+  FakeSender(Encoding encoding, int messageMaxBytes, BytesEncoder<Span> encoder,
+    BytesDecoder<Span> decoder, Consumer<List<Span>> onSpans) {
     super(encoding);
     this.messageMaxBytes = messageMaxBytes;
-    this.messageEncoder = messageEncoder;
     this.encoder = encoder;
     this.decoder = decoder;
     this.onSpans = onSpans;
   }
 
   FakeSender encoding(Encoding encoding) {
-    return new FakeSender(encoding, messageMaxBytes, messageEncoder, // invalid but not needed, yet
+    return new FakeSender(encoding, messageMaxBytes, // invalid but not needed, yet
       encoder, // invalid but not needed, yet
       decoder, // invalid but not needed, yet
       onSpans);
   }
 
   FakeSender onSpans(Consumer<List<Span>> onSpans) {
-    return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
+    return new FakeSender(encoding, messageMaxBytes, encoder, decoder, onSpans);
   }
 
   @Override public int messageMaxBytes() {

--- a/brave/src/test/java/zipkin2/reporter/brave/MutableSpanBytesEncoderTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/MutableSpanBytesEncoderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tag;
+import brave.Tags;
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MutableSpanBytesEncoderTest {
+  @Test void forEncoding() {
+    assertThat(MutableSpanBytesEncoder.forEncoding(Encoding.JSON))
+      .isSameAs(MutableSpanBytesEncoder.JSON_V2);
+    assertThatThrownBy(() -> MutableSpanBytesEncoder.forEncoding(Encoding.PROTO3))
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessage("PROTO3 is not yet a built-in encoder");
+    assertThatThrownBy(() -> MutableSpanBytesEncoder.forEncoding(Encoding.THRIFT))
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessage("THRIFT is not yet a built-in encoder");
+  }
+
+  Tag<Throwable> iceCream = new Tag<>("exception") {
+    @Override protected String parseValue(Throwable throwable, TraceContext traceContext) {
+      return "ice cream";
+    }
+  };
+
+  @Test void create_json() {
+    // doesn't allocate on defaults
+    assertThat(MutableSpanBytesEncoder.create(Encoding.JSON, Tags.ERROR))
+      .isSameAs(MutableSpanBytesEncoder.JSON_V2);
+
+    MutableSpan span = new MutableSpan();
+    span.traceId("1");
+    span.id("2");
+    span.error(new OutOfMemoryError("out of memory"));
+
+    // Default makes a tag named error
+    assertThat(new String(MutableSpanBytesEncoder.JSON_V2.encode(span), StandardCharsets.UTF_8))
+      .isEqualTo("{\"traceId\":\"0000000000000001\",\"id\":\"0000000000000002\",\"tags\":{\"error\":\"out of memory\"}}");
+
+
+    // but, using create, you can override with something else.
+    BytesEncoder<MutableSpan> iceCreamEncoder =
+      MutableSpanBytesEncoder.create(Encoding.JSON, iceCream);
+    assertThat(new String(iceCreamEncoder.encode(span), StandardCharsets.UTF_8))
+      .isEqualTo("{\"traceId\":\"0000000000000001\",\"id\":\"0000000000000002\",\"tags\":{\"exception\":\"ice cream\"}}");
+  }
+
+  @Test void create_unsupported() {
+    assertThatThrownBy(() -> MutableSpanBytesEncoder.create(Encoding.PROTO3, iceCream))
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessage("PROTO3 is not yet a built-in encoder");
+    assertThatThrownBy(() -> MutableSpanBytesEncoder.create(Encoding.THRIFT, iceCream))
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessage("THRIFT is not yet a built-in encoder");
+  }
+}

--- a/core/src/main/java/zipkin2/reporter/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/AsyncReporter.java
@@ -163,16 +163,7 @@ public class AsyncReporter<S> extends Component implements Reporter<S>, Closeabl
 
     /** Builds an async reporter that encodes zipkin spans as they are reported. */
     public AsyncReporter<zipkin2.Span> build() {
-      switch (encoding) {
-        case JSON:
-          return build(SpanBytesEncoder.JSON_V2);
-        case PROTO3:
-          return build(SpanBytesEncoder.PROTO3);
-        case THRIFT:
-          return build(SpanBytesEncoder.THRIFT);
-        default:
-          throw new UnsupportedOperationException(encoding.name());
-      }
+      return build(SpanBytesEncoder.forEncoding(encoding));
     }
 
     /** Builds an async reporter that encodes arbitrary spans as they are reported. */

--- a/core/src/main/java/zipkin2/reporter/BytesMessageEncoder.java
+++ b/core/src/main/java/zipkin2/reporter/BytesMessageEncoder.java
@@ -18,7 +18,10 @@ import java.util.List;
 /**
  * Senders like Kafka use byte[] message encoding. This provides helpers to concatenate spans into a
  * list.
+ *
+ * @deprecated As of 3.3, use {@linkplain Encoding#encode(List)}. This will be removed in v4.0.
  */
+@Deprecated
 public enum BytesMessageEncoder {
   JSON {
     @Override public byte[] encode(List<byte[]> values) {

--- a/core/src/main/java/zipkin2/reporter/SpanBytesEncoder.java
+++ b/core/src/main/java/zipkin2/reporter/SpanBytesEncoder.java
@@ -16,7 +16,6 @@ package zipkin2.reporter;
 import zipkin2.Span;
 
 /** Includes built-in formats used in Zipkin. */
-@SuppressWarnings("ImmutableEnumChecker") // because span is immutable
 public enum SpanBytesEncoder implements BytesEncoder<Span> {
   /** Corresponds to the Zipkin v1 thrift format */
   THRIFT {
@@ -73,4 +72,23 @@ public enum SpanBytesEncoder implements BytesEncoder<Span> {
       return zipkin2.codec.SpanBytesEncoder.PROTO3.encode(input);
     }
   };
+
+  /**
+   * Returns the default {@linkplain Span} encoder for given encoding.
+   *
+   * @since 3.3
+   */
+  public static BytesEncoder<Span> forEncoding(Encoding encoding) {
+    if (encoding == null) throw new NullPointerException("encoding == null");
+    switch (encoding) {
+      case JSON:
+        return JSON_V2;
+      case PROTO3:
+        return PROTO3;
+      case THRIFT:
+        return THRIFT;
+      default: // BUG: as encoding is an enum!
+        throw new UnsupportedOperationException("BUG: " + encoding.name());
+    }
+  }
 }

--- a/core/src/test/java/zipkin2/reporter/EncodingTest.java
+++ b/core/src/test/java/zipkin2/reporter/EncodingTest.java
@@ -13,56 +13,55 @@
  */
 package zipkin2.reporter;
 
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class BytesMessageEncoderTest {
+class EncodingTest {
   @Test void emptyList_json() {
-    List<byte[]> encoded = Arrays.asList();
-    assertThat(BytesMessageEncoder.JSON.encode(encoded))
+    List<byte[]> encoded = List.of();
+    assertThat(Encoding.JSON.encode(encoded))
       .containsExactly('[', ']');
   }
 
   @Test void singletonList_json() {
-    List<byte[]> encoded = Arrays.asList(new byte[] {'{', '}'});
+    List<byte[]> encoded = List.of(new byte[] {'{', '}'});
 
-    assertThat(BytesMessageEncoder.JSON.encode(encoded))
+    assertThat(Encoding.JSON.encode(encoded))
       .containsExactly('[', '{', '}', ']');
   }
 
   @Test void multiItemList_json() {
-    List<byte[]> encoded = Arrays.asList(
+    List<byte[]> encoded = List.of(
       "{\"k\":\"1\"}".getBytes(),
       "{\"k\":\"2\"}".getBytes(),
       "{\"k\":\"3\"}".getBytes()
     );
-    assertThat(new String(BytesMessageEncoder.JSON.encode(encoded)))
+    assertThat(new String(Encoding.JSON.encode(encoded)))
       .isEqualTo("[{\"k\":\"1\"},{\"k\":\"2\"},{\"k\":\"3\"}]");
   }
 
   @Test void emptyList_proto3() {
-    List<byte[]> encoded = Arrays.asList();
-    assertThat(BytesMessageEncoder.PROTO3.encode(encoded))
+    List<byte[]> encoded = List.of();
+    assertThat(Encoding.PROTO3.encode(encoded))
       .isEmpty();
   }
 
   @Test void singletonList_proto3() {
-    List<byte[]> encoded = Arrays.asList(new byte[] {1, 1, 'a'});
+    List<byte[]> encoded = List.of(new byte[] {1, 1, 'a'});
 
-    assertThat(BytesMessageEncoder.PROTO3.encode(encoded))
+    assertThat(Encoding.PROTO3.encode(encoded))
       .containsExactly(1, 1, 'a');
   }
 
   @Test void multiItemList_proto3() {
-    List<byte[]> encoded = Arrays.asList(
+    List<byte[]> encoded = List.of(
       new byte[] {1, 1, 'a'},
       new byte[] {1, 1, 'b'},
       new byte[] {1, 1, 'c'}
     );
-    assertThat(BytesMessageEncoder.PROTO3.encode(encoded)).containsExactly(
+    assertThat(Encoding.PROTO3.encode(encoded)).containsExactly(
       1, 1, 'a',
       1, 1, 'b',
       1, 1, 'c'

--- a/core/src/test/java/zipkin2/reporter/FakeSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeSender.java
@@ -23,41 +23,38 @@ import zipkin2.codec.SpanBytesDecoder;
 public final class FakeSender extends BytesMessageSender.Base {
 
   public static FakeSender create() {
-    return new FakeSender(Encoding.JSON, Integer.MAX_VALUE,
-      BytesMessageEncoder.forEncoding(Encoding.JSON), SpanBytesEncoder.JSON_V2,
+    return new FakeSender(Encoding.JSON, Integer.MAX_VALUE, SpanBytesEncoder.JSON_V2,
       SpanBytesDecoder.JSON_V2, spans -> {
     });
   }
 
   final int messageMaxBytes;
-  final BytesMessageEncoder messageEncoder;
   final BytesEncoder<Span> encoder;
   final BytesDecoder<Span> decoder;
   final Consumer<List<Span>> onSpans;
 
-  FakeSender(Encoding encoding, int messageMaxBytes, BytesMessageEncoder messageEncoder,
-    BytesEncoder<Span> encoder, BytesDecoder<Span> decoder, Consumer<List<Span>> onSpans) {
+  FakeSender(Encoding encoding, int messageMaxBytes, BytesEncoder<Span> encoder,
+    BytesDecoder<Span> decoder, Consumer<List<Span>> onSpans) {
     super(encoding);
     this.messageMaxBytes = messageMaxBytes;
-    this.messageEncoder = messageEncoder;
     this.encoder = encoder;
     this.decoder = decoder;
     this.onSpans = onSpans;
   }
 
   public FakeSender encoding(Encoding encoding) {
-    return new FakeSender(encoding, messageMaxBytes, messageEncoder, // invalid but not needed, yet
+    return new FakeSender(encoding, messageMaxBytes, // invalid but not needed, yet
       encoder, // invalid but not needed, yet
       decoder, // invalid but not needed, yet
       onSpans);
   }
 
   public FakeSender onSpans(Consumer<List<Span>> onSpans) {
-    return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
+    return new FakeSender(encoding, messageMaxBytes, encoder, decoder, onSpans);
   }
 
   public FakeSender messageMaxBytes(int messageMaxBytes) {
-    return new FakeSender(encoding, messageMaxBytes, messageEncoder, encoder, decoder, onSpans);
+    return new FakeSender(encoding, messageMaxBytes, encoder, decoder, onSpans);
   }
 
   @Override public int messageMaxBytes() {

--- a/core/src/test/java/zipkin2/reporter/SpanBytesEncoderTest.java
+++ b/core/src/test/java/zipkin2/reporter/SpanBytesEncoderTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpanBytesEncoderTest {
+  @Test void forEncoding() {
+    assertThat(SpanBytesEncoder.forEncoding(Encoding.JSON))
+      .isSameAs(SpanBytesEncoder.JSON_V2);
+    assertThat(SpanBytesEncoder.forEncoding(Encoding.PROTO3))
+      .isSameAs(SpanBytesEncoder.PROTO3);
+    assertThat(SpanBytesEncoder.forEncoding(Encoding.THRIFT))
+      .isSameAs(SpanBytesEncoder.THRIFT);
+  }
+}

--- a/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
+++ b/kafka/src/main/java/zipkin2/reporter/kafka/KafkaSender.java
@@ -28,7 +28,6 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.AwaitableCallback;
-import zipkin2.reporter.BytesMessageEncoder;
 import zipkin2.reporter.BytesMessageSender;
 import zipkin2.reporter.Call;
 import zipkin2.reporter.Callback;
@@ -204,7 +203,6 @@ public final class KafkaSender extends Sender {
   final Properties properties;
   final String topic;
   final Encoding encoding;
-  final BytesMessageEncoder encoder;
   final int messageMaxBytes;
 
   KafkaSender(Builder builder) {
@@ -212,7 +210,6 @@ public final class KafkaSender extends Sender {
     properties.putAll(builder.properties);
     topic = builder.topic;
     encoding = builder.encoding;
-    encoder = BytesMessageEncoder.forEncoding(builder.encoding);
     messageMaxBytes = builder.messageMaxBytes;
   }
 
@@ -260,7 +257,7 @@ public final class KafkaSender extends Sender {
   /** {@inheritDoc} */
   @Override @Deprecated public Call<Void> sendSpans(List<byte[]> encodedSpans) {
     if (closeCalled) throw new ClosedSenderException();
-    byte[] message = encoder.encode(encodedSpans);
+    byte[] message = encoding.encode(encodedSpans);
     return new KafkaCall(message);
   }
 
@@ -271,7 +268,7 @@ public final class KafkaSender extends Sender {
    */
   @Override public void send(List<byte[]> encodedSpans) {
     if (closeCalled) throw new ClosedSenderException();
-    send(encoder.encode(encodedSpans));
+    send(encoding.encode(encodedSpans));
   }
 
   void send(byte[] message) {

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -14,6 +14,7 @@
 package zipkin2.reporter.okhttp3;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
@@ -387,7 +388,7 @@ public final class OkHttpSender extends Sender {
   @Override @Deprecated public CheckResult check() {
     try {
       Request request = new Request.Builder().url(urlSupplier.get())
-        .post(RequestBody.create(MediaType.parse("application/json"), "[]")).build();
+        .post(encoder.encode(Collections.<byte[]>emptyList())).build();
       try (Response response = client.newCall(request).execute()) {
         if (!response.isSuccessful()) {
           return CheckResult.failed(new RuntimeException("check response failed: " + response));

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/RequestBodyMessageEncoder.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/RequestBodyMessageEncoder.java
@@ -43,8 +43,8 @@ enum RequestBodyMessageEncoder {
     final List<byte[]> values;
     final long contentLength;
 
-    StreamingRequestBody(Encoding encoding, MediaType contentType, List<byte[]> values) {
-      this.contentType = contentType;
+    StreamingRequestBody(Encoding encoding, List<byte[]> values) {
+      this.contentType = MediaType.parse(encoding.mediaType());
       this.values = values;
       this.contentLength = encoding.listSizeInBytes(values);
     }
@@ -59,10 +59,8 @@ enum RequestBodyMessageEncoder {
   }
 
   static final class JsonRequestBody extends StreamingRequestBody {
-    static final MediaType CONTENT_TYPE = MediaType.parse("application/json");
-
     JsonRequestBody(List<byte[]> values) {
-      super(Encoding.JSON, CONTENT_TYPE, values);
+      super(Encoding.JSON, values);
     }
 
     @Override public void writeTo(BufferedSink sink) throws IOException {
@@ -77,10 +75,8 @@ enum RequestBodyMessageEncoder {
   }
 
   static final class ThriftRequestBody extends StreamingRequestBody {
-    static final MediaType CONTENT_TYPE = MediaType.parse("application/x-thrift");
-
     ThriftRequestBody(List<byte[]> values) {
-      super(Encoding.THRIFT, CONTENT_TYPE, values);
+      super(Encoding.THRIFT, values);
     }
 
     @Override
@@ -102,10 +98,8 @@ enum RequestBodyMessageEncoder {
   }
 
   static final class Protobuf3RequestBody extends StreamingRequestBody {
-    static final MediaType CONTENT_TYPE = MediaType.parse("application/x-protobuf");
-
     Protobuf3RequestBody(List<byte[]> values) {
-      super(Encoding.PROTO3, CONTENT_TYPE, values);
+      super(Encoding.PROTO3, values);
     }
 
     @Override public void writeTo(BufferedSink sink) throws IOException {


### PR DESCRIPTION
I noticed in our senders and reporters there were multiple internal `switch` statements to get functions for a specific encoding. This is worse externally for zipkin-reporter-brave, as call sites need to duplicate switch statements, and also update them in order to allow another encoding. This is the case with PROTO3, for example, which is not yet supported for brave spans.

Here are the main changes:

* Add `Encoding.encode(List<byte[]>)` from the now deprecated `BytesMessageEncoder`.
* Add `Encoding.mediaType()`, useful in internal and external HTTP senders.
* Re-use the existing zipkin `SpanBytesEncoder.forEncoding(Encoding)` to reduce redundant switch logic.
* Add `MutableSpanBytesEncoder.forEncoding(Encoding)` for Brave
* Add `MutableSpanBytesEncoder.create(Encoding, Tag<Throwable>)` for Brave users who want an alt error tag.

With these changes in place, external senders such as those defined in spring-boot, can inherit sensible defaults without maintenance.

This acknowledges some specialized senders (such as okhttp) won't use `Encoding.encode(List<byte[]>)`. However, this change makes commodity senders a lot easier to write and configure, as they can now be driven by just `Encoding` and an endpoint.