### PR TITLE
brave: adds PROTO3 encoding

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,13 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+This product contains a modified part of Guava, distributed by Google:
+
+  * License: Apache License v2.0
+  * Homepage: https://github.com/google/guava
+
+This product contains a modified part of Okio, distributed by Square:
+
+  * License: Apache License v2.0
+  * Homepage: https://github.com/square/okio

--- a/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoderBenchmarks.java
@@ -84,7 +84,7 @@ public class MutableSpanBytesEncoderBenchmarks {
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
       .addProfiler("gc")
-      .include(".*" + MutableSpanBytesEncoderBenchmarks.class.getSimpleName())
+      .include(".*" + MutableSpanBytesEncoderBenchmarks.class.getSimpleName() + ".*")
       .build();
 
     new Runner(opt).run();

--- a/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoderBenchmarks.java
@@ -14,8 +14,6 @@
 package zipkin2.reporter.brave;
 
 import brave.handler.MutableSpan;
-import brave.handler.SpanHandler;
-import brave.propagation.TraceContext;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -31,7 +29,7 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import zipkin2.reporter.Reporter;
+import zipkin2.reporter.BytesEncoder;
 
 import static zipkin2.reporter.brave.MutableSpans.newBigClientSpan;
 import static zipkin2.reporter.brave.MutableSpans.newServerSpan;
@@ -43,26 +41,50 @@ import static zipkin2.reporter.brave.MutableSpans.newServerSpan;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
 @Threads(1)
-public class ZipkinSpanHandlerBenchmarks {
-  final SpanHandler handler =
-    ZipkinSpanHandler.newBuilder(Reporter.NOOP).alwaysReportSpans(true).build();
-  final TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
-  final MutableSpan serverSpan = newServerSpan();
-  final MutableSpan bigClientSpan = newBigClientSpan();
+public class MutableSpanBytesEncoderBenchmarks {
 
-  @Benchmark public boolean handleServerSpan() {
-    return handler.end(context, serverSpan, SpanHandler.Cause.FINISHED);
+  static final BytesEncoder<MutableSpan> jsonEncoder = MutableSpanBytesEncoder.JSON_V2;
+  static final BytesEncoder<MutableSpan> protoEncoder = MutableSpanBytesEncoder.PROTO3;
+  static final MutableSpan serverSpan = newServerSpan();
+  static final MutableSpan bigClientSpan = newBigClientSpan();
+
+  @Benchmark public int sizeInBytes_serverSpan_json() {
+    return jsonEncoder.sizeInBytes(serverSpan);
   }
 
-  @Benchmark public boolean handleBigClientSpan() {
-    return handler.end(context, bigClientSpan, SpanHandler.Cause.FINISHED);
+  @Benchmark public int sizeInBytes_serverSpan_proto() {
+    return protoEncoder.sizeInBytes(serverSpan);
+  }
+
+  @Benchmark public byte[] encode_serverSpan_json() {
+    return jsonEncoder.encode(serverSpan);
+  }
+
+  @Benchmark public byte[] encode_serverSpan_proto() {
+    return protoEncoder.encode(serverSpan);
+  }
+
+  @Benchmark public int sizeInBytes_bigClientSpan_json() {
+    return jsonEncoder.sizeInBytes(bigClientSpan);
+  }
+
+  @Benchmark public int sizeInBytes_bigClientSpan_proto() {
+    return protoEncoder.sizeInBytes(bigClientSpan);
+  }
+
+  @Benchmark public byte[] encode_bigClientSpan_json() {
+    return jsonEncoder.encode(bigClientSpan);
+  }
+
+  @Benchmark public byte[] encode_bigClientSpan_proto() {
+    return protoEncoder.encode(bigClientSpan);
   }
 
   // Convenience main entry-point
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
       .addProfiler("gc")
-      .include(".*" + ZipkinSpanHandlerBenchmarks.class.getSimpleName() + ".*")
+      .include(".*" + MutableSpanBytesEncoderBenchmarks.class.getSimpleName())
       .build();
 
     new Runner(opt).run();

--- a/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpans.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/brave/MutableSpans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 The OpenZipkin Authors
+ * Copyright 2016-2024 The OpenZipkin Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,36 +15,9 @@ package zipkin2.reporter.brave;
 
 import brave.Span;
 import brave.handler.MutableSpan;
-import java.util.concurrent.TimeUnit;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-@Measurement(iterations = 5, time = 1)
-@Warmup(iterations = 10, time = 1)
-@Fork(3)
-@BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
-@State(Scope.Thread)
-@Threads(1)
-public class MutableSpanBenchmarks {
-
-  @Benchmark public MutableSpan makeServerSpan() {
-    return newServerSpan();
-  }
-
-  public static MutableSpan newServerSpan() {
+class MutableSpans {
+  static MutableSpan newServerSpan() {
     MutableSpan span = new MutableSpan();
     span.name("get /");
     span.kind(Span.Kind.SERVER);
@@ -58,11 +31,7 @@ public class MutableSpanBenchmarks {
     return span;
   }
 
-  @Benchmark public MutableSpan makeBigClientSpan() {
-    return newBigClientSpan();
-  }
-
-  public static MutableSpan newBigClientSpan() {
+  static MutableSpan newBigClientSpan() {
     MutableSpan span = new MutableSpan();
     span.name("getuserinfobyaccesstoken");
     span.kind(Span.Kind.CLIENT);
@@ -77,19 +46,11 @@ public class MutableSpanBenchmarks {
     span.tag("http.path", "/thrift/shopForTalk");
     span.tag("http.status_code", "200");
     span.tag("http.url", "tbinary+h2c://abasdasgad.hsadas.ism/thrift/shopForTalk");
+    span.tag("error", "true");
     span.tag("instanceId", "line-wallet-api");
     span.tag("phase", "beta");
     span.tag("siteId", "shop");
+    span.error(new RuntimeException("ice cream"));
     return span;
-  }
-
-  // Convenience main entry-point
-  public static void main(String[] args) throws RunnerException {
-    Options opt = new OptionsBuilder()
-        .addProfiler("gc")
-        .include(".*" + MutableSpanBenchmarks.class.getSimpleName() + ".*")
-        .build();
-
-    new Runner(opt).run();
   }
 }

--- a/brave/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoder.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/MutableSpanBytesEncoder.java
@@ -34,6 +34,19 @@ public enum MutableSpanBytesEncoder implements BytesEncoder<MutableSpan> {
     @Override public byte[] encode(MutableSpan input) {
       return JsonV2Encoder.INSTANCE.encode(input);
     }
+  },
+  PROTO3 {
+    @Override public Encoding encoding() {
+      return Encoding.PROTO3;
+    }
+
+    @Override public int sizeInBytes(MutableSpan input) {
+      return ZipkinProto3Encoder.INSTANCE.sizeInBytes(input);
+    }
+
+    @Override public byte[] encode(MutableSpan input) {
+      return ZipkinProto3Encoder.INSTANCE.encode(input);
+    }
   };
 
   /**
@@ -48,7 +61,7 @@ public enum MutableSpanBytesEncoder implements BytesEncoder<MutableSpan> {
       case JSON:
         return JSON_V2;
       case PROTO3:
-        throw new UnsupportedOperationException("PROTO3 is not yet a built-in encoder");
+        return PROTO3;
       case THRIFT:
         throw new UnsupportedOperationException("THRIFT is not yet a built-in encoder");
       default: // BUG: as encoding is an enum!
@@ -70,7 +83,7 @@ public enum MutableSpanBytesEncoder implements BytesEncoder<MutableSpan> {
       case JSON:
         return new JsonV2Encoder(errorTag);
       case PROTO3:
-        throw new UnsupportedOperationException("PROTO3 is not yet a built-in encoder");
+        return new ZipkinProto3Encoder(errorTag);
       case THRIFT:
         throw new UnsupportedOperationException("THRIFT is not yet a built-in encoder");
       default: // BUG: as encoding is an enum!

--- a/brave/src/main/java/zipkin2/reporter/brave/ZipkinProto3Encoder.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/ZipkinProto3Encoder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tag;
+import brave.Tags;
+import brave.handler.MutableSpan;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Encoding;
+import zipkin2.reporter.brave.internal.ZipkinProto3Writer;
+
+final class ZipkinProto3Encoder implements BytesEncoder<MutableSpan> {
+  static final BytesEncoder<MutableSpan> INSTANCE = new ZipkinProto3Encoder(Tags.ERROR);
+  final ZipkinProto3Writer delegate;
+
+  ZipkinProto3Encoder(Tag<Throwable> errorTag) {
+    if (errorTag == null) throw new NullPointerException("errorTag == null");
+    this.delegate = new ZipkinProto3Writer(errorTag);
+  }
+
+  @Override public Encoding encoding() {
+    return Encoding.PROTO3;
+  }
+
+  @Override public int sizeInBytes(MutableSpan span) {
+    return delegate.sizeInBytes(span);
+  }
+
+  @Override public byte[] encode(MutableSpan span) {
+    return delegate.write(span);
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/IpParser.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/IpParser.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import java.nio.ByteBuffer;
+import zipkin2.reporter.internal.Nullable;
+
+class IpParser {
+  /** Originally from zipkin2.Endpoint.getIpv4Bytes */
+  @Nullable static byte[] getIpv4Bytes(String ipv4) {
+    byte[] result = new byte[4];
+    int pos = 0;
+    for (int i = 0, len = ipv4.length(); i < len; ) {
+      char ch = ipv4.charAt(i++);
+      int octet = ch - '0';
+      if (i == len || (ch = ipv4.charAt(i++)) == '.') {
+        // then we have a single digit octet
+        result[pos++] = (byte) octet;
+        continue;
+      }
+      // push the decimal
+      octet = (octet * 10) + (ch - '0');
+      if (i == len || (ch = ipv4.charAt(i++)) == '.') {
+        // then we have a two digit octet
+        result[pos++] = (byte) octet;
+        continue;
+      }
+      // otherwise, we have a three digit octet
+      octet = (octet * 10) + (ch - '0');
+      result[pos++] = (byte) octet;
+      i++; // skip the dot
+    }
+    return result;
+  }
+
+  // Begin code from com.google.common.net.InetAddresses.textToNumericFormatV6 23
+  static final int IPV6_PART_COUNT = 8;
+
+  @Nullable static byte[] getIpv6Bytes(String ipString) {
+    // An address can have [2..8] colons, and N colons make N+1 parts.
+    String[] parts = ipString.split(":", IPV6_PART_COUNT + 2);
+    if (parts.length < 3 || parts.length > IPV6_PART_COUNT + 1) {
+      return null;
+    }
+
+    // Disregarding the endpoints, find "::" with nothing in between.
+    // This indicates that a run of zeroes has been skipped.
+    int skipIndex = -1;
+    for (int i = 1; i < parts.length - 1; i++) {
+      if (parts[i].isEmpty()) {
+        if (skipIndex >= 0) {
+          return null; // Can't have more than one ::
+        }
+        skipIndex = i;
+      }
+    }
+
+    int partsHi; // Number of parts to copy from above/before the "::"
+    int partsLo; // Number of parts to copy from below/after the "::"
+    if (skipIndex >= 0) {
+      // If we found a "::", then check if it also covers the endpoints.
+      partsHi = skipIndex;
+      partsLo = parts.length - skipIndex - 1;
+      if (parts[0].isEmpty() && --partsHi != 0) {
+        return null; // ^: requires ^::
+      }
+      if (parts[parts.length - 1].isEmpty() && --partsLo != 0) {
+        return null; // :$ requires ::$
+      }
+    } else {
+      // Otherwise, allocate the entire address to partsHi. The endpoints
+      // could still be empty, but parseHextet() will check for that.
+      partsHi = parts.length;
+      partsLo = 0;
+    }
+
+    // If we found a ::, then we must have skipped at least one part.
+    // Otherwise, we must have exactly the right number of parts.
+    int partsSkipped = IPV6_PART_COUNT - (partsHi + partsLo);
+    if (!(skipIndex >= 0 ? partsSkipped >= 1 : partsSkipped == 0)) {
+      return null;
+    }
+
+    // Now parse the hextets into a byte array.
+    ByteBuffer rawBytes = ByteBuffer.allocate(2 * IPV6_PART_COUNT);
+    try {
+      for (int i = 0; i < partsHi; i++) {
+        rawBytes.putShort(parseHextet(parts[i]));
+      }
+      for (int i = 0; i < partsSkipped; i++) {
+        rawBytes.putShort((short) 0);
+      }
+      for (int i = partsLo; i > 0; i--) {
+        rawBytes.putShort(parseHextet(parts[parts.length - i]));
+      }
+    } catch (NumberFormatException ex) {
+      return null;
+    }
+    return rawBytes.array();
+  }
+
+  static short parseHextet(String ipPart) {
+    // Note: we already verified that this string contains only hex digits.
+    int hextet = Integer.parseInt(ipPart, 16);
+    if (hextet > 0xffff) {
+      throw new NumberFormatException();
+    }
+    return (short) hextet;
+  }
+  // End code from com.google.common.net.InetAddresses 23
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/Proto3Fields.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/Proto3Fields.java
@@ -13,17 +13,18 @@
  */
 package zipkin2.reporter.brave.internal;
 
-import zipkin2.Endpoint;
 import static zipkin2.reporter.brave.internal.WriteBuffer.utf8SizeInBytes;
 import static zipkin2.reporter.brave.internal.WriteBuffer.varintSizeInBytes;
 
 /**
- * Everything here assumes the field numbers are less than 16, implying a 1 byte tag.
+ * Stripped version of {@linkplain zipkin2.internal.Proto3Fields}, without decoding logic.
+ *
+ * <p>Everything here assumes the field numbers are less than 16, implying a 1 byte tag.
  */
 //@Immutable
 final class Proto3Fields {
   /**
-   * Define the wire types, except the deprecated ones (groups)
+   * Define the wire types we use.
    *
    * <p>See https://developers.google.com/protocol-buffers/docs/encoding#structure
    */
@@ -69,13 +70,6 @@ final class Proto3Fields {
     }
   }
 
-  /**
-   * Leniently skips out null, but not on empty string, allowing tag "error" -> "" to serialize
-   * properly.
-   *
-   * <p>This won't result in empty {@link brave.handler.MutableSpan#name()} or {@link Endpoint#serviceName()}
-   * because in both cases constructors coerce empty values to null.
-   */
   static abstract class LengthDelimitedField<T> extends Field {
     LengthDelimitedField(int key) {
       super(key);

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/Proto3Fields.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/Proto3Fields.java
@@ -13,6 +13,8 @@
  */
 package zipkin2.reporter.brave.internal;
 
+import zipkin2.reporter.internal.Nullable;
+
 import static zipkin2.reporter.brave.internal.WriteBuffer.utf8SizeInBytes;
 import static zipkin2.reporter.brave.internal.WriteBuffer.varintSizeInBytes;
 
@@ -106,6 +108,34 @@ final class Proto3Fields {
 
     @Override void writeValue(WriteBuffer b, byte[] bytes) {
       b.write(bytes);
+    }
+  }
+
+  static class IPv4Field extends LengthDelimitedField<String> {
+    IPv4Field(int key) {
+      super(key);
+    }
+
+    @Override int sizeOfValue(@Nullable String ipv4) {
+      return ipv4 != null ? 4 : 0;
+    }
+
+    @Override void writeValue(WriteBuffer b, String ipv4) {
+      IpWriter.writeIpv4Bytes(b, ipv4);
+    }
+  }
+
+  static class IPv6Field extends LengthDelimitedField<String> {
+    IPv6Field(int key) {
+      super(key);
+    }
+
+    @Override int sizeOfValue(String ipv6) {
+      return ipv6 != null ? 16 : 0;
+    }
+
+    @Override void writeValue(WriteBuffer b, String ipv6) {
+      IpWriter.writeIpv6Bytes(b, ipv6);
     }
   }
 

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/Proto3Fields.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/Proto3Fields.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import zipkin2.Endpoint;
+import static zipkin2.reporter.brave.internal.WriteBuffer.utf8SizeInBytes;
+import static zipkin2.reporter.brave.internal.WriteBuffer.varintSizeInBytes;
+
+/**
+ * Everything here assumes the field numbers are less than 16, implying a 1 byte tag.
+ */
+//@Immutable
+final class Proto3Fields {
+  /**
+   * Define the wire types, except the deprecated ones (groups)
+   *
+   * <p>See https://developers.google.com/protocol-buffers/docs/encoding#structure
+   */
+  static final int
+    WIRETYPE_VARINT = 0,
+    WIRETYPE_FIXED64 = 1,
+    WIRETYPE_LENGTH_DELIMITED = 2;
+
+  static class Field {
+    final int fieldNumber;
+    final int wireType;
+    /**
+     * "Each key in the streamed message is a varint with the value {@code (field_number << 3) |
+     * wire_type}"
+     *
+     * <p>See https://developers.google.com/protocol-buffers/docs/encoding#structure
+     */
+    final int key;
+
+    Field(int key) {
+      this(key >>> 3, key & (1 << 3) - 1, key);
+    }
+
+    Field(int fieldNumber, int wireType, int key) {
+      this.fieldNumber = fieldNumber;
+      this.wireType = wireType;
+      this.key = key;
+    }
+
+    static int fieldNumber(int key, int byteL) {
+      int fieldNumber = key >>> 3;
+      if (fieldNumber != 0) return fieldNumber;
+      throw new IllegalArgumentException("Malformed: fieldNumber was zero at byte " + byteL);
+    }
+
+    static int wireType(int key, int byteL) {
+      int wireType = key & (1 << 3) - 1;
+      if (wireType != 0 && wireType != 1 && wireType != 2 && wireType != 5) {
+        throw new IllegalArgumentException(
+          "Malformed: invalid wireType " + wireType + " at byte " + byteL);
+      }
+      return wireType;
+    }
+  }
+
+  /**
+   * Leniently skips out null, but not on empty string, allowing tag "error" -> "" to serialize
+   * properly.
+   *
+   * <p>This won't result in empty {@link brave.handler.MutableSpan#name()} or {@link Endpoint#serviceName()}
+   * because in both cases constructors coerce empty values to null.
+   */
+  static abstract class LengthDelimitedField<T> extends Field {
+    LengthDelimitedField(int key) {
+      super(key);
+      assert wireType == WIRETYPE_LENGTH_DELIMITED;
+    }
+
+    final int sizeInBytes(T value) {
+      if (value == null) return 0;
+      int sizeOfValue = sizeOfValue(value);
+      return sizeOfLengthDelimitedField(sizeOfValue);
+    }
+
+    final void write(WriteBuffer b, T value) {
+      if (value == null) return;
+      int sizeOfValue = sizeOfValue(value);
+      b.writeByte(key);
+      b.writeVarint(sizeOfValue); // length prefix
+      writeValue(b, value);
+    }
+
+    abstract int sizeOfValue(T value);
+
+    abstract void writeValue(WriteBuffer b, T value);
+  }
+
+  static class BytesField extends LengthDelimitedField<byte[]> {
+    BytesField(int key) {
+      super(key);
+    }
+
+    @Override int sizeOfValue(byte[] bytes) {
+      return bytes.length;
+    }
+
+    @Override void writeValue(WriteBuffer b, byte[] bytes) {
+      b.write(bytes);
+    }
+  }
+
+  static class HexField extends LengthDelimitedField<String> {
+    HexField(int key) {
+      super(key);
+    }
+
+    @Override int sizeOfValue(String hex) {
+      if (hex == null) return 0;
+      return hex.length() / 2;
+    }
+
+    @Override void writeValue(WriteBuffer b, String hex) {
+      // similar logic to okio.ByteString.decodeHex
+      for (int i = 0, length = hex.length(); i < length; i++) {
+        int d1 = decodeLowerHex(hex.charAt(i++)) << 4;
+        int d2 = decodeLowerHex(hex.charAt(i));
+        b.writeByte((byte) (d1 + d2));
+      }
+    }
+
+    static int decodeLowerHex(char c) {
+      if (c >= '0' && c <= '9') return c - '0';
+      if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+      throw new AssertionError("not lowerHex " + c); // bug
+    }
+  }
+
+  static class Utf8Field extends LengthDelimitedField<String> {
+    Utf8Field(int key) {
+      super(key);
+    }
+
+    @Override int sizeOfValue(String utf8) {
+      return utf8 != null ? utf8SizeInBytes(utf8) : 0;
+    }
+
+    @Override void writeValue(WriteBuffer b, String utf8) {
+      b.writeUtf8(utf8);
+    }
+  }
+
+  static final class Fixed64Field extends Field {
+    Fixed64Field(int key) {
+      super(key);
+      assert wireType == WIRETYPE_FIXED64;
+    }
+
+    void write(WriteBuffer b, long number) {
+      if (number == 0) return;
+      b.writeByte(key);
+      b.writeLongLe(number);
+    }
+
+    int sizeInBytes(long number) {
+      if (number == 0) return 0;
+      return 1 + 8; // tag + 8 byte number
+    }
+  }
+
+  static class VarintField extends Field {
+    VarintField(int key) {
+      super(key);
+      assert wireType == WIRETYPE_VARINT;
+    }
+
+    int sizeInBytes(int number) {
+      return number != 0 ? 1 + varintSizeInBytes(number) : 0; // tag + varint
+    }
+
+    void write(WriteBuffer b, int number) {
+      if (number == 0) return;
+      b.writeByte(key);
+      b.writeVarint(number);
+    }
+
+    int sizeInBytes(long number) {
+      return number != 0 ? 1 + varintSizeInBytes(number) : 0; // tag + varint
+    }
+
+    void write(WriteBuffer b, long number) {
+      if (number == 0) return;
+      b.writeByte(key);
+      b.writeVarint(number);
+    }
+  }
+
+  static final class BooleanField extends Field {
+    BooleanField(int key) {
+      super(key);
+      assert wireType == WIRETYPE_VARINT;
+    }
+
+    int sizeInBytes(boolean bool) {
+      return bool ? 2 : 0; // tag + varint
+    }
+
+    void write(WriteBuffer b, boolean bool) {
+      if (!bool) return;
+      b.writeByte(key);
+      b.writeByte(1);
+    }
+  }
+
+  static int sizeOfLengthDelimitedField(int sizeInBytes) {
+    return 1 + varintSizeInBytes(sizeInBytes) + sizeInBytes; // tag + len + bytes
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/WriteBuffer.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/WriteBuffer.java
@@ -35,6 +35,11 @@ final class WriteBuffer {
     buf[pos++] = (byte) (v & 0xff);
   }
 
+  public void writeShort(short v) {
+    buf[pos++] = (byte) ((v >> 8) & 0xff);
+    buf[pos++] = (byte) ((v) & 0xff);
+  }
+
   void write(byte[] v) {
     System.arraycopy(v, 0, buf, pos, v.length);
     pos += v.length;

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/WriteBuffer.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/WriteBuffer.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import static zipkin2.internal.HexCodec.HEX_DIGITS;
+
+/**
+ * Writes are unsafe as they do no bounds checks. This means you should take care to allocate or
+ * wrap an array at least as big as you need prior to writing. As it is possible to calculate size
+ * prior to writing, overrunning a buffer is a programming error.
+ */
+final class WriteBuffer {
+  final byte[] buf;
+  int pos;
+
+  WriteBuffer(byte[] buf) {
+    this.buf = buf;
+    this.pos = 0;
+  }
+
+  void writeByte(int v) {
+    buf[pos++] = (byte) (v & 0xff);
+  }
+
+  void write(byte[] v) {
+    System.arraycopy(v, 0, buf, pos, v.length);
+    pos += v.length;
+  }
+
+  void writeBackwards(long v) {
+    int lastPos = pos + asciiSizeInBytes(v); // We write backwards from right to left.
+    pos = lastPos;
+    while (v != 0) {
+      int digit = (int) (v % 10);
+      buf[--lastPos] = (byte) HEX_DIGITS[digit];
+      v /= 10;
+    }
+  }
+
+  int pos() {
+    return pos;
+  }
+
+  void writeAscii(String v) {
+    for (int i = 0, length = v.length(); i < length; i++) {
+      writeByte(v.charAt(i) & 0xff);
+    }
+  }
+
+  /**
+   * This transcodes a UTF-16 Java String to UTF-8 bytes.
+   *
+   * <p>This looks most similar to {@code io.netty.buffer.ByteBufUtil.writeUtf8(AbstractByteBuf,
+   * int, CharSequence, int)} v4.1, modified including features to address ASCII runs of text.
+   */
+  void writeUtf8(CharSequence string) {
+    for (int i = 0, len = string.length(); i < len; i++) {
+      char ch = string.charAt(i);
+      if (ch < 0x80) { // 7-bit ASCII character
+        writeByte(ch);
+        // This could be an ASCII run, or possibly entirely ASCII
+        while (i < len - 1) {
+          ch = string.charAt(i + 1);
+          if (ch >= 0x80) break;
+          i++;
+          writeByte(ch); // another 7-bit ASCII character
+        }
+      } else if (ch < 0x800) { // 11-bit character
+        writeByte(0xc0 | (ch >> 6));
+        writeByte(0x80 | (ch & 0x3f));
+      } else if (ch < 0xd800 || ch > 0xdfff) { // 16-bit character
+        writeByte(0xe0 | (ch >> 12));
+        writeByte(0x80 | ((ch >> 6) & 0x3f));
+        writeByte(0x80 | (ch & 0x3f));
+      } else { // Possibly a 21-bit character
+        if (!Character.isHighSurrogate(ch)) { // Malformed or not UTF-8
+          writeByte('?');
+          continue;
+        }
+        if (i == len - 1) { // Truncated or not UTF-8
+          writeByte('?');
+          break;
+        }
+        char low = string.charAt(++i);
+        if (!Character.isLowSurrogate(low)) { // Malformed or not UTF-8
+          writeByte('?');
+          writeByte(Character.isHighSurrogate(low) ? '?' : low);
+          continue;
+        }
+        // Write the 21-bit character using 4 bytes
+        // See http://www.unicode.org/versions/Unicode7.0.0/ch03.pdf#G2630
+        int codePoint = Character.toCodePoint(ch, low);
+        writeByte(0xf0 | (codePoint >> 18));
+        writeByte(0x80 | ((codePoint >> 12) & 0x3f));
+        writeByte(0x80 | ((codePoint >> 6) & 0x3f));
+        writeByte(0x80 | (codePoint & 0x3f));
+      }
+    }
+  }
+
+  // Adapted from okio.Buffer.writeDecimalLong
+  void writeAscii(long v) {
+    if (v == 0) {
+      writeByte('0');
+      return;
+    }
+
+    if (v == Long.MIN_VALUE) {
+      writeAscii("-9223372036854775808");
+      return;
+    }
+
+    if (v < 0) {
+      writeByte('-');
+      v = -v; // needs to be positive so we can use this for an array index
+    }
+
+    writeBackwards(v);
+  }
+
+  // com.squareup.wire.ProtoWriter.writeVarint v2.3.0
+  void writeVarint(int v) {
+    while ((v & ~0x7f) != 0) {
+      writeByte((byte) ((v & 0x7f) | 0x80));
+      v >>>= 7;
+    }
+    writeByte((byte) v);
+  }
+
+  // com.squareup.wire.ProtoWriter.writeVarint v2.3.0
+  void writeVarint(long v) {
+    while ((v & ~0x7fL) != 0) {
+      writeByte((byte) ((v & 0x7f) | 0x80));
+      v >>>= 7;
+    }
+    writeByte((byte) v);
+  }
+
+  void writeLongLe(long v) {
+    writeByte((byte) (v & 0xff));
+    writeByte((byte) ((v >> 8) & 0xff));
+    writeByte((byte) ((v >> 16) & 0xff));
+    writeByte((byte) ((v >> 24) & 0xff));
+    writeByte((byte) ((v >> 32) & 0xff));
+    writeByte((byte) ((v >> 40) & 0xff));
+    writeByte((byte) ((v >> 48) & 0xff));
+    writeByte((byte) ((v >> 56) & 0xff));
+  }
+
+  /**
+   * This returns the bytes needed to transcode a UTF-16 Java String to UTF-8 bytes.
+   *
+   * <p>Originally based on
+   * http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
+   *
+   * <p>Later, ASCII run and malformed surrogate logic borrowed from okio.Utf8
+   */
+  // TODO: benchmark vs https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/Utf8.java#L240
+  // there seem to be less branches for for strings without surrogates
+  static int utf8SizeInBytes(CharSequence string) {
+    int sizeInBytes = 0;
+    for (int i = 0, len = string.length(); i < len; i++) {
+      char ch = string.charAt(i);
+      if (ch < 0x80) {
+        sizeInBytes++; // 7-bit ASCII character
+        // This could be an ASCII run, or possibly entirely ASCII
+        while (i < len - 1) {
+          ch = string.charAt(i + 1);
+          if (ch >= 0x80) break;
+          i++;
+          sizeInBytes++; // another 7-bit ASCII character
+        }
+      } else if (ch < 0x800) {
+        sizeInBytes += 2; // 11-bit character
+      } else if (ch < 0xd800 || ch > 0xdfff) {
+        sizeInBytes += 3; // 16-bit character
+      } else {
+        int low = i + 1 < len ? string.charAt(i + 1) : 0;
+        if (ch > 0xdbff || low < 0xdc00 || low > 0xdfff) {
+          sizeInBytes++; // A malformed surrogate, which yields '?'.
+        } else {
+          // A 21-bit character
+          sizeInBytes += 4;
+          i++;
+        }
+      }
+    }
+    return sizeInBytes;
+  }
+
+  /**
+   * Binary search for character width which favors matching lower numbers.
+   *
+   * <p>Adapted from okio.Buffer
+   */
+  static int asciiSizeInBytes(long v) {
+    if (v == 0) return 1;
+    if (v == Long.MIN_VALUE) return 20;
+
+    boolean negative = false;
+    if (v < 0) {
+      v = -v; // making this positive allows us to compare using less-than
+      negative = true;
+    }
+    int width =
+      v < 100000000L
+        ? v < 10000L
+        ? v < 100L ? v < 10L ? 1 : 2 : v < 1000L ? 3 : 4
+        : v < 1000000L ? v < 100000L ? 5 : 6 : v < 10000000L ? 7 : 8
+        : v < 1000000000000L
+          ? v < 10000000000L ? v < 1000000000L ? 9 : 10 : v < 100000000000L ? 11 : 12
+          : v < 1000000000000000L
+            ? v < 10000000000000L ? 13 : v < 100000000000000L ? 14 : 15
+            : v < 100000000000000000L
+              ? v < 10000000000000000L ? 16 : 17
+              : v < 1000000000000000000L ? 18 : 19;
+    return negative ? width + 1 : width; // conditionally add room for negative sign
+  }
+
+  /**
+   * A base 128 varint encodes 7 bits at a time, this checks how many bytes are needed to represent
+   * the value.
+   *
+   * <p>See https://developers.google.com/protocol-buffers/docs/encoding#varints
+   *
+   * <p>This logic is the same as {@code com.squareup.wire.ProtoWriter.varint32Size} v2.3.0 which
+   * benchmarked faster than loop variants of the frequently copy/pasted VarInt.varIntSize
+   */
+  static int varintSizeInBytes(int value) {
+    if ((value & (0xffffffff << 7)) == 0) return 1;
+    if ((value & (0xffffffff << 14)) == 0) return 2;
+    if ((value & (0xffffffff << 21)) == 0) return 3;
+    if ((value & (0xffffffff << 28)) == 0) return 4;
+    return 5;
+  }
+
+  /** Like {@link #varintSizeInBytes(int)}, except for uint64. */
+  // TODO: benchmark vs https://github.com/protocolbuffers/protobuf/blob/master/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java#L770
+  // Since trace IDs are random, I guess they cover the entire spectrum of varint sizes and probably would especially benefit from this.
+  static int varintSizeInBytes(long v) {
+    if ((v & (0xffffffffffffffffL << 7)) == 0) return 1;
+    if ((v & (0xffffffffffffffffL << 14)) == 0) return 2;
+    if ((v & (0xffffffffffffffffL << 21)) == 0) return 3;
+    if ((v & (0xffffffffffffffffL << 28)) == 0) return 4;
+    if ((v & (0xffffffffffffffffL << 35)) == 0) return 5;
+    if ((v & (0xffffffffffffffffL << 42)) == 0) return 6;
+    if ((v & (0xffffffffffffffffL << 49)) == 0) return 7;
+    if ((v & (0xffffffffffffffffL << 56)) == 0) return 8;
+    if ((v & (0xffffffffffffffffL << 63)) == 0) return 9;
+    return 10;
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/WriteBuffer.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/WriteBuffer.java
@@ -16,7 +16,9 @@ package zipkin2.reporter.brave.internal;
 import static zipkin2.internal.HexCodec.HEX_DIGITS;
 
 /**
- * Writes are unsafe as they do no bounds checks. This means you should take care to allocate or
+ * Stripped version of {@linkplain zipkin2.internal.WriteBuffer}, without fields we don't use.
+ *
+ * <p>Writes are unsafe as they do no bounds checks. This means you should take care to allocate or
  * wrap an array at least as big as you need prior to writing. As it is possible to calculate size
  * prior to writing, overrunning a buffer is a programming error.
  */

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Fields.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Fields.java
@@ -15,9 +15,9 @@ package zipkin2.reporter.brave.internal;
 
 import brave.Tag;
 import brave.handler.MutableSpan;
-import zipkin2.reporter.internal.Nullable;
 import zipkin2.reporter.brave.internal.Proto3Fields.BooleanField;
 import zipkin2.reporter.brave.internal.Proto3Fields.Utf8Field;
+import zipkin2.reporter.internal.Nullable;
 
 import static zipkin2.reporter.brave.internal.IpParser.getIpv4Bytes;
 import static zipkin2.reporter.brave.internal.IpParser.getIpv6Bytes;
@@ -31,7 +31,15 @@ import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_LENGTH_DELIM
 import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_VARINT;
 import static zipkin2.reporter.brave.internal.Proto3Fields.sizeOfLengthDelimitedField;
 
-/** Keys are used in this class because while verbose, it allows us to use switch statements */
+/**
+ * Stripped version of {@linkplain zipkin2.internal.Proto3ZipkinFields}, without decoding logic.
+ *
+ * <p>Also, brave has no structs for things like annotations or endpoints, so we have to flatten
+ * some logic.
+ *
+ * <p>Finally, brave has more involved error logic, so this logic was derived from
+ * {@link brave.internal.codec.ZipkinV2JsonWriter}.
+ */
 //@Immutable
 final class ZipkinProto3Fields {
   static class EndpointField extends Proto3Fields.Field {

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Fields.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Fields.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+import zipkin2.reporter.internal.Nullable;
+import zipkin2.reporter.brave.internal.Proto3Fields.BooleanField;
+import zipkin2.reporter.brave.internal.Proto3Fields.Utf8Field;
+
+import static zipkin2.reporter.brave.internal.IpParser.getIpv4Bytes;
+import static zipkin2.reporter.brave.internal.IpParser.getIpv6Bytes;
+import static zipkin2.reporter.brave.internal.Proto3Fields.BytesField;
+import static zipkin2.reporter.brave.internal.Proto3Fields.Fixed64Field;
+import static zipkin2.reporter.brave.internal.Proto3Fields.HexField;
+import static zipkin2.reporter.brave.internal.Proto3Fields.LengthDelimitedField;
+import static zipkin2.reporter.brave.internal.Proto3Fields.VarintField;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_FIXED64;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_VARINT;
+import static zipkin2.reporter.brave.internal.Proto3Fields.sizeOfLengthDelimitedField;
+
+/** Keys are used in this class because while verbose, it allows us to use switch statements */
+//@Immutable
+final class ZipkinProto3Fields {
+  static class EndpointField extends Proto3Fields.Field {
+    static final int SERVICE_NAME_KEY = (1 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int IPV4_KEY = (2 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int IPV6_KEY = (3 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int PORT_KEY = (4 << 3) | WIRETYPE_VARINT;
+
+    static final Utf8Field SERVICE_NAME = new Utf8Field(SERVICE_NAME_KEY);
+    static final BytesField IPV4 = new BytesField(IPV4_KEY);
+    static final BytesField IPV6 = new BytesField(IPV6_KEY);
+    static final VarintField PORT = new VarintField(PORT_KEY);
+
+    EndpointField(int key) {
+      super(key);
+      assert wireType == WIRETYPE_LENGTH_DELIMITED;
+    }
+
+    int sizeInBytes(@Nullable String serviceName, @Nullable String ip, int port) {
+      int sizeOfValue = sizeOfValue(serviceName, ip, port);
+      // size is possibly zero, so don't write an empty field!
+      return sizeOfValue > 0 ? sizeOfLengthDelimitedField(sizeOfValue) : 0;
+    }
+
+    static int sizeOfValue(@Nullable String serviceName, @Nullable String ip, int port) {
+      int sizeInBytes = 0;
+      sizeInBytes += SERVICE_NAME.sizeInBytes(serviceName);
+      if (ip != null) {
+        // MutableSpan unwraps any Ipv4 from a mapped or compatability mode IPv6.
+        if (ip.indexOf('.') != -1) {
+          sizeInBytes += 6; // tag + size of 4 + 4 bytes
+        } else {
+          sizeInBytes += 18; // tag + size of 16 + 16 bytes
+        }
+      }
+      sizeInBytes += PORT.sizeInBytes(port);
+      return sizeInBytes;
+    }
+
+    void write(WriteBuffer b, @Nullable String serviceName, @Nullable String ip, int port) {
+      int sizeOfValue = sizeOfValue(serviceName, ip, port);
+      if (sizeOfValue == 0) return; // special-case empty endpoint
+      b.writeByte(key);
+      b.writeVarint(sizeOfValue); // length prefix
+      SERVICE_NAME.write(b, serviceName);
+      if (ip != null) {
+        // MutableSpan unwraps any Ipv4 from a mapped or compatability mode IPv6.
+        if (ip.indexOf('.') != -1) {
+          IPV4.write(b, getIpv4Bytes(ip));
+        } else {
+          IPV6.write(b, getIpv6Bytes(ip));
+        }
+      }
+      PORT.write(b, port);
+    }
+  }
+
+  static class AnnotationField extends Proto3Fields.Field {
+    static final int TIMESTAMP_KEY = (1 << 3) | WIRETYPE_FIXED64;
+    static final int VALUE_KEY = (2 << 3) | WIRETYPE_LENGTH_DELIMITED;
+
+    static final Fixed64Field TIMESTAMP = new Fixed64Field(TIMESTAMP_KEY);
+    static final Utf8Field VALUE = new Utf8Field(VALUE_KEY);
+
+    AnnotationField(int key) {
+      super(key);
+      assert wireType == WIRETYPE_LENGTH_DELIMITED;
+    }
+
+    int sizeInBytes(long timestamp, String value) {
+      int sizeOfValue = sizeOfValue(timestamp, value);
+      return sizeOfLengthDelimitedField(sizeOfValue);
+    }
+
+    static int sizeOfValue(long timestamp, String value) {
+      return TIMESTAMP.sizeInBytes(timestamp) + VALUE.sizeInBytes(value);
+    }
+
+    final void write(WriteBuffer b, long timestamp, String value) {
+      int sizeOfValue = sizeOfValue(timestamp, value);
+      b.writeByte(key);
+      b.writeVarint(sizeOfValue); // length prefix
+      TIMESTAMP.write(b, timestamp);
+      VALUE.write(b, value);
+    }
+  }
+
+  static final class TagField extends Proto3Fields.Field {
+    // map<string,string> in proto is a special field with key, value
+    static final int KEY_KEY = (1 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int VALUE_KEY = (2 << 3) | WIRETYPE_LENGTH_DELIMITED;
+
+    static final Utf8Field KEY = new Utf8Field(KEY_KEY);
+    static final Utf8Field VALUE = new Utf8Field(VALUE_KEY);
+
+    TagField(int key) {
+      super(key);
+      assert wireType == WIRETYPE_LENGTH_DELIMITED;
+    }
+
+    int sizeInBytes(String key, String value) {
+      int sizeInBytes = sizeOfValue(key, value);
+      return sizeOfLengthDelimitedField(sizeInBytes);
+    }
+
+    static int sizeOfValue(String key, String value) {
+      return KEY.sizeInBytes(key) + VALUE.sizeInBytes(value);
+    }
+
+    void write(WriteBuffer b, String key, String value) {
+      if (value == null) return;
+      int sizeOfValue = sizeOfValue(key, value);
+      b.writeByte(this.key);
+      b.writeVarint(sizeOfValue); // length prefix
+      KEY.write(b, key);
+      VALUE.write(b, value);
+    }
+  }
+
+  /** This is the only field in the ListOfSpans type */
+  static class SpanField extends LengthDelimitedField<MutableSpan> {
+    static final int TRACE_ID_KEY = (1 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int PARENT_ID_KEY = (2 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int ID_KEY = (3 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int KIND_KEY = (4 << 3) | WIRETYPE_VARINT;
+    static final int NAME_KEY = (5 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int TIMESTAMP_KEY = (6 << 3) | WIRETYPE_FIXED64;
+    static final int DURATION_KEY = (7 << 3) | WIRETYPE_VARINT;
+    static final int LOCAL_ENDPOINT_KEY = (8 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int REMOTE_ENDPOINT_KEY = (9 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int ANNOTATION_KEY = (10 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int TAG_KEY = (11 << 3) | WIRETYPE_LENGTH_DELIMITED;
+    static final int DEBUG_KEY = (12 << 3) | WIRETYPE_VARINT;
+    static final int SHARED_KEY = (13 << 3) | WIRETYPE_VARINT;
+
+    static final HexField TRACE_ID = new HexField(TRACE_ID_KEY);
+    static final HexField PARENT_ID = new HexField(PARENT_ID_KEY);
+    static final HexField ID = new HexField(ID_KEY);
+    static final VarintField KIND = new VarintField(KIND_KEY);
+    static final Utf8Field NAME = new Utf8Field(NAME_KEY);
+    static final Fixed64Field TIMESTAMP = new Fixed64Field(TIMESTAMP_KEY);
+    static final VarintField DURATION = new VarintField(DURATION_KEY);
+    static final EndpointField LOCAL_ENDPOINT = new EndpointField(LOCAL_ENDPOINT_KEY);
+    static final EndpointField REMOTE_ENDPOINT = new EndpointField(REMOTE_ENDPOINT_KEY);
+    static final AnnotationField ANNOTATION = new AnnotationField(ANNOTATION_KEY);
+    static final TagField TAG = new TagField(TAG_KEY);
+    static final BooleanField DEBUG = new BooleanField(DEBUG_KEY);
+    static final BooleanField SHARED = new BooleanField(SHARED_KEY);
+
+    final Tag<Throwable> errorTag;
+
+    SpanField(Tag<Throwable> errorTag) {
+      super((1 << 3) | WIRETYPE_LENGTH_DELIMITED);
+      if (errorTag == null) throw new NullPointerException("errorTag == null");
+      this.errorTag = errorTag;
+    }
+
+    @Override int sizeOfValue(MutableSpan span) {
+      int sizeInBytes = TRACE_ID.sizeInBytes(span.traceId());
+      sizeInBytes += PARENT_ID.sizeInBytes(span.parentId());
+      sizeInBytes += ID.sizeInBytes(span.id());
+      sizeInBytes += KIND.sizeInBytes(span.kind() != null ? 1 : 0);
+      sizeInBytes += NAME.sizeInBytes(span.name());
+      if (span.startTimestamp() != 0L) {
+        sizeInBytes += TIMESTAMP.sizeInBytes(span.startTimestamp());
+        if (span.finishTimestamp() != 0L) {
+          sizeInBytes += DURATION.sizeInBytes(span.finishTimestamp() - span.startTimestamp());
+        }
+      }
+
+      sizeInBytes +=
+        LOCAL_ENDPOINT.sizeInBytes(span.localServiceName(), span.localIp(), span.localPort());
+      sizeInBytes +=
+        REMOTE_ENDPOINT.sizeInBytes(span.remoteServiceName(), span.remoteIp(), span.remotePort());
+
+      int annotationLength = span.annotationCount();
+      for (int i = 0; i < annotationLength; i++) {
+        sizeInBytes +=
+          ANNOTATION.sizeInBytes(span.annotationTimestampAt(i), span.annotationValueAt(i));
+      }
+
+      int tagCount = span.tagCount();
+      String errorValue = errorTag.value(span.error(), null);
+      String errorTagName = errorValue != null ? errorTag.key() : null;
+      boolean writeError = errorTagName != null;
+      if (tagCount > 0 || writeError) {
+        for (int i = 0; i < tagCount; i++) {
+          String key = span.tagKeyAt(i);
+          if (writeError && key.equals(errorTagName)) writeError = false;
+          sizeInBytes += TAG.sizeInBytes(key, span.tagValueAt(i));
+        }
+        if (writeError) {
+          sizeInBytes += TAG.sizeInBytes(errorTagName, errorValue);
+        }
+      }
+
+      sizeInBytes += DEBUG.sizeInBytes(Boolean.TRUE.equals(span.debug()));
+      sizeInBytes += SHARED.sizeInBytes(Boolean.TRUE.equals(span.shared()));
+      return sizeInBytes;
+    }
+
+    @Override void writeValue(WriteBuffer b, MutableSpan span) {
+      TRACE_ID.write(b, span.traceId());
+      PARENT_ID.write(b, span.parentId());
+      ID.write(b, span.id());
+      KIND.write(b, toByte(span.kind()));
+      NAME.write(b, span.name());
+
+      if (span.startTimestamp() != 0L) {
+        TIMESTAMP.write(b, span.startTimestamp());
+        if (span.finishTimestamp() != 0L) {
+          DURATION.write(b, span.finishTimestamp() - span.startTimestamp());
+        }
+      }
+
+      LOCAL_ENDPOINT.write(b, span.localServiceName(), span.localIp(), span.localPort());
+      REMOTE_ENDPOINT.write(b, span.remoteServiceName(), span.remoteIp(), span.remotePort());
+
+      int annotationLength = span.annotationCount();
+      for (int i = 0; i < annotationLength; i++) {
+        ANNOTATION.write(b, span.annotationTimestampAt(i), span.annotationValueAt(i));
+      }
+
+      int tagCount = span.tagCount();
+      String errorValue = errorTag.value(span.error(), null);
+      String errorTagName = errorValue != null ? errorTag.key() : null;
+      boolean writeError = errorTagName != null;
+      if (tagCount > 0 || writeError) {
+        for (int i = 0; i < tagCount; i++) {
+          String key = span.tagKeyAt(i);
+          if (writeError && key.equals(errorTagName)) writeError = false;
+          TAG.write(b, key, span.tagValueAt(i));
+        }
+        if (writeError) {
+          TAG.write(b, errorTagName, errorValue);
+        }
+      }
+
+      SpanField.DEBUG.write(b, Boolean.TRUE.equals(span.debug()));
+      SpanField.SHARED.write(b, Boolean.TRUE.equals(span.shared()));
+    }
+
+    // in java, there's no zero index for unknown
+    int toByte(brave.Span.Kind kind) {
+      return kind != null ? kind.ordinal() + 1 : 0;
+    }
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Writer.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Writer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+
+import static zipkin2.reporter.brave.internal.Proto3Fields.sizeOfLengthDelimitedField;
+
+//@Immutable
+public final class ZipkinProto3Writer {
+
+  final ZipkinProto3Fields.SpanField spanField;
+
+  public ZipkinProto3Writer(Tag<Throwable> errorTag) {
+    this.spanField = new ZipkinProto3Fields.SpanField(errorTag);
+  }
+
+  public int sizeInBytes(MutableSpan span) {
+    return spanField.sizeInBytes(span);
+  }
+
+  @Override public String toString() {
+    return "MutableSpan";
+  }
+
+  public byte[] write(MutableSpan span) {
+    int sizeOfSpan = spanField.sizeOfValue(span);
+    byte[] result = new byte[sizeOfLengthDelimitedField(sizeOfSpan)];
+    WriteBuffer buf = new WriteBuffer(result);
+    buf.writeByte(spanField.key);
+    buf.writeVarint(sizeOfSpan); // length prefix
+    spanField.writeValue(buf, span);
+    return result;
+  }
+}

--- a/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Writer.java
+++ b/brave/src/main/java/zipkin2/reporter/brave/internal/ZipkinProto3Writer.java
@@ -18,7 +18,10 @@ import brave.handler.MutableSpan;
 
 import static zipkin2.reporter.brave.internal.Proto3Fields.sizeOfLengthDelimitedField;
 
-//@Immutable
+/**
+ * Stripped version of {@linkplain zipkin2.internal.Proto3SpanWriter}, which only can write a single
+ * span at a time.
+ */
 public final class ZipkinProto3Writer {
 
   final ZipkinProto3Fields.SpanField spanField;

--- a/brave/src/test/java/zipkin2/reporter/brave/AsyncZipkinSpanHandlerTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/AsyncZipkinSpanHandlerTest.java
@@ -31,13 +31,14 @@ import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Sender;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AsyncZipkinSpanHandlerTest {
-  @Test void build_protoNotYetSupported() {
+  @Test void build_proto() {
     FakeSender sender = FakeSender.create().encoding(Encoding.PROTO3);
-    AsyncZipkinSpanHandler.Builder builder = AsyncZipkinSpanHandler.newBuilder(sender);
-    assertThrows(UnsupportedOperationException.class, builder::build);
+    try (AsyncZipkinSpanHandler spanReporter = AsyncZipkinSpanHandler.newBuilder(sender).build()) {
+      assertThat(spanReporter).isNotNull();
+      assertThat(spanReporter.encoding).isEqualTo(Encoding.PROTO3);
+    }
   }
 
   /** Ready for custom format such as OTLP or Stackdriver. */

--- a/brave/src/test/java/zipkin2/reporter/brave/JsonV2RoundTripTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/JsonV2RoundTripTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import zipkin2.codec.SpanBytesDecoder;
+
+class JsonV2RoundTripTest extends RoundTripTest {
+  JsonV2RoundTripTest() {
+    super(MutableSpanBytesEncoder.JSON_V2, SpanBytesDecoder.JSON_V2);
+  }
+
+  @Override @Disabled @Test void differentErrorTagName() {
+    // awaiting https://github.com/openzipkin/brave/pull/1415 to be released
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/JsonV2RoundTripTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/JsonV2RoundTripTest.java
@@ -13,16 +13,10 @@
  */
 package zipkin2.reporter.brave;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import zipkin2.codec.SpanBytesDecoder;
 
 class JsonV2RoundTripTest extends RoundTripTest {
   JsonV2RoundTripTest() {
     super(MutableSpanBytesEncoder.JSON_V2, SpanBytesDecoder.JSON_V2);
-  }
-
-  @Override @Disabled @Test void differentErrorTagName() {
-    // awaiting https://github.com/openzipkin/brave/pull/1415 to be released
   }
 }

--- a/brave/src/test/java/zipkin2/reporter/brave/MutableSpanBytesEncoderTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/MutableSpanBytesEncoderTest.java
@@ -17,7 +17,6 @@ import brave.Tag;
 import brave.Tags;
 import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
-import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.Encoding;

--- a/brave/src/test/java/zipkin2/reporter/brave/Proto3RoundTripTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/Proto3RoundTripTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import zipkin2.codec.SpanBytesDecoder;
+
+class Proto3RoundTripTest extends RoundTripTest {
+  Proto3RoundTripTest() {
+    super(MutableSpanBytesEncoder.PROTO3, SpanBytesDecoder.PROTO3);
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/RoundTripTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/RoundTripTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Tag;
+import brave.handler.MutableSpan;
+import brave.propagation.TraceContext;
+import org.junit.jupiter.api.Test;
+import zipkin2.Endpoint;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+import zipkin2.codec.BytesDecoder;
+import zipkin2.reporter.BytesEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.reporter.brave.ZipkinSpanConverter.CLIENT_SPAN;
+
+abstract class RoundTripTest {
+
+  final BytesEncoder<MutableSpan> encoder;
+  final BytesDecoder<Span> zipkinDecoder;
+
+  RoundTripTest(BytesEncoder<MutableSpan> encoder, BytesDecoder<Span> zipkinDecoder) {
+    this.encoder = encoder;
+    this.zipkinDecoder = zipkinDecoder;
+  }
+
+  @Test void clientSpan() {
+    assertDecodableByZipkin(CLIENT_SPAN, TestObjects.CLIENT_SPAN);
+  }
+
+  @Test void specialCharacters() {
+    MutableSpan span = newSpan();
+    span.name("\u2028 and \u2029");
+    span.localServiceName("\"foo");
+    span.tag("hello \n", "\t\b");
+    span.annotate(1L, "\uD83D\uDCA9");
+
+    assertDecodableByZipkin(span, newZipkinSpan()
+      .name("\u2028 and \u2029")
+      .localEndpoint(Endpoint.newBuilder().serviceName("\"foo").build())
+      .putTag("hello \n", "\t\b")
+      .addAnnotation(1L, "\uD83D\uDCA9").build());
+  }
+
+  @Test void errorTag() {
+    MutableSpan span = newSpan();
+    span.tag("a", "1");
+    span.tag("error", "true");
+    span.tag("b", "2");
+
+    assertDecodableByZipkin(span, newZipkinSpan()
+      .putTag("a", "1")
+      .putTag("error", "true")
+      .putTag("b", "2").build());
+  }
+
+  @Test void error() {
+    MutableSpan span = newSpan();
+    span.tag("a", "1");
+    span.tag("b", "2");
+    span.error(new RuntimeException("ice cream"));
+
+    assertDecodableByZipkin(span, newZipkinSpan()
+      .putTag("a", "1")
+      .putTag("error", "ice cream")
+      .putTag("b", "2").build());
+  }
+
+  @Test void existingErrorTagWins() {
+    MutableSpan span = newSpan();
+    span.tag("a", "1");
+    span.tag("error", "true");
+    span.tag("b", "2");
+    span.error(new RuntimeException("ice cream"));
+
+    assertDecodableByZipkin(span, newZipkinSpan()
+      .putTag("a", "1")
+      .putTag("error", "true")
+      .putTag("b", "2").build());
+  }
+
+  @Test void differentErrorTagName() {
+    BytesEncoder<MutableSpan> encoder =
+      MutableSpanBytesEncoder.create(this.encoder.encoding(), new Tag<Throwable>("exception") {
+        @Override protected String parseValue(Throwable input, TraceContext context) {
+          return input.getMessage();
+        }
+      });
+
+    MutableSpan span = newSpan();
+    span.tag("a", "1");
+    span.tag("error", "true");
+    span.tag("b", "2");
+    span.error(new RuntimeException("ice cream"));
+
+    assertDecodableByZipkin(encoder, span, newZipkinSpan()
+      .putTag("a", "1")
+      .putTag("error", "true")
+      .putTag("b", "2")
+      .putTag("exception", "ice cream")
+      .build());
+  }
+
+  @Test void localIp_mappedIpv4() {
+    String mappedIpv4 = "::FFFF:43.0.192.2";
+
+    MutableSpan span = newSpan();
+    span.localIp(mappedIpv4);
+
+    assertDecodableByZipkin(span, newZipkinSpan()
+      .localEndpoint(Endpoint.newBuilder().ip(mappedIpv4).build())
+      .build());
+  }
+
+  @Test void localIp_compatIpv4() {
+    String compatIpv4 = "::0000:43.0.192.2";
+
+    MutableSpan span = newSpan();
+    span.localIp(compatIpv4);
+
+    assertDecodableByZipkin(span, newZipkinSpan()
+      .localEndpoint(Endpoint.newBuilder().ip(compatIpv4).build())
+      .build());
+  }
+
+  @Test void localIp_notMappedIpv4() {
+    String invalid = "::ffef:43.0.192.2";
+
+    MutableSpan span = newSpan();
+    span.localIp(invalid);
+
+    // Prove that the zipkin logic knows this is invalid
+    Endpoint endpoint = Endpoint.newBuilder().ip(invalid).build();
+    assertThat(endpoint.ipv4()).isNull();
+    assertThat(endpoint.ipv6()).isNull();
+
+    // Prove we didn't encode the local IP!
+    assertDecodableByZipkin(span, newZipkinSpan().build());
+  }
+
+  void assertDecodableByZipkin(MutableSpan span, Span zSpan) {
+    assertDecodableByZipkin(encoder, span, zSpan);
+  }
+
+  void assertDecodableByZipkin(BytesEncoder<MutableSpan> encoder, MutableSpan span, Span zSpan) {
+    int size = encoder.sizeInBytes(span);
+    byte[] encoded = encoder.encode(span);
+    assertThat(encoded).hasSize(size);
+
+    // Zipkin doesn't maintain the same tag order, so we need to use equals.
+    Span decoded = zipkinDecoder.decodeOne(encoded);
+    assertThat(decoded).isEqualTo(zSpan);
+  }
+
+  static MutableSpan newSpan() {
+    MutableSpan span = new MutableSpan();
+    span.traceId("1");
+    span.id("2");
+    return span;
+  }
+
+  static Span.Builder newZipkinSpan() {
+    return Span.newBuilder().traceId("1").id("2");
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanConverter.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/ZipkinSpanConverter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave;
+
+import brave.Span;
+import brave.handler.MutableSpan;
+import java.util.Map;
+import zipkin2.Annotation;
+import zipkin2.Endpoint;
+import zipkin2.TestObjects;
+
+public class ZipkinSpanConverter {
+  public static final MutableSpan CLIENT_SPAN = toMutableSpan(TestObjects.CLIENT_SPAN);
+
+  public static MutableSpan toMutableSpan(zipkin2.Span zSpan) {
+    MutableSpan span = new MutableSpan();
+    span.traceId(zSpan.traceId());
+    span.parentId(zSpan.parentId());
+    span.id(zSpan.id());
+    span.name(zSpan.name());
+    switch (zSpan.kind()) {
+      case CLIENT:
+        span.kind(Span.Kind.CLIENT);
+        break;
+      case SERVER:
+        span.kind(Span.Kind.SERVER);
+        break;
+      case PRODUCER:
+        span.kind(Span.Kind.PRODUCER);
+        break;
+      case CONSUMER:
+        span.kind(Span.Kind.CONSUMER);
+        break;
+    }
+    span.localServiceName(zSpan.localServiceName());
+    span.localIp(maybeIp(zSpan.localEndpoint()));
+    span.localPort(maybePort(zSpan.localEndpoint()));
+    span.remoteServiceName(zSpan.remoteServiceName());
+    span.remoteIpAndPort(maybeIp(zSpan.remoteEndpoint()), maybePort(zSpan.remoteEndpoint()));
+    span.startTimestamp(zSpan.timestampAsLong());
+    span.finishTimestamp(zSpan.timestampAsLong() + zSpan.durationAsLong());
+    for (Annotation a : zSpan.annotations()) {
+      span.annotate(a.timestamp(), a.value());
+    }
+    for (Map.Entry<String, String> t : zSpan.tags().entrySet()) {
+      span.tag(t.getKey(), t.getValue());
+    }
+    if (Boolean.TRUE.equals(zSpan.debug())) {
+      span.setDebug();
+    }
+    if (Boolean.TRUE.equals(zSpan.shared())) {
+      span.setShared();
+    }
+    return span;
+  }
+
+  static String maybeIp(Endpoint endpoint) {
+    return endpoint != null ? endpoint.ipv6() != null ? endpoint.ipv6() : endpoint.ipv4() : null;
+  }
+
+  static int maybePort(Endpoint endpoint) {
+    return endpoint != null ? endpoint.portAsInt() : 0;
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/IpParserTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/IpParserTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import brave.handler.MutableSpan;
+import java.net.Inet6Address;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test data adapted from zipkin2.EndpointTest. We can assume the inputs are valid as
+ * {@linkplain MutableSpan} already checks them.
+ */
+class IpParserTest {
+  @Test void getIpv4Bytes() {
+    assertThat(IpParser.getIpv4Bytes("43.0.192.2"))
+      .containsExactly(43, 0, 192, 2);
+  }
+
+  @Test void getIpv4Bytes_localhost() {
+    assertThat(IpParser.getIpv4Bytes("127.0.0.1"))
+      .containsExactly(127, 0, 0, 1);
+  }
+
+  @Test void getIpv6Bytes() throws Exception {
+    String ipv6 = "2001:db8::c001";
+
+    assertThat(IpParser.getIpv6Bytes(ipv6))
+      .containsExactly(Inet6Address.getByName(ipv6).getAddress());
+  }
+
+  @Test void getIpv6Bytes_uppercase() throws Exception {
+    String ipv6 = "2001:DB8::C001";
+
+    assertThat(IpParser.getIpv6Bytes(ipv6))
+      .containsExactly(Inet6Address.getByName(ipv6).getAddress());
+  }
+
+  @Test void getIpv6Bytes_localhost() {
+    String ipv6 = "::1";
+
+    assertThat(IpParser.getIpv6Bytes(ipv6))
+      .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/IpWriterTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/IpWriterTest.java
@@ -23,35 +23,45 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test data adapted from zipkin2.EndpointTest. We can assume the inputs are valid as
  * {@linkplain MutableSpan} already checks them.
  */
-class IpParserTest {
-  @Test void getIpv4Bytes() {
-    assertThat(IpParser.getIpv4Bytes("43.0.192.2"))
-      .containsExactly(43, 0, 192, 2);
+class IpWriterTest {
+  @Test void writeIpv4Bytes() {
+    byte[] bytes = new byte[4];
+    IpWriter.writeIpv4Bytes(new WriteBuffer(bytes), "43.0.192.2");
+
+    assertThat(bytes).containsExactly(43, 0, 192, 2);
   }
 
-  @Test void getIpv4Bytes_localhost() {
-    assertThat(IpParser.getIpv4Bytes("127.0.0.1"))
-      .containsExactly(127, 0, 0, 1);
+  @Test void writeIpv4Bytes_localhost() {
+    byte[] bytes = new byte[4];
+    IpWriter.writeIpv4Bytes(new WriteBuffer(bytes), "127.0.0.1");
+
+    assertThat(bytes).containsExactly(127, 0, 0, 1);
   }
 
-  @Test void getIpv6Bytes() throws Exception {
+  @Test void writeIpv6Bytes() throws Exception {
     String ipv6 = "2001:db8::c001";
 
-    assertThat(IpParser.getIpv6Bytes(ipv6))
+    byte[] bytes = new byte[16];
+    IpWriter.writeIpv6Bytes(new WriteBuffer(bytes), ipv6);
+    assertThat(bytes)
       .containsExactly(Inet6Address.getByName(ipv6).getAddress());
   }
 
-  @Test void getIpv6Bytes_uppercase() throws Exception {
+  @Test void writeIpv6Bytes_uppercase() throws Exception {
     String ipv6 = "2001:DB8::C001";
 
-    assertThat(IpParser.getIpv6Bytes(ipv6))
+    byte[] bytes = new byte[16];
+    IpWriter.writeIpv6Bytes(new WriteBuffer(bytes), ipv6);
+    assertThat(bytes)
       .containsExactly(Inet6Address.getByName(ipv6).getAddress());
   }
 
-  @Test void getIpv6Bytes_localhost() {
+  @Test void writeIpv6Bytes_localhost() {
     String ipv6 = "::1";
 
-    assertThat(IpParser.getIpv6Bytes(ipv6))
+    byte[] bytes = new byte[16];
+    IpWriter.writeIpv6Bytes(new WriteBuffer(bytes), ipv6);
+    assertThat(bytes)
       .containsExactly(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
   }
 }

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/Proto3FieldsTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/Proto3FieldsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import zipkin2.reporter.brave.internal.Proto3Fields.BooleanField;
+import zipkin2.reporter.brave.internal.Proto3Fields.BytesField;
+import zipkin2.reporter.brave.internal.Proto3Fields.Fixed64Field;
+import zipkin2.reporter.brave.internal.Proto3Fields.Utf8Field;
+import zipkin2.reporter.brave.internal.Proto3Fields.VarintField;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static zipkin2.reporter.brave.internal.Proto3Fields.Field;
+import static zipkin2.reporter.brave.internal.Proto3Fields.HexField;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_FIXED64;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_VARINT;
+
+class Proto3FieldsTest {
+  byte[] bytes = new byte[2048]; // bigger than needed to test sizeInBytes
+  WriteBuffer buf = new WriteBuffer(bytes);
+
+  /** Shows we can reliably look at a byte zero to tell if we are decoding proto3 repeated fields. */
+  @Test void field_key_fieldOneLengthDelimited() {
+    Field field = new Field(1 << 3 | WIRETYPE_LENGTH_DELIMITED);
+    assertThat(field.key)
+      .isEqualTo(0b00001010) // (field_number << 3) | wire_type = 1 << 3 | 2
+      .isEqualTo(10); // for sanity of those looking at debugger, 4th bit + 2nd bit = 10
+    assertThat(field.fieldNumber)
+      .isEqualTo(1);
+    assertThat(field.wireType)
+      .isEqualTo(WIRETYPE_LENGTH_DELIMITED);
+  }
+
+  @Test void varint_sizeInBytes() {
+    VarintField field = new VarintField(1 << 3 | WIRETYPE_VARINT);
+
+    assertThat(field.sizeInBytes(0))
+      .isZero();
+    assertThat(field.sizeInBytes(0xffffffff))
+      .isEqualTo(0
+        + 1 /* tag of varint field */ + 5 // max size of varint32
+      );
+
+    assertThat(field.sizeInBytes(0L))
+      .isZero();
+    assertThat(field.sizeInBytes(0xffffffffffffffffL))
+      .isEqualTo(0
+        + 1 /* tag of varint field */ + 10 // max size of varint64
+      );
+  }
+
+  @Test void boolean_sizeInBytes() {
+    BooleanField field = new BooleanField(1 << 3 | WIRETYPE_VARINT);
+
+    assertThat(field.sizeInBytes(false))
+      .isZero();
+    assertThat(field.sizeInBytes(true))
+      .isEqualTo(0
+        + 1 /* tag of varint field */ + 1 // size of 1
+      );
+  }
+
+  @Test void utf8_sizeInBytes() {
+    Utf8Field field = new Utf8Field(1 << 3 | WIRETYPE_LENGTH_DELIMITED);
+    assertThat(field.sizeInBytes("12345678"))
+      .isEqualTo(0
+        + 1 /* tag of string field */ + 1 /* len */ + 8 // 12345678
+      );
+  }
+
+  @Test void fixed64_sizeInBytes() {
+    Fixed64Field field = new Fixed64Field(1 << 3 | WIRETYPE_FIXED64);
+    assertThat(field.sizeInBytes(Long.MIN_VALUE))
+      .isEqualTo(9);
+  }
+
+  @Test void supportedFields() {
+    for (Field field : List.of(
+      new VarintField(128 << 3 | WIRETYPE_VARINT),
+      new BooleanField(128 << 3 | WIRETYPE_VARINT),
+      new HexField(128 << 3 | WIRETYPE_LENGTH_DELIMITED),
+      new Utf8Field(128 << 3 | WIRETYPE_LENGTH_DELIMITED),
+      new BytesField(128 << 3 | WIRETYPE_LENGTH_DELIMITED),
+      new Fixed64Field(128 << 3 | WIRETYPE_FIXED64)
+    )) {
+      assertThat(Field.fieldNumber(field.key, 1))
+        .isEqualTo(field.fieldNumber);
+      assertThat(Field.wireType(field.key, 1))
+        .isEqualTo(field.wireType);
+    }
+  }
+
+  @Test void fieldNumber_malformed() {
+    try {
+      Field.fieldNumber(0, 2);
+      failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertThat(e)
+        .hasMessage("Malformed: fieldNumber was zero at byte 2");
+    }
+  }
+
+  @Test void wireType_unsupported() {
+    for (int unsupported : List.of(3, 4, 6)) {
+      try {
+        Field.wireType(1 << 3 | unsupported, 2);
+        failBecauseExceptionWasNotThrown(IllegalArgumentException.class);
+      } catch (IllegalArgumentException e) {
+        assertThat(e)
+          .hasMessage("Malformed: invalid wireType " + unsupported + " at byte 2");
+      }
+    }
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/Proto3SpanWriterTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/Proto3SpanWriterTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import brave.Tags;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipkin2.reporter.brave.ZipkinSpanConverter.CLIENT_SPAN;
+import static zipkin2.reporter.brave.internal.ZipkinProto3FieldsTest.SPAN_FIELD;
+
+public class Proto3SpanWriterTest {
+  ZipkinProto3Writer writer = new ZipkinProto3Writer(Tags.ERROR);
+
+  /** proto messages always need a key, so the non-list form is just a single-field */
+  @Test void write_startsWithSpanKeyAndLengthPrefix() {
+    byte[] bytes = writer.write(CLIENT_SPAN);
+
+    assertThat(bytes)
+      .hasSize(writer.sizeInBytes(CLIENT_SPAN))
+      .startsWith((byte) 10, SPAN_FIELD.sizeOfValue(CLIENT_SPAN));
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/WriteBufferTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/WriteBufferTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WriteBufferTest {
+  // Adapted from http://stackoverflow.com/questions/8511490/calculating-length-in-utf-8-of-java-string-without-actually-encoding-it
+  @Test void utf8SizeInBytes() {
+    for (int codepoint = 0; codepoint <= 0x10FFFF; codepoint++) {
+      if (codepoint == 0xD800) codepoint = 0xDFFF + 1; // skip surrogates
+      if (Character.isDefined(codepoint)) {
+        String test = new String(Character.toChars(codepoint));
+        int expected = test.getBytes(UTF_8).length;
+        int actual = WriteBuffer.utf8SizeInBytes(test);
+        if (actual != expected) {
+          throw new AssertionError(actual + " length != " + expected + " for " + codepoint);
+        }
+      }
+    }
+  }
+
+  /** Uses test data and codepoint wrapping trick from okhttp3.FormBodyTest */
+  @Test void utf8_malformed() {
+    for (int codepoint : List.of(0xD800, 0xDFFF, 0xD83D)) {
+      String test = new String(new int[] {'a', codepoint, 'c'}, 0, 3);
+      assertThat(WriteBuffer.utf8SizeInBytes(test))
+        .isEqualTo(3);
+
+      byte[] bytes = new byte[3];
+      new WriteBuffer(bytes).writeUtf8(test);
+      assertThat(bytes)
+        .containsExactly('a', '?', 'c');
+    }
+  }
+
+  @Test void utf8_21Bit_truncated() {
+    // https://en.wikipedia.org/wiki/Mahjong_Tiles_(Unicode_block)
+    char[] array = "\uD83C\uDC00\uD83C\uDC01".toCharArray();
+    array[array.length - 1] = 'c';
+    String test = new String(array, 0, array.length - 1);
+    assertThat(WriteBuffer.utf8SizeInBytes(test))
+      .isEqualTo(5);
+
+    byte[] bytes = new byte[5];
+    new WriteBuffer(bytes).writeUtf8(test);
+    assertThat(new String(bytes, UTF_8))
+      .isEqualTo("\uD83C\uDC00?");
+  }
+
+  @Test void utf8_21Bit_brokenLowSurrogate() {
+    // https://en.wikipedia.org/wiki/Mahjong_Tiles_(Unicode_block)
+    char[] array = "\uD83C\uDC00\uD83C\uDC01".toCharArray();
+    array[array.length - 1] = 'c';
+    String test = new String(array);
+    assertThat(WriteBuffer.utf8SizeInBytes(test))
+      .isEqualTo(6);
+
+    byte[] bytes = new byte[6];
+    new WriteBuffer(bytes).writeUtf8(test);
+    assertThat(new String(bytes, UTF_8))
+      .isEqualTo("\uD83C\uDC00?c");
+  }
+
+  @Test void utf8_matchesJRE() {
+    // examples from http://utf8everywhere.org/
+    for (String string : List.of(
+      "Приве́т नमस्ते שָׁלוֹם",
+      "ю́ cyrillic small letter yu with acute",
+      "∃y ∀x ¬(x ≺ y)"
+    )) {
+      int encodedSize = WriteBuffer.utf8SizeInBytes(string);
+      assertThat(encodedSize)
+        .isEqualTo(string.getBytes(UTF_8).length);
+
+      byte[] bytes = new byte[encodedSize];
+      new WriteBuffer(bytes).writeUtf8(string);
+      assertThat(new String(bytes, UTF_8))
+        .isEqualTo(string);
+    }
+  }
+
+  @Test void utf8_matchesAscii() {
+    String ascii = "86154a4ba6e913854d1e00c0db9010db";
+    int encodedSize = WriteBuffer.utf8SizeInBytes(ascii);
+    assertThat(encodedSize)
+      .isEqualTo(ascii.length());
+
+    byte[] bytes = new byte[encodedSize];
+    new WriteBuffer(bytes).writeAscii(ascii);
+    assertThat(new String(bytes, UTF_8))
+      .isEqualTo(ascii);
+
+    new WriteBuffer(bytes).writeUtf8(ascii);
+    assertThat(new String(bytes, UTF_8))
+      .isEqualTo(ascii);
+  }
+
+  @Test void emoji() {
+    byte[] emojiBytes = {(byte) 0xF0, (byte) 0x9F, (byte) 0x98, (byte) 0x81};
+    String emoji = new String(emojiBytes, UTF_8);
+    assertThat(WriteBuffer.utf8SizeInBytes(emoji))
+      .isEqualTo(emojiBytes.length);
+
+    byte[] bytes = new byte[emojiBytes.length];
+    new WriteBuffer(bytes).writeUtf8(emoji);
+    assertThat(bytes)
+      .isEqualTo(emojiBytes);
+  }
+
+  @Test void writeAscii_long() {
+    assertThat(writeAscii(-1005656679588439279L))
+      .isEqualTo("-1005656679588439279");
+    assertThat(writeAscii(0L))
+      .isEqualTo("0");
+    assertThat(writeAscii(-9223372036854775808L /* Long.MIN_VALUE */))
+      .isEqualTo("-9223372036854775808");
+    assertThat(writeAscii(123456789L))
+      .isEqualTo("123456789");
+  }
+
+  static String writeAscii(long v) {
+    byte[] bytes = new byte[WriteBuffer.asciiSizeInBytes(v)];
+    new WriteBuffer(bytes).writeAscii(v);
+    return new String(bytes, UTF_8);
+  }
+
+  // Test creating Buffer for a long string
+  @Test void writeString() {
+    String string = "a".repeat(100000);
+    byte[] bytes = new byte[string.length()];
+    new WriteBuffer(bytes).writeAscii(string);
+    assertThat(new String(bytes, UTF_8)).isEqualTo(string);
+  }
+
+  @Test void unsignedVarintSize_32_largest() {
+    // largest to encode is a negative number
+    assertThat(WriteBuffer.varintSizeInBytes(Integer.MIN_VALUE))
+      .isEqualTo(5);
+  }
+
+  @Test void unsignedVarintSize_64_largest() {
+    // largest to encode is a negative number
+    assertThat(WriteBuffer.varintSizeInBytes(Long.MIN_VALUE))
+      .isEqualTo(10);
+  }
+
+  @Test void writeLongLe_matchesByteBuffer() {
+    for (long number : List.of(Long.MIN_VALUE, 0L, Long.MAX_VALUE)) {
+      byte[] bytes = new byte[8];
+      new WriteBuffer(bytes).writeLongLe(number);
+
+      ByteBuffer byteBuffer = ByteBuffer.allocate(8);
+      byteBuffer.order(ByteOrder.LITTLE_ENDIAN);
+      byteBuffer.putLong(number);
+
+      assertThat(bytes)
+        .containsExactly(byteBuffer.array());
+    }
+  }
+
+  // https://developers.google.com/protocol-buffers/docs/encoding#varints
+  @Test void writeVarint_32() {
+    int number = 300;
+
+    byte[] bytes = new byte[WriteBuffer.varintSizeInBytes(number)];
+    new WriteBuffer(bytes).writeVarint(number);
+
+    assertThat(bytes)
+      .containsExactly(0b1010_1100, 0b0000_0010);
+  }
+
+  // https://developers.google.com/protocol-buffers/docs/encoding#varints
+  @Test void writeVarint_64() {
+    long number = 300;
+
+    byte[] bytes = new byte[WriteBuffer.varintSizeInBytes(number)];
+    new WriteBuffer(bytes).writeVarint(number);
+
+    assertThat(bytes)
+      .containsExactly(0b1010_1100, 0b0000_0010);
+  }
+
+  @Test void writeVarint_ports() {
+    // normal case
+    byte[] bytes = new byte[WriteBuffer.varintSizeInBytes(80)];
+    new WriteBuffer(bytes).writeVarint(80);
+
+    assertThat(bytes)
+      .containsExactly(0b0101_0000);
+
+    // largest value to not require more than 2 bytes (14 bits set)
+    bytes = new byte[WriteBuffer.varintSizeInBytes(16383)];
+    new WriteBuffer(bytes).writeVarint(16383);
+
+    assertThat(bytes)
+      .containsExactly(0b1111_1111, 0b0111_1111);
+
+    // worst case is a byte longer than fixed 16
+    bytes = new byte[WriteBuffer.varintSizeInBytes(65535)];
+    new WriteBuffer(bytes).writeVarint(65535);
+
+    assertThat(bytes)
+      .containsExactly(0b1111_1111, 0b1111_1111, 0b0000_0011);
+
+    // most bits
+    bytes = new byte[WriteBuffer.varintSizeInBytes(0xFFFFFFFF)];
+    new WriteBuffer(bytes).writeVarint(0xFFFFFFFF);
+
+    // we have a total of 32 bits encoded
+    assertThat(bytes)
+      .containsExactly(0b1111_1111, 0b1111_1111, 0b1111_1111, 0b1111_1111, 0b0000_1111);
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/ZipkinProto3FieldsTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/ZipkinProto3FieldsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2016-2024 The OpenZipkin Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package zipkin2.reporter.brave.internal;
+
+import brave.Span.Kind;
+import brave.Tags;
+import brave.handler.MutableSpan;
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+import zipkin2.Span;
+import zipkin2.TestObjects;
+import zipkin2.codec.SpanBytesDecoder;
+import zipkin2.reporter.brave.internal.ZipkinProto3Fields.AnnotationField;
+import zipkin2.reporter.brave.internal.ZipkinProto3Fields.EndpointField;
+import zipkin2.reporter.brave.internal.ZipkinProto3Fields.SpanField;
+import zipkin2.reporter.brave.internal.ZipkinProto3Fields.TagField;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+import static zipkin2.reporter.brave.ZipkinSpanConverter.toMutableSpan;
+import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
+
+class ZipkinProto3FieldsTest {
+  static final SpanField SPAN_FIELD = new SpanField(Tags.ERROR);
+  byte[] bytes = new byte[2048]; // bigger than needed to test sizeInBytes
+  WriteBuffer buf = new WriteBuffer(bytes);
+
+  /** A map entry is an embedded messages: one for field the key and one for the value */
+  @Test void tag_sizeInBytes() {
+    TagField field = new TagField(1 << 3 | WIRETYPE_LENGTH_DELIMITED);
+    assertThat(field.sizeInBytes("123", "56789"))
+      .isEqualTo(0
+        + 1 /* tag of embedded key field */ + 1 /* len */ + 3
+        + 1 /* tag of embedded value field  */ + 1 /* len */ + 5
+        + 1 /* tag of map entry field */ + 1 /* len */
+      );
+  }
+
+  @Test void annotation_sizeInBytes() {
+    AnnotationField field = new AnnotationField(1 << 3 | WIRETYPE_LENGTH_DELIMITED);
+    assertThat(field.sizeInBytes(1L, "12345678"))
+      .isEqualTo(0
+        + 1 /* tag of timestamp field */ + 8 /* 8 byte number */
+        + 1 /* tag of value field */ + 1 /* len */ + 8 // 12345678
+        + 1 /* tag of annotation field */ + 1 /* len */
+      );
+  }
+
+  @Test void endpoint_sizeInBytes() {
+    EndpointField field = new EndpointField(1 << 3 | WIRETYPE_LENGTH_DELIMITED);
+
+    assertThat(field.sizeInBytes("12345678", "192.168.99.101", 80))
+      .isEqualTo(0
+        + 1 /* tag of servicename field */ + 1 /* len */ + 8 // 12345678
+        + 1 /* tag of ipv4 field */ + 1 /* len */ + 4 // octets in ipv4
+        + 1 /* tag of port field */ + 1 /* small varint */
+        + 1 /* tag of endpoint field */ + 1 /* len */
+      );
+
+    assertThat(field.sizeInBytes("12345678", "2001:db8::c001", 80))
+      .isEqualTo(0
+        + 1 /* tag of servicename field */ + 1 /* len */ + 8 // 12345678
+        + 1 /* tag of ipv6 field */ + 1 /* len */ + 16 // octets in ipv6
+        + 1 /* tag of port field */ + 1 /* small varint */
+        + 1 /* tag of endpoint field */ + 1 /* len */
+      );
+  }
+
+  @Test void span_write_startsWithFieldInListOfSpans() {
+    SPAN_FIELD.write(buf, newSpan());
+
+    assertThat(bytes).startsWith(
+      0b00001010 /* span key */, 20 /* bytes for length of the span */
+    );
+  }
+
+  @Test void span_write_writesIds() {
+    SPAN_FIELD.write(buf, newSpan());
+    assertThat(bytes).startsWith(
+      0b00001010 /* span key */, 20 /* bytes for length of the span */,
+      0b00001010 /* trace ID key */, 8 /* bytes for 64-bit trace ID */,
+      0, 0, 0, 0, 0, 0, 0, 1, // hex trace ID
+      0b00011010 /* span ID key */, 8 /* bytes for 64-bit span ID */,
+      0, 0, 0, 0, 0, 0, 0, 2 // hex span ID
+    );
+    assertThat(buf.pos())
+      .isEqualTo(3 * 2 /* overhead of three fields */ + 2 * 8 /* 64-bit fields */)
+      .isEqualTo(22); // easier math on the next test
+  }
+
+  @Test void span_write_omitsEmptyEndpoints() {
+    SPAN_FIELD.write(buf, newSpan());
+
+    assertThat(buf.pos())
+      .isEqualTo(22);
+  }
+
+  @Test void span_write_kind() {
+    MutableSpan span = newSpan();
+    span.kind(Kind.PRODUCER);
+    SPAN_FIELD.write(buf, span);
+    assertThat(bytes)
+      .contains(0b0100000, atIndex(22)) // (field_number << 3) | wire_type = 4 << 3 | 0
+      .contains(0b0000011, atIndex(23)); // producer's index is 3
+  }
+
+  @Test void span_write_debug() {
+    MutableSpan span = newSpan();
+    span.setDebug();
+    SPAN_FIELD.write(buf, span);
+
+    assertThat(bytes)
+      .contains(0b01100000, atIndex(buf.pos() - 2)) // (field_number << 3) | wire_type = 12 << 3 | 0
+      .contains(1, atIndex(buf.pos() - 1)); // true
+  }
+
+  @Test void span_write_shared() {
+    MutableSpan span = newSpan();
+    span.kind(Kind.SERVER);
+    span.setShared();
+    SPAN_FIELD.write(buf, span);
+
+    assertThat(bytes)
+      .contains(0b01101000, atIndex(buf.pos() - 2)) // (field_number << 3) | wire_type = 13 << 3 | 0
+      .contains(1, atIndex(buf.pos() - 1)); // true
+  }
+
+  static MutableSpan newSpan() {
+    MutableSpan span = new MutableSpan();
+    span.traceId("1");
+    span.id("2");
+    return span;
+  }
+}

--- a/brave/src/test/java/zipkin2/reporter/brave/internal/ZipkinProto3FieldsTest.java
+++ b/brave/src/test/java/zipkin2/reporter/brave/internal/ZipkinProto3FieldsTest.java
@@ -16,11 +16,7 @@ package zipkin2.reporter.brave.internal;
 import brave.Span.Kind;
 import brave.Tags;
 import brave.handler.MutableSpan;
-import java.nio.ByteBuffer;
 import org.junit.jupiter.api.Test;
-import zipkin2.Span;
-import zipkin2.TestObjects;
-import zipkin2.codec.SpanBytesDecoder;
 import zipkin2.reporter.brave.internal.ZipkinProto3Fields.AnnotationField;
 import zipkin2.reporter.brave.internal.ZipkinProto3Fields.EndpointField;
 import zipkin2.reporter.brave.internal.ZipkinProto3Fields.SpanField;
@@ -28,7 +24,6 @@ import zipkin2.reporter.brave.internal.ZipkinProto3Fields.TagField;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static zipkin2.reporter.brave.ZipkinSpanConverter.toMutableSpan;
 import static zipkin2.reporter.brave.internal.Proto3Fields.WIRETYPE_LENGTH_DELIMITED;
 
 class ZipkinProto3FieldsTest {

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/OkHttpSender.java
@@ -295,7 +295,7 @@ public final class OkHttpSender extends Sender {
         encoder = RequestBodyMessageEncoder.JSON;
         break;
       case THRIFT:
-        this.encoder = RequestBodyMessageEncoder.THRIFT;
+        encoder = RequestBodyMessageEncoder.THRIFT;
         break;
       case PROTO3:
         encoder = RequestBodyMessageEncoder.PROTO3;

--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,16 @@
     <zipkin.version>2.27.1</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>6.0.0</brave.version>
+    <brave.version>6.0.1</brave.version>
 
-    <junit-jupiter.version>5.10.1</junit-jupiter.version>
-    <assertj.version>3.25.1</assertj.version>
-    <okhttp.version>4.12.0</okhttp.version>
     <log4j.version>2.22.1</log4j.version>
-    <testcontainers.version>1.19.3</testcontainers.version>
+    <okhttp.version>4.12.0</okhttp.version>
+
+    <junit-jupiter.version>5.10.2</junit-jupiter.version>
+    <mockito.version>5.10.0</mockito.version>
+    <assertj.version>3.25.3</assertj.version>
+    <awaitility.version>4.2.0</awaitility.version>
+    <testcontainers.version>1.19.4</testcontainers.version>
 
     <license.skip>${skipTests}</license.skip>
 

--- a/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
+++ b/spring-beans/src/main/java/zipkin2/reporter/beans/AsyncReporterFactoryBean.java
@@ -14,12 +14,15 @@
 package zipkin2.reporter.beans;
 
 import java.util.concurrent.TimeUnit;
+import zipkin2.Span;
 import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.SpanBytesEncoder;
 
 /** Spring XML config does not support chained builders. This converts accordingly */
 public class AsyncReporterFactoryBean extends BaseAsyncFactoryBean {
-  SpanBytesEncoder encoder;
+  BytesEncoder<Span> encoder;
 
   @Override public Class<? extends AsyncReporter> getObjectType() {
     return AsyncReporter.class;
@@ -40,7 +43,12 @@ public class AsyncReporterFactoryBean extends BaseAsyncFactoryBean {
     ((AsyncReporter) instance).close();
   }
 
-  public void setEncoder(SpanBytesEncoder encoder) {
-    this.encoder = encoder;
+  // Object to allow built-in encoder types.
+  public void setEncoder(Object encoder) {
+    if (encoder instanceof String) {
+      this.encoder = SpanBytesEncoder.forEncoding(Encoding.valueOf(encoder.toString()));
+    } else if (encoder instanceof BytesEncoder) {
+      this.encoder = (BytesEncoder) encoder;
+    }
   }
 }

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/AsyncZipkinSpanHandlerFactoryBeanTest.java
@@ -14,13 +14,17 @@
 package zipkin2.reporter.beans;
 
 import brave.Tag;
+import brave.handler.MutableSpan;
 import brave.propagation.TraceContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import zipkin2.reporter.BytesEncoder;
 import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.ReporterMetrics;
 import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
+import zipkin2.reporter.brave.MutableSpanBytesEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +35,24 @@ class AsyncZipkinSpanHandlerFactoryBeanTest {
     }
   };
   public static BytesMessageSender SENDER = new FakeSender();
+  public static BytesMessageSender PROTO3_SENDER = new FakeSender() {
+    @Override public Encoding encoding() {
+      return Encoding.PROTO3;
+    }
+  };
+  public static BytesEncoder<MutableSpan> CUSTOM_ENCODER = new BytesEncoder<MutableSpan>() {
+    @Override public Encoding encoding() {
+      return Encoding.PROTO3;
+    }
+
+    @Override public int sizeInBytes(MutableSpan input) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public byte[] encode(MutableSpan input) {
+      throw new UnsupportedOperationException();
+    }
+  };
   public static ReporterMetrics METRICS = ReporterMetrics.NOOP_METRICS;
 
   XmlBeans context;
@@ -41,148 +63,198 @@ class AsyncZipkinSpanHandlerFactoryBeanTest {
 
   @Test void errorTag() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "  <property name=\"errorTag\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".ERROR_TAG\"/>\n"
-        + "  </property>\n"
-        + "</bean>\n"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "  <property name=\"errorTag\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".ERROR_TAG\"/>\n"
+      + "  </property>\n"
+      + "</bean>\n"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.encoder.delegate.writer.errorTag")
-        .isSameAs(ERROR_TAG);
+      .extracting("spanReporter.encoder.delegate.writer.errorTag")
+      .isSameAs(ERROR_TAG);
   }
 
   @Test void alwaysReportSpans() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "  <property name=\"alwaysReportSpans\" value=\"true\"/>\n"
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "  <property name=\"alwaysReportSpans\" value=\"true\"/>\n"
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("alwaysReportSpans")
-        .isEqualTo(true);
+      .extracting("alwaysReportSpans")
+      .isEqualTo(true);
   }
 
   // below copied from AsyncReporterFactoryBean
   @Test void sender() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.sender")
-        .isEqualTo(SENDER);
+      .extracting("spanReporter.sender")
+      .isEqualTo(SENDER);
+  }
+
+  @Test void sender_proto3() {
+    context = new XmlBeans(""
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".PROTO3_SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
+      .extracting("spanReporter.sender")
+      .isEqualTo(PROTO3_SENDER);
   }
 
   @Test void metrics() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"metrics\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".METRICS\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"metrics\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".METRICS\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.metrics")
-        .isEqualTo(METRICS);
+      .extracting("spanReporter.metrics")
+      .isEqualTo(METRICS);
   }
 
   @Test void messageMaxBytes() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"messageMaxBytes\" value=\"512\"/>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageMaxBytes\" value=\"512\"/>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.messageMaxBytes")
-        .isEqualTo(512);
+      .extracting("spanReporter.messageMaxBytes")
+      .isEqualTo(512);
   }
 
   @Test void messageTimeout() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"messageTimeout\" value=\"500\"/>\n"
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"500\"/>\n"
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.messageTimeoutNanos")
-        .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
+      .extracting("spanReporter.messageTimeoutNanos")
+      .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
   }
 
   @Test void closeTimeout() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"closeTimeout\" value=\"500\"/>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"closeTimeout\" value=\"500\"/>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.closeTimeoutNanos")
-        .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
+      .extracting("spanReporter.closeTimeoutNanos")
+      .isEqualTo(TimeUnit.MILLISECONDS.toNanos(500));
   }
 
   @Test void queuedMaxSpans() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"queuedMaxSpans\" value=\"10\"/>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"queuedMaxSpans\" value=\"10\"/>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.pending.maxSize")
-        .isEqualTo(10);
+      .extracting("spanReporter.pending.maxSize")
+      .isEqualTo(10);
   }
 
   @Test void queuedMaxBytes() {
     context = new XmlBeans(""
-        + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
-        + "  <property name=\"sender\">\n"
-        + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
-        + "  </property>\n"
-        + "  <property name=\"queuedMaxBytes\" value=\"512\"/>\n"
-        + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
-        + "</bean>"
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"queuedMaxBytes\" value=\"512\"/>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
     );
 
     assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
-        .extracting("spanReporter.pending.maxBytes")
-        .isEqualTo(512);
+      .extracting("spanReporter.pending.maxBytes")
+      .isEqualTo(512);
+  }
+
+  @Test void encoder() {
+    context = new XmlBeans(""
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".PROTO3_SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"encoder\" value=\"PROTO3\"/>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
+      .extracting("spanReporter.encoder")
+      .isEqualTo(MutableSpanBytesEncoder.PROTO3);
+  }
+
+  /** Ensures encoders not built-into zipkin-reporter can be used. */
+  @Test void encoder_custom() {
+    context = new XmlBeans(""
+      + "<bean id=\"zipkinSpanHandler\" class=\"zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean\">\n"
+      + "  <property name=\"sender\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".PROTO3_SENDER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"encoder\">\n"
+      + "    <util:constant static-field=\"" + getClass().getName() + ".CUSTOM_ENCODER\"/>\n"
+      + "  </property>\n"
+      + "  <property name=\"messageTimeout\" value=\"0\"/>\n" // disable thread for test
+      + "</bean>"
+    );
+
+    assertThat(context.getBean("zipkinSpanHandler", AsyncZipkinSpanHandler.class))
+      .extracting("spanReporter.encoder")
+      .isEqualTo(CUSTOM_ENCODER);
   }
 }


### PR DESCRIPTION
This adds `MutableSpanEncoder.PROTO3` similar to what's available for `zipkin2.Span`. The code and tests are based on similar inside zipkin and brave. This is added to the reporter, not brave, to reduce version lock-up for a useful, but more rare encoding type.
```
Benchmark                                                                               Mode     Cnt     Score     Error   Units
MutableSpanBytesEncoderBenchmarks.encode_bigClientSpan_json:gc.alloc.rate.norm        sample      15  584.183 ± 0.045    B/op
MutableSpanBytesEncoderBenchmarks.encode_bigClientSpan_json:p0.99                     sample            1.166           us/op
MutableSpanBytesEncoderBenchmarks.encode_bigClientSpan_proto:gc.alloc.rate.norm       sample      15  472.141 ± 0.006    B/op
MutableSpanBytesEncoderBenchmarks.encode_bigClientSpan_proto:p0.99                    sample            1.042           us/op
MutableSpanBytesEncoderBenchmarks.encode_serverSpan_json:gc.alloc.rate.norm           sample      15  288.054 ± 0.008    B/op
MutableSpanBytesEncoderBenchmarks.encode_serverSpan_json:p0.99                        sample            0.417           us/op
MutableSpanBytesEncoderBenchmarks.encode_serverSpan_proto:gc.alloc.rate.norm          sample      15  200.052 ± 0.006    B/op
MutableSpanBytesEncoderBenchmarks.encode_serverSpan_proto:p0.99                       sample            0.417           us/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_bigClientSpan_json:gc.alloc.rate.norm   sample      15    0.043 ± 0.011    B/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_bigClientSpan_json:p0.99                sample            0.334           us/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_bigClientSpan_proto:gc.alloc.rate.norm  sample      15    0.028 ± 0.004    B/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_bigClientSpan_proto:p0.99               sample            0.250           us/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_serverSpan_json:gc.alloc.rate.norm      sample      15    0.013 ± 0.002    B/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_serverSpan_json:p0.99                   sample            0.125           us/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_serverSpan_proto:gc.alloc.rate.norm     sample      15    0.008 ± 0.001    B/op
MutableSpanBytesEncoderBenchmarks.sizeInBytes_serverSpan_proto:p0.99                  sample            0.125           us/op
```

Fixes #178