### PR TITLE
Renames HttpSender to BaseHttpSender

### DIFF
--- a/core/src/main/java/zipkin2/reporter/BaseHttpSender.java
+++ b/core/src/main/java/zipkin2/reporter/BaseHttpSender.java
@@ -64,7 +64,7 @@ public abstract class BaseHttpSender<U, B> extends BytesMessageSender.Base {
    *
    * @since 3.3
    */
-  protected abstract B newBody(List<byte[]> encodedSpans);
+  protected abstract B newBody(List<byte[]> encodedSpans) throws IOException;
 
   /**
    * Implement to POST spans to the given endpoint.

--- a/core/src/main/java/zipkin2/reporter/BaseHttpSender.java
+++ b/core/src/main/java/zipkin2/reporter/BaseHttpSender.java
@@ -14,6 +14,8 @@
 package zipkin2.reporter;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
@@ -27,9 +29,11 @@ import static zipkin2.reporter.Call.propagateIfFatal;
  * <p>Calls to {@linkplain #postSpans(Object, Object)} happen on the same async reporting thread,
  * but {@linkplain #close()} might be called from any thread.
  *
+ * @param <U> The URL type for the HTTP client, such as {@linkplain URL} or {@linkplain URI}.
+ * @param <B> The POST body, such as {@code byte[]} or an HTTP client-specific body type.
  * @since 3.3
  */
-public abstract class HttpSender<U, B> extends BytesMessageSender.Base {
+public abstract class BaseHttpSender<U, B> extends BytesMessageSender.Base {
   final Logger logger;
   final HttpEndpointSupplier endpointSupplier;
   final U endpoint;
@@ -49,7 +53,7 @@ public abstract class HttpSender<U, B> extends BytesMessageSender.Base {
   /**
    * Creates a new POST body from the encoded spans.
    *
-   * <p>Below is the simplest implementation, when {@linkplain HttpSender#<B>} is a byte array.
+   * <p>Below is the simplest implementation, when {@linkplain BaseHttpSender#<B>} is a byte array.
    * <pre>{@code
    * @Override protected byte[] newBody(List<byte[]> encodedSpans) {
    *   return encoding.encode(encodedSpans);
@@ -79,11 +83,13 @@ public abstract class HttpSender<U, B> extends BytesMessageSender.Base {
   protected void doClose() {
   }
 
-  protected HttpSender(Encoding encoding, Factory endpointSupplierFactory, String endpoint) {
-    this(Logger.getLogger(HttpSender.class.getName()), encoding, endpointSupplierFactory, endpoint);
+  protected BaseHttpSender(Encoding encoding, Factory endpointSupplierFactory, String endpoint) {
+    this(Logger.getLogger(BaseHttpSender.class.getName()), encoding, endpointSupplierFactory,
+      endpoint);
   }
 
-  HttpSender(Logger logger, Encoding encoding, Factory endpointSupplierFactory, String endpoint) {
+  BaseHttpSender(Logger logger, Encoding encoding, Factory endpointSupplierFactory,
+    String endpoint) {
     super(encoding);
     this.logger = logger;
     if (endpointSupplierFactory == null) {

--- a/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
+++ b/core/src/main/java/zipkin2/reporter/HttpEndpointSupplier.java
@@ -17,8 +17,8 @@ import java.io.Closeable;
 import java.util.List;
 
 /**
- * HTTP-based {@link BytesMessageSender senders}, such as {@linkplain HttpSender} use this to get
- * the endpoint to post spans to. For example, http://localhost:9411/api/v2/spans
+ * HTTP-based {@link BytesMessageSender senders}, such as {@linkplain BaseHttpSender} use this to
+ * get the endpoint to POST spans to. For example, http://localhost:9411/api/v2/spans
  *
  * <p>These are created by a {@linkplain Factory}, allows this to be constructed with a
  * potentially-pseudo endpoint passed by configuration.
@@ -34,7 +34,7 @@ import java.util.List;
  *
  * <h3>Implementation Notes</h3>
  *
- * {@linkplain HttpSender} is a convenience type that implements the following logic:
+ * {@linkplain BaseHttpSender} is a convenience type that implements the following logic:
  * <ul>
  *   <li>During build, the sender should invoke the {@linkplain Factory}.</li>
  *   <li>If the result is {@link Constant}, build the sender to use a static value.</li>
@@ -55,8 +55,8 @@ import java.util.List;
  * dependency injection, without limiting an HTTP framework that can handle groups, to a
  * single-endpoint supplier.
  *
+ * @see BaseHttpSender
  * @see Constant
- * @see HttpSender
  * @see HttpEndpointSuppliers
  * @since 3.3
  */

--- a/core/src/main/java/zipkin2/reporter/HttpEndpointSuppliers.java
+++ b/core/src/main/java/zipkin2/reporter/HttpEndpointSuppliers.java
@@ -49,8 +49,8 @@ public final class HttpEndpointSuppliers {
   }
 
   /**
-   * {@link HttpSender sender} implementations look for a {@linkplain Constant} to avoid the
-   * overhead of dynamic lookups on each call to {@link HttpSender#postSpans(Object, Object)}.
+   * {@link BaseHttpSender sender} implementations look for a {@linkplain Constant} to avoid the
+   * overhead of dynamic lookups on each call to {@link BaseHttpSender#postSpans(Object, Object)}.
    *
    * @since 3.3
    */

--- a/core/src/test/java/zipkin2/reporter/BaseHttpSenderTest.java
+++ b/core/src/test/java/zipkin2/reporter/BaseHttpSenderTest.java
@@ -34,7 +34,7 @@ import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.reporter.HttpEndpointSuppliers.newConstant;
 
 @ExtendWith(MockitoExtension.class)
-class HttpSenderTest {
+class BaseHttpSenderTest {
 
   @Mock Logger logger;
   @Mock Consumer<List<Span>> onSpans;

--- a/core/src/test/java/zipkin2/reporter/FakeHttpSender.java
+++ b/core/src/test/java/zipkin2/reporter/FakeHttpSender.java
@@ -24,7 +24,7 @@ import zipkin2.reporter.HttpEndpointSupplier.Factory;
 
 import static zipkin2.reporter.HttpEndpointSuppliers.constantFactory;
 
-class FakeHttpSender extends HttpSender<String, byte[]> {
+class FakeHttpSender extends BaseHttpSender<String, byte[]> {
   final String originalEndpoint;
   final Consumer<List<Span>> onSpans;
 

--- a/core/src/test/java/zipkin2/reporter/HttpEndpointSuppliersTest.java
+++ b/core/src/test/java/zipkin2/reporter/HttpEndpointSuppliersTest.java
@@ -14,8 +14,6 @@
 package zipkin2.reporter;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import zipkin2.reporter.HttpEndpointSupplier.Constant;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/src/test/java/zipkin2/reporter/internal/PlatformTest.java
+++ b/core/src/test/java/zipkin2/reporter/internal/PlatformTest.java
@@ -16,7 +16,6 @@ package zipkin2.reporter.internal;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.junit.jupiter.api.Test;
-import zipkin2.reporter.internal.Platform;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/okhttp3/src/main/java/zipkin2/reporter/okhttp3/InternalOkHttpSender.java
+++ b/okhttp3/src/main/java/zipkin2/reporter/okhttp3/InternalOkHttpSender.java
@@ -34,15 +34,15 @@ import okio.BufferedSource;
 import okio.GzipSink;
 import okio.GzipSource;
 import okio.Okio;
+import zipkin2.reporter.BaseHttpSender;
 import zipkin2.reporter.Component;
 import zipkin2.reporter.Encoding;
-import zipkin2.reporter.HttpSender;
 
 /**
  * We have to nest this class until v4 when {@linkplain OkHttpSender} no longer needs to extend
  * {@linkplain Component}.
  */
-final class InternalOkHttpSender extends HttpSender<HttpUrl, RequestBody> {
+final class InternalOkHttpSender extends BaseHttpSender<HttpUrl, RequestBody> {
   final OkHttpClient client;
   final RequestBodyMessageEncoder encoder;
   final Encoding encoding;

--- a/okhttp3/src/test/java/zipkin2/reporter/okhttp3/ITOkHttpSender.java
+++ b/okhttp3/src/test/java/zipkin2/reporter/okhttp3/ITOkHttpSender.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import okhttp3.mockwebserver.Dispatcher;
@@ -40,7 +39,6 @@ import zipkin2.reporter.okhttp3.OkHttpSenderTest.BaseHttpEndpointSupplier;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 import static zipkin2.TestObjects.CLIENT_SPAN;
 import static zipkin2.reporter.okhttp3.OkHttpSenderTest.sendSpans;
 

--- a/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
+++ b/spring-beans/src/test/java/zipkin2/reporter/beans/URLConnectionSenderFactoryBeanTest.java
@@ -15,7 +15,6 @@ package zipkin2.reporter.beans;
 
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/urlconnection/src/main/java/zipkin2/reporter/urlconnection/InternalURLConnectionSender.java
+++ b/urlconnection/src/main/java/zipkin2/reporter/urlconnection/InternalURLConnectionSender.java
@@ -21,14 +21,14 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
+import zipkin2.reporter.BaseHttpSender;
 import zipkin2.reporter.Component;
-import zipkin2.reporter.HttpSender;
 
 /**
  * We have to nest this class until v4 when {@linkplain URLConnectionSender} no longer needs to
  * extend {@linkplain Component}.
  */
-final class InternalURLConnectionSender extends HttpSender<URL, byte[]> {
+final class InternalURLConnectionSender extends BaseHttpSender<URL, byte[]> {
 
   final int messageMaxBytes;
   final int connectTimeout;


### PR DESCRIPTION
spring-boot has their own type HttpSender and this makes it more obvious that it is an abstract class.