### PR TITLE
deps: fix kafka floor JRE to 8 and updates all libs to latest

### DIFF
--- a/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQContainer.java
+++ b/activemq-client/src/test/java/zipkin2/reporter/activemq/ActiveMQContainer.java
@@ -19,7 +19,7 @@ final class ActiveMQContainer extends GenericContainer<ActiveMQContainer> {
   static final int ACTIVEMQ_PORT = 61616;
 
   ActiveMQContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-activemq:3.0.6"));
+    super(parse("ghcr.io/openzipkin/zipkin-activemq:3.1.1"));
     withExposedPorts(ACTIVEMQ_PORT);
     waitStrategy = Wait.forListeningPorts(ACTIVEMQ_PORT);
     withStartupTimeout(Duration.ofSeconds(60));

--- a/amqp-client/pom.xml
+++ b/amqp-client/pom.xml
@@ -22,7 +22,7 @@
     <module.name>zipkin2.reporter.amqp</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-    <amqp-client.version>5.20.0</amqp-client.version>
+    <amqp-client.version>5.21.0</amqp-client.version>
     <!-- Last pre-1.8 version -->
     <old-amqp-client.version>4.12.0</old-amqp-client.version>
   </properties>

--- a/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQContainer.java
+++ b/amqp-client/src/test/java/zipkin2/reporter/amqp/RabbitMQContainer.java
@@ -20,7 +20,7 @@ final class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
   static final int RABBIT_PORT = 5672;
 
   RabbitMQContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.0.6"));
+    super(parse("ghcr.io/openzipkin/zipkin-rabbitmq:3.1.1"));
     withExposedPorts(RABBIT_PORT);
     waitStrategy = Wait.forLogMessage(".*Server startup complete.*", 1);
     withStartupTimeout(Duration.ofSeconds(60));

--- a/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
+++ b/benchmarks/src/main/java/zipkin2/reporter/KafkaSenderBenchmarks.java
@@ -33,7 +33,7 @@ public class KafkaSenderBenchmarks extends SenderBenchmarks {
 
   static final class KafkaContainer extends GenericContainer<KafkaContainer> {
     KafkaContainer() {
-      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.6"));
+      super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.1"));
       waitStrategy = Wait.forHealthcheck();
       // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
       addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -163,7 +163,7 @@
 
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.2</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -58,10 +58,10 @@
     <profile>
       <id>release</id>
       <properties>
-        <!-- Kafka 0.11+ is Java 1.7 bytecode -->
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.release>7</maven.compiler.release>
+        <!-- Kafka 0.11+ is Java 8 bytecode -->
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
       </properties>
       <build>
         <plugins>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -43,7 +43,7 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <!-- recent clients can talk to old 0.10 brokers -->
-      <version>3.6.1</version>
+      <version>3.7.0</version>
     </dependency>
 
     <dependency>

--- a/kafka/src/test/java/zipkin2/reporter/kafka/KafkaContainer.java
+++ b/kafka/src/test/java/zipkin2/reporter/kafka/KafkaContainer.java
@@ -28,7 +28,7 @@ final class KafkaContainer extends GenericContainer<KafkaContainer> {
   static final int KAFKA_PORT = 19092;
 
   KafkaContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin-kafka:3.0.6"));
+    super(parse("ghcr.io/openzipkin/zipkin-kafka:3.1.1"));
     waitStrategy = Wait.forHealthcheck();
     // Kafka broker listener port (19092) needs to be exposed for test cases to access it.
     addFixedExposedPort(KAFKA_PORT, KAFKA_PORT, InternetProtocol.TCP);

--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -47,7 +47,7 @@
            common in libthrift and lead to rev-lock. As scribe is a deprecated
            transport in Zipkin, it is ok to update this to a signature breaking
            version on minor, but increment to the next minor in the PR. -->
-      <version>0.19.0</version>
+      <version>0.20.0</version>
     </dependency>
 
     <dependency>

--- a/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinContainer.java
+++ b/libthrift/src/test/java/zipkin2/reporter/libthrift/ZipkinContainer.java
@@ -22,7 +22,7 @@ final class ZipkinContainer extends GenericContainer<ZipkinContainer> {
   static final int HTTP_PORT = 9411;
 
   ZipkinContainer() {
-    super(parse("ghcr.io/openzipkin/zipkin:3.0.6"));
+    super(parse("ghcr.io/openzipkin/zipkin:3.1.1"));
     // zipkin-server disables scribe by default.
     withEnv("COLLECTOR_SCRIBE_ENABLED", "true");
     withExposedPorts(SCRIBE_PORT, HTTP_PORT);

--- a/metrics-micrometer/pom.xml
+++ b/metrics-micrometer/pom.xml
@@ -22,7 +22,7 @@
     <module.name>zipkin2.reporter.metrics.micrometer</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
-    <micrometer.version>1.12.1</micrometer.version>
+    <micrometer.version>1.12.5</micrometer.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -49,23 +49,23 @@
 
     <!-- override to set exclusions per-project -->
     <errorprone.args />
-    <errorprone.version>2.24.1</errorprone.version>
+    <errorprone.version>2.26.1</errorprone.version>
 
     <!-- use the same value in bom/pom.xml -->
     <!-- NOTE: Do not update to 3.x as that has floor Java 8 -->
     <zipkin.version>2.27.1</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>6.0.1</brave.version>
+    <brave.version>6.0.2</brave.version>
 
-    <log4j.version>2.22.1</log4j.version>
+    <log4j.version>2.23.1</log4j.version>
     <okhttp.version>4.12.0</okhttp.version>
 
     <junit-jupiter.version>5.10.2</junit-jupiter.version>
-    <mockito.version>5.10.0</mockito.version>
+    <mockito.version>5.11.0</mockito.version>
     <assertj.version>3.25.3</assertj.version>
-    <awaitility.version>4.2.0</awaitility.version>
-    <testcontainers.version>1.19.4</testcontainers.version>
+    <awaitility.version>4.2.1</awaitility.version>
+    <testcontainers.version>1.19.7</testcontainers.version>
 
     <license.skip>${skipTests}</license.skip>
 
@@ -73,7 +73,7 @@
     <!-- TODO: cleanup any redundant ignores now also in the 4.0 release (once final) -->
     <license-maven-plugin.version>4.3</license-maven-plugin.version>
     <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
-    <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+    <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <!-- Use same version as https://github.com/openzipkin/docker-java -->
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
@@ -85,8 +85,8 @@
     <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
-    <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
-    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+    <maven-shade-plugin.version>3.5.2</maven-shade-plugin.version>
+    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
   </properties>


### PR DESCRIPTION
We incorrectly had kafka as floor JRE 1.7 not 8  https://cwiki.apache.org/confluence/display/KAFKA/Release+Plan+0.11.0.0