### PR TITLE
ci: adds lint check, fixes yaml formatting and unnecessary auth

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,13 +1,12 @@
-# yamllint --format github .github/workflows/create_release.yml
 ---
 name: create_release
 
-# We create a release version on a trigger tag, regardless of if the commit is documentation-only.
-#
-# See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-on:
+# We create a release version on a trigger tag, regardless of if the commit is
+# documentation-only.
+on:  # yamllint disable-line rule:truthy
   push:
-    tags: 'release-[0-9]+.[0-9]+.[0-9]+**'  # Ex. release-1.2.3
+    tags:  # e.g. release-1.2.3
+      - 'release-[0-9]+.[0-9]+.[0-9]+**'
 
 jobs:
   create_release:
@@ -16,28 +15,28 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          # Prevent use of implicit GitHub Actions read-only token GITHUB_TOKEN. We don't deploy on
-          # the tag MAJOR.MINOR.PATCH event, but we still need to deploy the maven-release-plugin master commit.
+          # Prevent use of implicit GitHub Actions read-only GITHUB_TOKEN
+          # because maven-release-plugin pushes commits to master.
           token: ${{ secrets.GH_TOKEN }}
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '11'  # last that can compile the 1.6 release profile
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-11-maven-
       - name: Create Release
         env:
           # GH_USER=<user that created GH_TOKEN>
           GH_USER: ${{ secrets.GH_USER }}
           # GH_TOKEN=<hex token value>
-          #   - makes release commits and tags
-          #   - needs repo:status, public_repo
-          #   - referenced in .settings.xml
+          # * makes release commits and tags
+          # * needs repo:status, public_repo
+          # * referenced in .settings.xml
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |  # GITHUB_REF will be refs/tags/release-MAJOR.MINOR.PATCH
           build-bin/git/login_git &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-17-maven-
+          restore-keys: ${{ runner.os }}-jdk-11-maven-
       - name: Deploy
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,14 @@ name: deploy
 
 # We deploy on master and release versions, regardless of if the commit is
 # documentation-only or not.
-#
-# See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    # Don't deploy tags as they conflict with [maven-release-plugin] prepare release MAJOR.MINOR.PATCH
-    tags: ''
-    branches: master
+    branches:
+      - master
+    # Don't deploy tags because the same commit for MAJOR.MINOR.PATCH is also
+    # on master: Redundant deployment of a release version will fail uploading.
+    tags-ignore:
+      - '*'
 
 jobs:
   deploy:
@@ -22,42 +23,39 @@ jobs:
         include:
           - name: jars
             deploy_script: build-bin/deploy
-          # Deploy the Bill of Materials (BOM) separately as it is unhooked from the main project intentionally
+          # Deploy the Bill of Materials (BOM) separately as it is unhooked
+          # from the main project intentionally.
           - name: bom
             deploy_script: build-bin/deploy_bom
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          # Prevent use of implicit GitHub Actions read-only token GITHUB_TOKEN.
-          # We push Javadocs to the gh-pages branch on commit.
-          token: ${{ secrets.GH_TOKEN }}
       - name: Setup java
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
+          java-version: '11'  # last that can compile the 1.6 release profile
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
+          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-17-maven-
       - name: Deploy
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           # GPG_PASSPHRASE=<passphrase for GPG_SIGNING_KEY>
-          #   - referenced in .settings.xml
+          # * referenced in .settings.xml
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           # SONATYPE_USER=<sonatype account token>
-          #   - deploys snapshots and releases to Sonatype
-          #   - needs access to io.zipkin via https://issues.sonatype.org/browse/OSSRH-16669
-          #   - generate via https://oss.sonatype.org/#profile;User%20Token
-          #   - referenced in .settings.xml
+          # * deploys snapshots and releases to Sonatype
+          # * needs access to io.zipkin via OSSRH-16669
+          # * generate via https://oss.sonatype.org/#profile;User%20Token
+          # * referenced in .settings.xml
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           # SONATYPE_PASSWORD=<password to sonatype account token>
-          #   - referenced in .settings.xml
+          #  * referenced in .settings.xml
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: |  # GITHUB_REF will be refs/heads/master or refs/tags/MAJOR.MINOR.PATCH
+        run: |  # GITHUB_REF = refs/heads/master or refs/tags/MAJOR.MINOR.PATCH
           build-bin/configure_deploy &&
           ${{ matrix.deploy_script }} $(echo ${GITHUB_REF} | cut -d/ -f 3)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+---
+name: lint
+
+on:  # yamllint disable-line rule:truthy
+  push:  # non-tagged pushes to master
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+    paths:
+      - '**/*.md'
+      - '.github/workflows/*.yml'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+  pull_request:  # pull requests targeted at the master branch.
+    branches:
+      - master
+    paths:
+      - '**/*.md'
+      - '.github/workflows/*.yml'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    # skip commits made by the release plugin
+    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Lint
+        run: |
+          build-bin/configure_lint
+          build-bin/lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,52 +1,38 @@
-# yamllint --format github .github/workflows/test.yml
 ---
 name: test
 
 # We don't test documentation-only commits.
-on:
-  # We run tests on non-tagged pushes to master that aren't a commit made by the release plugin
-  push:
-    tags: ''
-    branches: master
-    paths-ignore: '**/*.md'
-  # We also run tests on pull requests targeted at the master branch.
-  pull_request:
-    branches: master
-    paths-ignore: '**/*.md'
+on:  # yamllint disable-line rule:truthy
+  push:  # non-tagged pushes to master
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+    paths-ignore:
+      - '**/*.md'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+  pull_request:  # pull requests targeted at the master branch.
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
 
 jobs:
-  test-javadoc:
-    name: Test JavaDoc Builds
-    runs-on: ubuntu-22.04 # newest available distribution, aka jellyfish
-    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: Setup java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'  # zulu as it supports a wide version range
-          java-version: '11'  # earliest LTS and last that can compile the 1.6 release profile.
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-11-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-jdk-11-maven-
-      - name: Build JavaDoc
-        run: ./mvnw clean javadoc:aggregate -Prelease
-
   test:
     name: test (JDK ${{ matrix.java_version }})
-    runs-on: ubuntu-22.04 # newest available distribution, aka jellyfish
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    # skip commits made by the release plugin
     if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
     strategy:
-      fail-fast: false  # don't fail fast as sometimes failures are operating system specific
-      matrix:  # use latest available versions and be consistent on all workflows!
+      fail-fast: false  # don't fail fast as some failures are LTS specific
+      matrix:  # match with maven-enforcer-plugin rules in pom.xml
         include:
-          - java_version: 11  # Last that can compile zipkin-reporter to 1.6 for Brave
-            maven_args: -Prelease -Dgpg.skip -Dmaven.javadoc.skip=true
-          - java_version: 21  # Most recent LTS
+          - java_version: '11'  # last that can compile the 1.6 release profile
+            maven_args: -Prelease -Dgpg.skip
+          - java_version: '21'  # Most recent LTS
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -56,9 +42,10 @@ jobs:
           distribution: 'zulu'  # zulu as it supports a wide version range
           java-version: ${{ matrix.java_version }}
       - name: Cache local Maven repository
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
+          # yamllint disable-line rule:line-length
           key: ${{ runner.os }}-jdk-${{ matrix.java_version }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-jdk-${{ matrix.java_version }}-maven-
       # Don't attempt to cache Docker. Sensitive information can be stolen

--- a/build-bin/README.md
+++ b/build-bin/README.md
@@ -24,24 +24,87 @@ CI-provider specific tools, doing so can easily create a dependency where no one
 release anymore. Do not use provider-specific mechanisms to implement release flow. Instead,
 automate triggering of the scripts here.
 
-The only scripts that should be modified per project are in the base directory. Those in sub
-directories, such as [docker], should not vary project to project except accident of version drift.
-Intentional changes in sub directories should be relevant and tested on multiple projects to ensure
-they can be blindly copy/pasted.
+The only scripts that should be modified per project are in the base directory. Those in
+subdirectories, such as [docker](docker), should not vary project to project except accident of
+version drift. Intentional changes in subdirectories should be relevant and tested on multiple
+projects to ensure they can be blindly copy/pasted.
 
 Conversely, the files in the base directory are project specific entry-points for test and deploy
 actions and are entirely appropriate to vary per project. Here's an overview:
+
+## Lint
+
+Lint makes sure that documentation and workflows are in-tact. CI providers should be configured to
+run lint on pull requests or pushes to the master branch, notably when the tag is blank. Linters
+should only run on documentation-only commits or those who affect workflow files. Linters must not
+depend on authenticated resources, as running lint can leak credentials.
+
+* [configure_lint](configure_lint) - Ensures linters are installed
+* [lint](lint) - Runs the linters
+
+We minimally check the following:
+
+* [markdown-link-check](https://github.com/tcort/markdown-link-check) on our Markdown content.
+  * we maintain [mlc_config.json](mlc_config.json) for exceptions
+* [yamllint](https://github.com/adrienverge/yamllint) on our GitHub Actions Workflow YAML.
+  * occasionally need line length exceptions via `# yamllint disable-line rule:line-length`
+
+### Example GitHub Actions setup
+
+A simplest GitHub Actions `lint.yml` runs linters after configuring them, but only on relevant event
+conditions. The name `lint.yml` and job `lint` allows easy references to status badges and parity of
+the scripts it uses.
+
+The `on:` section obviates job creation and resource usage for irrelevant events. Notably, GitHub
+Actions includes the ability to skip documentation-only jobs.
+
+Here's a partial `lint.yml` including only the aspects mentioned above.
+```yaml
+---
+on:  # yamllint disable-line rule:truthy
+  push:  # non-tagged pushes to master
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+    paths:
+      - '**/*.md'
+      - '.github/workflows/*.yml'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+  pull_request:  # pull requests targeted at the master branch.
+    branches:
+      - master
+    paths:
+      - '**/*.md'
+      - '.github/workflows/*.yml'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
+    # skip commits made by the release plugin
+    if: "!contains(github.event.head_commit.message, 'maven-release-plugin')"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Lint
+        run: |
+          build-bin/configure_lint
+          build-bin/lint
+```
 
 ## Test
 
 Test builds and runs any tests of the project, including integration tests. CI providers should be
 configured to run tests on pull requests or pushes to the master branch, notably when the tag is
 blank. Tests should not run on documentation-only commits. Tests must not depend on authenticated
-resources, as running tests can leak credentials. Git checkouts should include the full history so
-that license headers or other git analysis can take place.
+resources, as running tests can leak credentials.
 
-* [configure_test] - Sets up build environment for tests.
-* [test] - Builds and runs tests for this project.
+ * [configure_test](configure_test) - Sets up build environment for tests.
+ * [test](test) - Builds and runs tests for this project.
 
 ### Example GitHub Actions setup
 
@@ -54,22 +117,29 @@ Actions includes the ability to skip documentation-only jobs.
 
 Here's a partial `test.yml` including only the aspects mentioned above.
 ```yaml
-on:
-  push:
-    tags: ''
-    branches: master
-    paths-ignore: '**/*.md'
-  pull_request:
-    branches: master
-    paths-ignore: '**/*.md'
+on:  # yamllint disable-line rule:truthy
+  push:  # non-tagged pushes to master
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+    paths-ignore:
+      - '**/*.md'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
+  pull_request:  # pull requests targeted at the master branch.
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - './build-bin/*lint'
+      - ./build-bin/mlc_config.json
 
 jobs:
   test:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full git history for license check
       - name: Test
         run: |
           build-bin/configure_test
@@ -83,8 +153,8 @@ providers deploy pushes to master on when the tag is blank, but not on documenta
 Releases should deploy on version tags (ex `/^[0-9]+\.[0-9]+\.[0-9]+/`), without consideration of if
 the commit is documentation only or not.
 
-* [configure_deploy] - Sets up environment and logs in, assuming [configure_test] was not called.
-* [deploy] - deploys the project, with arg0 being "master" or a release commit like "1.2.3"
+ * [configure_deploy](configure_deploy) - Sets up environment and logs in.
+ * [deploy](deploy) - deploys the project, with arg1 being "master" or a release commit like "1.2.3"
 
 ### Example GitHub Actions setup
 
@@ -100,24 +170,28 @@ Here's a partial `deploy.yml` including only the aspects mentioned above. Notice
 explicitly defined and `on.tags` is a [glob pattern](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).
 
 ```yaml
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    tags: '[0-9]+.[0-9]+.[0-9]+**'  # e.g. 8.272.10 or 15.0.1_p9
-    branches: master
+    branches:
+      - master
+    # Don't deploy tags because the same commit for MAJOR.MINOR.PATCH is also
+    # on master: Redundant deployment of a release version will fail uploading.
+    tags-ignore:
+      - '*'
 
 jobs:
   deploy:
+    runs-on: ubuntu-22.04  # newest available distribution, aka jellyfish
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1  # only needed to get the sha label
-      - name: Configure Deploy
-        run: build-bin/configure_deploy
+      - name: Deploy
         env:
           GH_USER: ${{ secrets.GH_USER }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - name: Deploy
-        # GITHUB_REF will be refs/heads/master or refs/tags/1.2.3
-        run: build-bin/deploy $(echo ${GITHUB_REF} | cut -d/ -f 3)
+        run: |  # GITHUB_REF = refs/heads/master or refs/tags/MAJOR.MINOR.PATCH
+          build-bin/configure_deploy &&
+          build-bin/deploy $(echo ${GITHUB_REF} | cut -d/ -f 3)
 ```

--- a/build-bin/configure_lint
+++ b/build-bin/configure_lint
@@ -1,0 +1,7 @@
+#!/bin/sh -ue
+
+# Attempt to install markdown-link-check if absent
+markdown-link-check -V || npm install -g markdown-link-check
+
+# Attempt to install yamllint if absent
+yamllint || pip install --user yamllint

--- a/build-bin/lint
+++ b/build-bin/lint
@@ -1,0 +1,4 @@
+#!/bin/sh -ue
+
+yamllint --format github .github/workflows/*.yml
+find . -name \*.md |grep -v node|xargs markdown-link-check -c ./build-bin/mlc_config.json

--- a/build-bin/mlc_config.json
+++ b/build-bin/mlc_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "https://oss.sonatype.org/content/repositories/snapshots"
+    }
+  ]
+}


### PR DESCRIPTION
This adds new scripts configure_lint and lint which work like our other build-bin scripts. These lint the workflow yaml and our markdown links.

I also removed the separate step for javadoc checking as it is easy to do that in the release test target, as well uses less resources vs doing it twice.

See https://github.com/openzipkin/zipkin-gcp/pull/212 for the first impl of this.