### PR TITLE
Adds spring-beans context test and defaults to Spring 5

### DIFF
--- a/brave/pom.xml
+++ b/brave/pom.xml
@@ -50,12 +50,6 @@
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
       <version>${brave.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
       <!-- Don't pin Brave -->
       <scope>provided</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <zipkin.version>2.27.1</zipkin.version>
 
     <!-- Do not set this value in bom/pom.xml to avoid cyclic pinning -->
-    <brave.version>6.0.2</brave.version>
+    <brave.version>6.0.3</brave.version>
 
     <log4j.version>2.23.1</log4j.version>
     <okhttp.version>4.12.0</okhttp.version>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -22,6 +22,14 @@
     <module.name>zipkin2.reporter.beans</module.name>
 
     <main.basedir>${project.basedir}/..</main.basedir>
+
+    <!-- Note: Spring 6 is JDK 17 bytecode, so we can't update to it until we
+         stop supporting Java 6 compilation target, or change our release to
+         use multiple tool chains. -->
+    <spring.version>5.3.34</spring.version>
+
+    <spring-floor.version>2.5.6</spring-floor.version>
+    <log4j12.version>1.2.17</log4j12.version>
   </properties>
 
   <dependencyManagement>
@@ -93,18 +101,12 @@
       <groupId>io.zipkin.brave</groupId>
       <artifactId>brave</artifactId>
       <version>${brave.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
-      <version>2.5.6</version>
+      <version>${spring.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -115,7 +117,61 @@
       <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Dependencies for integration tests -->
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-junit5</artifactId>
+      <version>${zipkin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Test org.springframework:spring-beans dep via invoker -->
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>de.qaware.maven</groupId>
+        <artifactId>go-offline-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>resolve-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- Add dependencies specific to invoker tests so that they cache on go-offline -->
+          <dynamicDependencies>
+            <DynamicDependency>
+              <groupId>log4j</groupId>
+              <artifactId>log4j</artifactId>
+              <version>${log4j12.version}</version>
+              <repositoryType>MAIN</repositoryType>
+              <type>jar</type>
+            </DynamicDependency>
+            <DynamicDependency>
+              <groupId>org.springframework</groupId>
+              <artifactId>spring-beans</artifactId>
+              <version>${spring-floor.version}</version>
+              <repositoryType>MAIN</repositoryType>
+              <type>jar</type>
+            </DynamicDependency>
+          </dynamicDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <profile>

--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -117,20 +117,6 @@
       <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- Dependencies for integration tests -->
-    <dependency>
-      <groupId>io.zipkin.zipkin2</groupId>
-      <artifactId>zipkin-junit5</artifactId>
-      <version>${zipkin.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <version>${spring.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/spring-beans/src/it/spring_context/README.md
+++ b/spring-beans/src/it/spring_context/README.md
@@ -1,0 +1,2 @@
+# spring_context
+This tests that the zipkin2.reporter.beans can be using with Java Config.

--- a/spring-beans/src/it/spring_context/pom.xml
+++ b/spring-beans/src/it/spring_context/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>spring_context</artifactId>
+  <version>@project.version@</version>
+  <name>spring_context</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>zipkin-reporter-spring-beans</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>@brave.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>zipkin-reporter-brave</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>@junit-jupiter.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin-junit5</artifactId>
+      <version>@zipkin.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>@spring.version@</version>
+    </dependency>
+
+    <!-- route jcl over log4j2 during integration tests -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
+      <version>@log4j.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <directory>@project.basedir@/src/test/resources</directory>
+      </testResource>
+    </testResources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+        <configuration>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!-- Use surefire to run the ITs until someone figures out how to get invoker to run
+             failsafe -->
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-surefire-plugin.version@</version>
+        <configuration>
+          <failIfNoTests>true</failIfNoTests>
+          <includes>
+            <include>**/IT*.java</include>
+          </includes>
+          <!-- Try to prevent flakes in CI -->
+          <reuseForks>false</reuseForks>
+          <!-- workaround to SUREFIRE-1831 -->
+          <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-beans/src/it/spring_context/src/test/java/zipkin2/reporter/beans/context/ITAsyncZipkinSpanHandlerFactoryBean.java
+++ b/spring-beans/src/it/spring_context/src/test/java/zipkin2/reporter/beans/context/ITAsyncZipkinSpanHandlerFactoryBean.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenZipkin Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package zipkin2.reporter.beans.context;
+
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
+import brave.propagation.TraceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.junit5.ZipkinExtension;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.beans.AsyncZipkinSpanHandlerFactoryBean;
+import zipkin2.reporter.beans.OkHttpSenderFactoryBean;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ITAsyncZipkinSpanHandlerFactoryBean {
+  @RegisterExtension public static ZipkinExtension zipkin = new ZipkinExtension();
+
+  final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+  @AfterEach void close() {
+    context.close();
+  }
+
+  @Configuration static class TestConfiguration {
+    @Bean public OkHttpSenderFactoryBean sender() {
+      OkHttpSenderFactoryBean okHttpSenderFactoryBean = new OkHttpSenderFactoryBean();
+      okHttpSenderFactoryBean.setEndpoint(zipkin.httpUrl() + "/api/v2/spans");
+      return okHttpSenderFactoryBean;
+    }
+
+    @Bean public AsyncZipkinSpanHandlerFactoryBean spanHandler(BytesMessageSender sender) {
+      AsyncZipkinSpanHandlerFactoryBean asyncReporterFactoryBean =
+        new AsyncZipkinSpanHandlerFactoryBean();
+      asyncReporterFactoryBean.setSender(sender);
+      asyncReporterFactoryBean.setMessageTimeout(0); // don't spawn a thread
+      return asyncReporterFactoryBean;
+    }
+  }
+
+  @Test void providesAsyncZipkinSpanHandler() {
+    context.register(TestConfiguration.class);
+    context.refresh();
+
+    // Make sure the spring context was built correctly
+    SpanHandler spanHandler = context.getBean(SpanHandler.class);
+    assertThat(spanHandler).isInstanceOf(AsyncZipkinSpanHandler.class);
+
+    // Create and handle a span
+    TraceContext context = TraceContext.newBuilder().traceId(1).spanId(2).sampled(true).build();
+    MutableSpan span = new MutableSpan(context, null);
+    spanHandler.end(context, span, SpanHandler.Cause.FINISHED);
+
+    // Prove the integrated setup works.
+    ((AsyncZipkinSpanHandler) spanHandler).flush();
+    assertThat(zipkin.getTraces()).hasSize(1);
+  }
+}

--- a/spring-beans/src/it/spring_floor/README.md
+++ b/spring-beans/src/it/spring_floor/README.md
@@ -1,0 +1,2 @@
+# spring_floor
+This tests that the zipkin2.reporter.beans package does not rely on Spring 3+ APIs.

--- a/spring-beans/src/it/spring_floor/pom.xml
+++ b/spring-beans/src/it/spring_floor/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright The OpenZipkin Authors
+    SPDX-License-Identifier: Apache-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>@project.groupId@</groupId>
+  <artifactId>spring_floor</artifactId>
+  <version>@project.version@</version>
+  <name>spring_floor</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter-spring-beans</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.zipkin.zipkin2</groupId>
+          <artifactId>zipkin</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.zipkin2</groupId>
+      <artifactId>zipkin</artifactId>
+      <version>@zipkin.version@</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-libthrift</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-okhttp3</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-urlconnection</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-kafka</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-amqp-client</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-sender-activemq-client</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>zipkin-reporter-brave</artifactId>
+      <scope>provided</scope>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave</artifactId>
+      <version>@brave.version@</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+      <version>@spring-floor.version@</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>@junit-jupiter.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>@assertj.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>@mockito.version@</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>@log4j12.version@</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>@project.build.testSourceDirectory@</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@maven-surefire-plugin.version@</version>
+        <configuration>
+          <!-- This helps with mistakes, e.g. testSourceDirectory is wrong -->
+          <failIfNoTests>true</failIfNoTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring-beans/src/it/spring_floor/src/test/resources/log4j.properties
+++ b/spring-beans/src/it/spring_floor/src/test/resources/log4j.properties
@@ -1,0 +1,10 @@
+#
+# Copyright The OpenZipkin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+
+log4j.rootLogger=WARN, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=[%d{dd MMM yyyy HH:mm:ss,SSS}] - %m%n
+


### PR DESCRIPTION
This defaults the spring-beans version to Spring 5, and adds invoker tests for the following:

* spring floor version (2.5) continues to work
* spring java config (via spring-context) works

Fixes #248
Closes #212