### PR TITLE
Avoid encoding list of spans twice in BaseHttpSender

### DIFF
--- a/core/src/main/java/zipkin2/reporter/BaseHttpSender.java
+++ b/core/src/main/java/zipkin2/reporter/BaseHttpSender.java
@@ -120,7 +120,7 @@ public abstract class BaseHttpSender<U, B> extends BytesMessageSender.Base {
     if (endpoint == null) endpoint = nextEndpoint(endpointSupplier);
     B body = newBody(encodedSpans);
     if (body == null) throw new NullPointerException("newBody(encodedSpans) returned null");
-    postSpans(endpoint, newBody(encodedSpans));
+    postSpans(endpoint, body);
   }
 
   @Override public final void close() {


### PR DESCRIPTION
newBody was called twice which would result in encoding the list of spans twice unnecessarily. This change will reduce allocations and copying memory.