### PR TITLE
Removes io.zipkin.zipkin2:zipkin from bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -26,9 +26,6 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <!-- use the same value in ../pom.xml -->
-    <!-- NOTE: Do not update to 3.x as that has floor Java 8 -->
-    <zipkin.version>2.27.1</zipkin.version>
   </properties>
 
   <url>https://github.com/openzipkin/zipkin-reporter-java</url>
@@ -81,11 +78,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.zipkin.zipkin2</groupId>
-        <artifactId>zipkin</artifactId>
-        <version>${zipkin.version}</version>
-      </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>zipkin-reporter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
     <errorprone.args />
     <errorprone.version>2.30.0</errorprone.version>
 
-    <!-- use the same value in bom/pom.xml -->
     <!-- NOTE: Do not update to 3.x as that has floor Java 8 -->
     <zipkin.version>2.27.1</zipkin.version>
 


### PR DESCRIPTION
This prevents managing a dependency version we don't strictly require

fixes #274