### PR TITLE
fix NPE when exception message is null

### DIFF
--- a/core/src/main/java/zipkin2/reporter/internal/AsyncReporter.java
+++ b/core/src/main/java/zipkin2/reporter/internal/AsyncReporter.java
@@ -291,7 +291,7 @@ public abstract class AsyncReporter<S> extends Component
 
         // Old senders in other artifacts may be using this less precise way of indicating they've been closed
         // out-of-band.
-        if (t instanceof IllegalStateException && t.getMessage().equals("closed")) {
+        if (t instanceof IllegalStateException && "closed".equals(t.getMessage())) {
           throw (IllegalStateException) t;
         }
       }


### PR DESCRIPTION
When the Exception is an `IllegalStateException` and does not have a message, it is causing an NPE like we were having in our projects

```
java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "java.lang.Throwable.getMessage()" is null
	at zipkin2.reporter.internal.AsyncReporter$BoundedAsyncReporter.flush(AsyncReporter.java:294)
	at zipkin2.reporter.internal.AsyncReporter$Flusher.run(AsyncReporter.java:352)
	at java.base/java.lang.Thread.run(Unknown Source)
``` 
In our case, it was a `java.util.concurrent.CancellationException`

I am not sure because I cannot prove, but after we get this error, our pods stop exporting spans to zipkin. We loose all the observability after this NPE. 

PS: our stack is: Java 21, Spring boot 3.4.5 with 'io.micrometer:micrometer-tracing-bridge-brave', 'io.zipkin.reporter2:zipkin-reporter-brave'