### PR TITLE
Remove outdated BOM warning from dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,16 +142,6 @@
     <url>https://github.com/openzipkin/zipkin-reporter-java/issues</url>
   </issueManagement>
 
-  <dependencyManagement>
-    <!-- Be careful here, especially to not import BOMs as io.zipkin.reporter2:zipkin-reporter and
-         zipkin-reporter-brave have this parent.
-
-         For example, if you imported Netty's BOM here, using Brave would also download that BOM as
-         it depends indirectly on io.zipkin.reporter2:zipkin-reporter-brave. As Brave itself is
-         indirectly used, this can be extremely confusing when people are troubleshooting library
-         version assignments. -->
-  </dependencyManagement>
-
   <dependencies>
     <!-- Do not add compile dependencies here. This can cause problems for libraries that depend on
          io.zipkin.reporter2:zipkin-reporter or zipkin-reporter-brave difficult to unravel. -->


### PR DESCRIPTION
flattenMode=ossrh strips dependencyManagement from published poms, so end users never inherit BOMs declared here.

See: https://github.com/mojohaus/flatten-maven-plugin/blob/master/src/main/java/org/codehaus/mojo/flatten/FlattenMode.java
Signed-off-by: Adrian Cole <adrian@tetrate.io>

